### PR TITLE
Allow users to set a title when evergreening issues

### DIFF
--- a/src/events/message_create.ts
+++ b/src/events/message_create.ts
@@ -53,9 +53,8 @@ export async function evergreenIssueWorkflow(message: Message) {
   // TODO(rayhanadev): generate title using groq
   let title = `Evergreen request from @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`;
 
-  // TODO(theshadoweevee): "/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s" is ugly. There has to be a better way.
-  if (message.content.match(/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s?([^\s]+)/)) {
-    title = (message.content.replace(/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s?/, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
+  if (message.content.match(/evergreen it\s?([^\s]+)/i)) {
+    title = (message.content.replace(/evergreen it\s?/i, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
   }
 
   const body = `**@${people[original.author.id] ?? original.author.tag}**[^1] said in **[#${message.channel.name}](<${message.url}>)**:

--- a/src/events/message_create.ts
+++ b/src/events/message_create.ts
@@ -53,8 +53,8 @@ export async function evergreenIssueWorkflow(message: Message) {
   // TODO(rayhanadev): generate title using groq
   let title = `Evergreen request from @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`;
 
-  if (message.content.match(/evergreen it\s?/i)) {
-    title = (message.content.replace(/evergreen it\s?/i, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
+  if (message.content.match(/^evergreen it\s?/i)) {
+    title = (message.content.replace(/^evergreen it\s?/i, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
   }
 
   const body = `**@${people[original.author.id] ?? original.author.tag}**[^1] said in **[#${message.channel.name}](<${message.url}>)**:

--- a/src/events/message_create.ts
+++ b/src/events/message_create.ts
@@ -28,6 +28,8 @@ export async function evergreenIssueWorkflow(message: Message) {
   if (!message.content.toLowerCase().startsWith(EVERGREEN_CREATE_ISSUE_STRING))
     return;
 
+
+
   let original: Message;
 
   if (!message.reference || !message.reference.messageId) {
@@ -49,7 +51,13 @@ export async function evergreenIssueWorkflow(message: Message) {
   ].filter(Boolean);
 
   // TODO(rayhanadev): generate title using groq
-  const title = `Evergreen request from @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`;
+  let title = `Evergreen request from @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`;
+
+  // TODO(theshadoweevee): "/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s" is ugly. There has to be a better way.
+  if (message.content.match(/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s?([^\s]+)/)) {
+    title = (message.content.replace(/[Ee][Vv][Ee][Rr][Gg][Rr][Ee][Ee][Nn] [Ii][Tt]\s?/, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
+  }
+
   const body = `**@${people[original.author.id] ?? original.author.tag}**[^1] said in **[#${message.channel.name}](<${message.url}>)**:
 
 ${original.content

--- a/src/events/message_create.ts
+++ b/src/events/message_create.ts
@@ -53,7 +53,7 @@ export async function evergreenIssueWorkflow(message: Message) {
   // TODO(rayhanadev): generate title using groq
   let title = `Evergreen request from @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`;
 
-  if (message.content.match(/evergreen it\s?([^\s]+)/i)) {
+  if (message.content.match(/evergreen it\s?/i)) {
     title = (message.content.replace(/evergreen it\s?/i, "") + ` - @${people[message.author.id] ?? message.author.tag} in #${message.channel.name}`).substring(0, 255) // Limit 0-255 to accomadate Github's 256 Issue Title Length Limit
   }
 


### PR DESCRIPTION
This allows users to type "evergreen it XYZ", which will generate and issue with a title like "XYZ - @theshadoweevee in #hack-night".