### PR TITLE
Don't ping on simple creation of threads

### DIFF
--- a/src/events/message_create/welcomer.ts
+++ b/src/events/message_create/welcomer.ts
@@ -7,7 +7,9 @@ export default async function handler(message: Message) {
   if (message.author.bot) return;
   if (message.channelId !== "1182158612454449282") return;
   if (message.channel.isDMBased()) return;
+  if (message.channel.isThread()) return;
   if (message.system) return;
+  if (message.flags == 32) return; // Message ID for a Message Containing a thread creation prompt
 
   await message.client.channels
     .fetch(CORE_COMMUNITY_CHANNEL)


### PR DESCRIPTION
Don't ping welcomers if the message is:
- Simple thread creation (flag 32), preventing messages with only content like `X started a thread: Y. See all threads.` 
- Inside a thread already