### PR TITLE
Filter out non-image attachments from Hack Night images thread

### DIFF
--- a/src/utils/hack-night.ts
+++ b/src/utils/hack-night.ts
@@ -179,8 +179,9 @@ ${topContributors
     }
 
     // TODO(@rayhanadev): upload all these images to the Sanity project
-    // TODO(@rayhanadev): filter out files that are not images
-    const images = [...attachments.map((a) => a.url)];
+    const images = attachments
+      .filter((a) => a.contentType && (a.contentType.startsWith('image/') || a.contentType.startsWith('video/')))
+      .map((a) => a.url);
 
     await starterMessage.unpin();
     await hackNightImageThread.setLocked(true);


### PR DESCRIPTION
We don't do anything with the images yet, but at least they get filtered now.

Videos are also allowed, but that can be changed easily.