### PR TITLE
fix: prevent agent from taking extraneous actions

### DIFF
--- a/src/lib/ai/constants.ts
+++ b/src/lib/ai/constants.ts
@@ -33,6 +33,11 @@ export const SUBAGENT_PREAMBLE = `You are a specialized subagent delegated to by
 - Do not stop mid-task, hand back partial work, or wait for confirmation.
 - If one approach fails, try alternatives before giving up.
 
+## ONLY TAKE REQUESTED ACTIONS
+- Only perform actions (create, modify, delete resources) that the user explicitly asked for.
+- Never infer, guess, or assume the user wants a resource created, modified, or deleted unless they specifically said so.
+- If the delegated task is unclear or doesn't map to a concrete action, explain what you can do instead of taking speculative action.
+
 ## FINAL RESPONSE FORMAT (MANDATORY)
 Your final message MUST contain exactly two sections:
 

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -22,6 +22,8 @@ You have direct access to these tools:
 - **scheduleTask / listScheduledTasks / cancelTask** — schedule one-time or recurring messages and agent prompts. Use action_type "message" for static content, "agent" for dynamic content. Always confirm the schedule with the user before creating it. Default the channel and user to the execution context. Recurring tasks use 5-field cron (minute hour day month weekday).
 - **delegate_linear / delegate_github / delegate_discord / delegate_notion** — forward a task to a focused domain subagent. Forward the user's wording verbatim; the subagent needs the exact phrasing. Wait for the subagent's final result.
 
+Only delegate when the user's request clearly requires a domain-specific action (e.g. creating a channel, filing an issue, querying a database). If the message is casual, ambiguous, or conversational, respond directly — do not delegate.
+
 Plan multi-step requests before starting. For requests that span multiple domains, delegate each in turn.
 </tools>
 

--- a/src/lib/ai/skills/discord/SKILL.md
+++ b/src/lib/ai/skills/discord/SKILL.md
@@ -36,4 +36,5 @@ Map synonyms silently:
 - Always reference entities with Discord formatting: `<#channel_id>`, `<@&role_id>`, `<@user_id>`.
 - Always confirm destructive actions before proceeding.
 - Messages are limited to 2000 characters.
+- Only take server management actions (creating/editing/deleting channels, roles, etc.) when explicitly requested. Never speculatively create or modify resources.
 - Cannot: ban/kick members, manage permissions, timeout/mute, manage invites.


### PR DESCRIPTION
## Summary
- Adds guardrails to the orchestrator prompt to only delegate when the user's request clearly requires a domain action, avoiding delegation on casual/ambiguous messages
- Adds an "ONLY TAKE REQUESTED ACTIONS" section to the subagent preamble so all subagents avoid speculative resource creation/modification
- Adds a specific rule to the Discord skill to never speculatively create or modify server resources

## Test plan
- [ ] Ping the bot with an ambiguous message (e.g. "awe my struck") and verify it responds conversationally without creating roles/channels
- [ ] Verify explicit requests (e.g. "create a role called X") still work as expected