### PR TITLE
feat: add wackmas holiday feature

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,6 +1,7 @@
 export { commands, getEnabledCommands, findCommand } from "./commands";
 export {
     handleMessageCreate,
+    handleMessageDelete,
     handleMessageReactionAdd,
     handleMessageReactionRemove,
     handleThreadCreate,


### PR DESCRIPTION
## Summary
Add holiday-themed Wackmas feature for bot responses during the holiday season.

## Why?
To celebrate Wackmas with fun, interactive bot responses that engage the community.

## What changed?
- Added `handleWackmas` function in `src/features/commit-overflow/index.ts` for detecting and responding to Wackmas-related messages
- Registered the handler in `src/runtime/events.ts` with commit-overflow feature flag
- Updated `src/index.ts` to import and register the new handler
- Minor formatting updates in related files

## Test plan
1. Run `bun run build` to ensure no compilation errors
2. Start the bot in development mode
3. Mention the bot with a message containing "do you like your santa hat" (case insensitive with fuzzy matching)
4. Verify the bot responds with "yes yes yes!!! merry wackmas!!"
5. Test with various message formats and ensure proper fuzzy matching