### PR TITLE
Fix: Skip Approval for Thread Starter Message

### DIFF
--- a/src/features/commit-overflow/index.ts
+++ b/src/features/commit-overflow/index.ts
@@ -644,6 +644,17 @@ const handleApproveReaction = Effect.fn("CommitOverflow.handleApproveReaction")(
     const thread = message.channel as ThreadChannel;
     const isThreadOwner = thread.ownerId === user.id;
 
+    // Skip if this is the thread's starter message (default emoji gets auto-added)
+    if (message.id === thread.id) {
+        yield* Effect.logDebug("skipping starter message reaction", {
+            user_id: user.id,
+            message_id: message.id,
+            thread_id: thread.id,
+            reason: "starter_message",
+        });
+        return;
+    }
+
     if (!isOrganizer && !isBishop && !isThreadOwner) {
         yield* Effect.logDebug("unauthorized approval attempt", {
             user_id: user.id,


### PR DESCRIPTION
## Why?
To prevent false approvals when default emoji is auto-added to thread starter messages.

## What changed?
- Updated \`src/features/commit-overflow/index.ts\`: Added check to skip approval reactions on thread starter messages

## Test plan
1. Run \`bun run build\` to ensure no errors
2. Test adding approval emoji to starter message - should not count as approval
3. Test adding approval emoji to other messages - should work as before