### PR TITLE
fix: delete ship from DB when message is deleted

### DIFF
--- a/src/features/ship-scraper/index.ts
+++ b/src/features/ship-scraper/index.ts
@@ -1,4 +1,10 @@
-import { type ChatInputCommandInteraction, type Message, SlashCommandBuilder } from "discord.js";
+import {
+    type ChatInputCommandInteraction,
+    type Message,
+    type OmitPartialGroupDMChannel,
+    type PartialMessage,
+    SlashCommandBuilder,
+} from "discord.js";
 import { Effect } from "effect";
 
 import { AppConfig } from "../../config";
@@ -160,6 +166,40 @@ export const handleShipScraper = Effect.fn("ShipScraper.handle")(
             attachment_count: uploadedAttachments.length,
             uploaded_keys: uploadedAttachments.map((a) => a.key).join(","),
             duration_ms: Date.now() - startTime,
+        });
+    },
+    Effect.annotateLogs({ feature: "ShipScraper" }),
+);
+
+export const handleShipMessageDelete = Effect.fn("ShipScraper.handleDeleteMessage")(
+    function* (message: OmitPartialGroupDMChannel<Message | PartialMessage>) {
+        const startTime = performance.now();
+
+        if (message.channelId !== SHIP_CHANNEL_ID) {
+            yield* Effect.logDebug("message skipped", {
+                reason: "wrong_channel",
+                partial: message.partial,
+                message_id: message.id,
+                channel_id: message.channelId,
+            });
+            return;
+        }
+
+        yield* Effect.logDebug("ship message deletion detected", {
+            partial: message.partial,
+            message_id: message.id,
+            user_id: message.author?.id,
+            username: message.author?.username,
+        });
+
+        const shipDb = yield* ShipDatabase;
+        const deletedShipId = yield* shipDb.deleteByMessageId(message.id);
+
+        yield* Effect.logInfo("ship deleted from database", {
+            ship_id: deletedShipId,
+            message_id: message.id,
+            user_id: message.author?.id,
+            duration_ms: performance.now() - startTime,
         });
     },
     Effect.annotateLogs({ feature: "ShipScraper" }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,8 +261,6 @@ const program = Effect.gen(function* () {
     client.on(Events.MessageDelete, async (message) => {
         const deleteStartTime = Date.now();
 
-        if (message.partial) return;
-
         const deleteProgram = handleMessageDelete(message).pipe(
             Effect.tap(() =>
                 Effect.logDebug("message delete handled", {

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -5,6 +5,8 @@ import type {
     User,
     PartialUser,
     AnyThreadChannel,
+    OmitPartialGroupDMChannel,
+    PartialMessage,
 } from "discord.js";
 
 import { Effect } from "effect";
@@ -22,13 +24,16 @@ import { handleDashboardMessage } from "../features/dashboard";
 import { handleEvergreenIt } from "../features/evergreen";
 import { handleHackNightImages, handleHackNightImageRemoval } from "../features/hack-night";
 import { handlePraise } from "../features/praise";
-import { handleShipScraper } from "../features/ship-scraper";
+import { handleShipScraper, handleShipMessageDelete } from "../features/ship-scraper";
 import { handleGrokMessage } from "../features/summarize";
 import { handleVoiceTranscription } from "../features/voice-transcription";
 import { handleWelcomer } from "../features/welcomer";
 import { FeatureFlags, type Flags } from "../services";
 
 type MessageHandler = (message: Message) => Effect.Effect<void, unknown, unknown>;
+type MessageDeleteHandler = (
+    message: OmitPartialGroupDMChannel<Message | PartialMessage>,
+) => Effect.Effect<void, unknown, unknown>;
 type ReactionHandler = (
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
@@ -40,6 +45,11 @@ type ThreadCreateHandler = (
 
 interface MessageHandlerConfig {
     handler: MessageHandler;
+    featureFlag?: keyof Flags;
+}
+
+interface MessageDeleteHandlerConfig {
+    handler: MessageDeleteHandler;
     featureFlag?: keyof Flags;
 }
 
@@ -79,8 +89,9 @@ const threadCreateHandlers: ThreadCreateHandlerConfig[] = [
     { handler: handleCommitOverflowThreadCreate, featureFlag: "commitOverflow" },
 ];
 
-const messageDeleteHandlers: MessageHandlerConfig[] = [
+const messageDeleteHandlers: MessageDeleteHandlerConfig[] = [
     { handler: handleCommitOverflowMessageDelete, featureFlag: "commitOverflow" },
+    { handler: handleShipMessageDelete, featureFlag: "shipScraper" },
 ];
 
 export const handleMessageCreate = Effect.fn("Events.handleMessageCreate")(function* (
@@ -373,7 +384,7 @@ export const handleMessageReactionRemove = Effect.fn("Events.handleMessageReacti
 );
 
 export const handleMessageDelete = Effect.fn("Events.handleMessageDelete")(function* (
-    message: Message,
+    message: OmitPartialGroupDMChannel<Message | PartialMessage>,
 ) {
     const startTime = Date.now();
 

--- a/src/services/ShipDatabase.ts
+++ b/src/services/ShipDatabase.ts
@@ -76,7 +76,7 @@ export class ShipDatabase extends Effect.Service<ShipDatabase>()("ShipDatabase",
         ) {
             yield* Effect.annotateCurrentSpan({ message_id: messageId });
 
-            const [duration] = yield* Effect.tryPromise({
+            const [duration, deletedShipId] = yield* Effect.tryPromise({
                 try: async () => {
                     const res = await fetch(`${apiUrl}/api/ships/${messageId}`, {
                         method: "DELETE",
@@ -87,6 +87,8 @@ export class ShipDatabase extends Effect.Service<ShipDatabase>()("ShipDatabase",
                     if (!res.ok) {
                         throw new Error(`Ship API returned ${res.status}: ${await res.text()}`);
                     }
+                    const { id } = (await res.json()) as { ok: true; id: string };
+                    return id;
                 },
                 catch: (e) =>
                     new DatabaseError({ operation: "ShipDatabase.deleteByMessageId", cause: e }),
@@ -100,6 +102,8 @@ export class ShipDatabase extends Effect.Service<ShipDatabase>()("ShipDatabase",
                 message_id: messageId,
                 duration_ms,
             });
+
+            return deletedShipId;
         });
 
         return { insertShip, deleteByMessageId } as const;


### PR DESCRIPTION
When messages are deleted from the #ship channel, the corresponding ship should be deleted from the database.

See https://discord.com/channels/772576325897945119/1460379356131098676/1490871372606607420