### PR TITLE
Feat: Add is_private Field to Commit Overflow Profile Query

### DIFF
--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -276,7 +276,7 @@ export class Database extends Effect.Service<Database>()("Database", {
                 const [duration, rows] = yield* Effect.tryPromise({
                     try: () =>
                         d1Driver.rawQuery<CommitOverflowProfile>(
-                            `SELECT user_id, thread_id, timezone, created_at FROM commit_overflow_profiles WHERE user_id = ?`,
+                            `SELECT user_id, thread_id, timezone, is_private, created_at FROM commit_overflow_profiles WHERE user_id = ?`,
                             [userId],
                         ),
                     catch: (e) =>


### PR DESCRIPTION
## Why?
To support commit privacy controls feature, the database query for commit overflow profiles needs to include the is_private field.

## What changed?
- Updated \`src/services/Database.ts\`: Added \`is_private\` to the SELECT query for commit_overflow_profiles table

## Test plan
1. Run \`bun run build\` to ensure no TypeScript errors
2. Verify the query returns the is_private field correctly
3. Test commit privacy functionality if applicable