### PR TITLE
build: use Alpine as base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# CI workflows
+.github/
+
 # flyctl launch added from .gitignore
 # Based on https://raw.githubusercontent.com/github/gitignore/main/Node.gitignore
 


### PR DESCRIPTION
Uses Alpine instead of Ubuntu as the base Docker image.

Please test this before merging because it's possible there are runtime dependencies that Ubuntu ships by default but Alpine doesn't (e.g. `python3` which had to be installed for the build step). I can't run the app since I don't have the `.env` file.