### PR TITLE
Fix(Commit-Overflow): Credit Commits to Thread Owner and Delete on Removal

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,6 +1,7 @@
 export { commands, getEnabledCommands, findCommand } from "./commands";
 export {
     handleMessageCreate,
+    handleMessageDelete,
     handleMessageReactionAdd,
     handleMessageReactionRemove,
     handleThreadCreate,


### PR DESCRIPTION
## Why?

Commits were incorrectly being credited to the message author instead of the thread owner. Additionally, commits remained in the database even after their source messages were deleted or approval reactions were removed.

## What changed?

- **src/features/commit-overflow/index.ts**: 
  - `handleApproveReaction`: Now uses `thread.ownerId` instead of `message.author.id` for commit storage
  - `handlePrivateReactionRemove`: Now uses thread owner's profile for privacy fallback
  - Added `handleApproveReactionRemove`: Deletes commit when all approve reactions are removed
  - Added `handleCommitOverflowMessageDelete`: Deletes commit when message is deleted
- **src/services/Database.ts**: Added `commits.delete(messageId)` method
- **src/runtime/events.ts**: Added `handleMessageDelete` event handler and message delete handler registry
- **src/runtime/index.ts**: Exported new `handleMessageDelete` handler
- **src/index.ts**: Registered `MessageDelete` Discord event

## Test plan

1. Approve a commit in someone's thread → verify it's credited to the thread owner (not message author)
2. Remove all approve reactions from a message → verify commit is deleted from DB
3. Delete a message with an approved commit → verify commit is deleted from DB