### PR TITLE
feat: add Figma domain tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ LINEAR_API_KEY=
 # Notion
 NOTION_TOKEN=
 
+# Figma
+FIGMA_ACCESS_TOKEN=
+FIGMA_TEAM_ID=
+
 # Purdue Hackers Knowledge Base (ask.purduehackers.com)
 PHACK_ASK_API_KEY=
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -33,6 +33,8 @@ export const env = createEnv({
     KV_REST_API_TOKEN: z.string(),
     VERCEL_API_TOKEN: z.string(),
     VERCEL_EDGE_CONFIG_ID: z.string(),
+    FIGMA_ACCESS_TOKEN: z.string(),
+    FIGMA_TEAM_ID: z.string(),
     SENTRY_DSN: z.string().optional(),
   },
   extends: [vercel()],

--- a/src/lib/ai/delegates.test.ts
+++ b/src/lib/ai/delegates.test.ts
@@ -41,12 +41,14 @@ vi.mock("@/lib/ai/skills/generated/domains/linear", () => ({ SKILL_MANIFEST: {} 
 vi.mock("@/lib/ai/skills/generated/domains/github", () => ({ SKILL_MANIFEST: {} }));
 vi.mock("@/lib/ai/skills/generated/domains/discord", () => ({ SKILL_MANIFEST: {} }));
 vi.mock("@/lib/ai/skills/generated/domains/notion", () => ({ SKILL_MANIFEST: {} }));
+vi.mock("@/lib/ai/skills/generated/domains/figma", () => ({ SKILL_MANIFEST: {} }));
 
 // Stub the heavy tool index modules so env-backed SDK clients don't initialize.
 vi.mock("@/lib/ai/tools/linear", () => ({}));
 vi.mock("@/lib/ai/tools/github", () => ({}));
 vi.mock("@/lib/ai/tools/discord", () => ({}));
 vi.mock("@/lib/ai/tools/notion", () => ({}));
+vi.mock("@/lib/ai/tools/figma", () => ({}));
 
 // Stub createDelegationTool so we can see what spec each domain was passed.
 vi.mock("@/lib/ai/subagent", () => ({

--- a/src/lib/ai/delegates.ts
+++ b/src/lib/ai/delegates.ts
@@ -3,6 +3,7 @@ import type { ToolSet } from "ai";
 import type { UserRole } from "./constants.ts";
 
 import { SKILL_MANIFEST as DISCORD_SUBSKILLS } from "./skills/generated/domains/discord.ts";
+import { SKILL_MANIFEST as FIGMA_SUBSKILLS } from "./skills/generated/domains/figma.ts";
 import { SKILL_MANIFEST as GITHUB_SUBSKILLS } from "./skills/generated/domains/github.ts";
 import { SKILL_MANIFEST as LINEAR_SUBSKILLS } from "./skills/generated/domains/linear.ts";
 import { SKILL_MANIFEST as NOTION_SUBSKILLS } from "./skills/generated/domains/notion.ts";
@@ -10,6 +11,7 @@ import { SKILL_MANIFEST } from "./skills/generated/manifest.ts";
 import { SkillRegistry } from "./skills/registry.ts";
 import { createDelegationTool } from "./subagent.ts";
 import * as discordTools from "./tools/discord/index.ts";
+import * as figmaTools from "./tools/figma/index.ts";
 import * as githubTools from "./tools/github/index.ts";
 import * as linearTools from "./tools/linear/index.ts";
 import * as notionTools from "./tools/notion/index.ts";
@@ -48,6 +50,16 @@ const DOMAINS = {
     tools: notionTools as unknown as ToolSet,
     subSkills: NOTION_SUBSKILLS,
     baseToolNames: ["search_notion", "retrieve_page", "retrieve_database", "list_users"],
+  },
+  figma: {
+    tools: figmaTools as unknown as ToolSet,
+    subSkills: FIGMA_SUBSKILLS,
+    baseToolNames: [
+      "list_team_projects",
+      "list_project_files",
+      "get_file_metadata",
+      "get_current_user",
+    ],
   },
 } as const satisfies Record<
   string,

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -20,7 +20,7 @@ You have direct access to these tools:
 - **currentTime** — get the current timestamp.
 - **documentation** — look up Purdue Hackers info (events, projects, history, culture, docs). Prefer this over notion for general informational questions. Relay the tool's answer directly without paraphrasing.
 - **scheduleTask / listScheduledTasks / cancelTask** — schedule one-time or recurring messages and agent prompts. Use action_type "message" for static content, "agent" for dynamic content. Always confirm the schedule with the user before creating it. Default the channel and user to the execution context. Recurring tasks use 5-field cron (minute hour day month weekday).
-- **delegate_linear / delegate_github / delegate_discord / delegate_notion** — forward a task to a focused domain subagent. Forward the user's wording verbatim; the subagent needs the exact phrasing. Wait for the subagent's final result.
+- **delegate_linear / delegate_github / delegate_discord / delegate_notion / delegate_figma** — forward a task to a focused domain subagent. Forward the user's wording verbatim; the subagent needs the exact phrasing. Wait for the subagent's final result.
 
 Plan multi-step requests before starting. For requests that span multiple domains, delegate each in turn.
 </tools>

--- a/src/lib/ai/skills/figma/SKILL.md
+++ b/src/lib/ai/skills/figma/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: figma
+description: Browse Figma files, export design images, manage comments, and inspect components
+criteria: When the user asks about Figma designs, design files, exporting images or mockups, design comments, components, or styles
+tools: []
+minRole: organizer
+mode: delegate
+---
+
+You are Figma, a design assistant for Purdue Hackers. You help users browse design files, export images to share, manage comments for design review, and inspect components and styles.
+
+## Sub-skills
+
+When delegated to, you have access to these skill bundles (loaded via `load_skill`):
+
+{{SKILL_MENU}}
+
+## Terminology
+
+Map synonyms silently:
+
+- "mockup", "design", "wireframe", "layout" -> file
+- "frame", "artboard", "screen", "page" -> node
+- "design system", "library" -> team components + team styles
+- "color", "typography", "font" -> style
+- "screenshot", "export", "render" -> export_file_images
+
+## Key Rules
+
+- Always link to Figma files: `[File Name](<url>)`.
+- When a user asks to "see" or "show" a design, use `export_file_images` to render it as PNG and share the URL.
+- Use `get_file_metadata` to discover page/frame IDs before exporting or inspecting nodes.
+- The team ID is pre-configured — use `list_team_projects` as the entry point for browsing.
+- Don't post comments without explicit user intent.
+- Export image URLs expire after 14 days — note this when sharing.

--- a/src/lib/ai/skills/figma/skills/comments/SKILL.md
+++ b/src/lib/ai/skills/figma/skills/comments/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: comments
+description: Read and post comments on Figma files for design review.
+criteria: Use when the user wants to read comments on a design, post feedback, or reply to a comment.
+tools: [list_file_comments, post_file_comment]
+minRole: organizer
+mode: inline
+---
+
+<reading>
+- `list_file_comments` returns all comments on a file (newest first).
+- Each comment includes: text, author, timestamp, resolved status, and pinned node (if any).
+- Comments with a `parent_id` are replies in a thread.
+</reading>
+
+<posting>
+- Use `post_file_comment` to add a new comment to a file.
+- Pin to a specific node with `node_id` for targeted feedback.
+- Reply to a thread by providing `comment_id` (the parent comment's ID).
+- Never post comments without explicit user intent.
+</posting>

--- a/src/lib/ai/skills/figma/skills/components/SKILL.md
+++ b/src/lib/ai/skills/figma/skills/components/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: components
+description: Browse components and styles in files and the team design library.
+criteria: Use when the user asks about design components, styles, colors, typography, or the design system.
+tools: [list_file_components, list_team_components, list_file_styles, list_team_styles]
+minRole: organizer
+mode: inline
+---
+
+<components>
+- File-level: `list_file_components` shows components defined in a specific file.
+- Team-level: `list_team_components` shows published components shared across all team files.
+- Each component has a `key` (unique identifier), `name`, and optional `description`.
+</components>
+
+<styles>
+- File-level: `list_file_styles` shows styles in a specific file.
+- Team-level: `list_team_styles` shows published styles shared across the team.
+- Style types: FILL (colors), TEXT (typography), EFFECT (shadows, blurs), GRID (layout grids).
+</styles>

--- a/src/lib/ai/skills/figma/skills/files/SKILL.md
+++ b/src/lib/ai/skills/figma/skills/files/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: files
+description: Inspect file nodes in detail and export design images as PNG/SVG/PDF.
+criteria: Use when the user wants to see specific frames or nodes, export design images, or view version history.
+tools: [get_file_nodes, export_file_images, list_file_versions]
+minRole: organizer
+mode: inline
+---
+
+<inspecting>
+- Use `get_file_metadata` first to find page and frame IDs.
+- Node IDs use the format "X:Y" (e.g., "0:1", "123:456").
+- Set `depth` to limit how deep children are fetched — use 1 or 2 for an overview.
+</inspecting>
+
+<exporting>
+- `export_file_images` renders nodes to temporary image URLs (expire after 14 days).
+- Format options: `png` (default, best for Discord), `svg` (vector), `jpg` (smaller), `pdf` (print).
+- Scale: 1 = original size, 2 = 2x resolution. Max 4. Only applies to png/jpg.
+- Export entire pages by using the page's node ID, or individual frames for specific designs.
+- Share the image URL directly — it can be embedded in Discord messages.
+</exporting>
+
+<versions>
+- `list_file_versions` shows who changed what and when.
+- Named versions have a `label` field — unnamed versions have an empty label.
+</versions>

--- a/src/lib/ai/tools/figma/base.ts
+++ b/src/lib/ai/tools/figma/base.ts
@@ -1,0 +1,86 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { env } from "../../../../env.ts";
+import { figmaFetch, figmaFileUrl } from "./client.ts";
+
+export const list_team_projects = tool({
+  description: `List all projects in the Purdue Hackers Figma team. Returns project names and IDs — use a project ID with list_project_files to browse its contents.`,
+  inputSchema: z.object({}),
+  execute: async () => {
+    const data = await figmaFetch<{
+      projects: Array<{ id: string; name: string }>;
+    }>(`/teams/${env.FIGMA_TEAM_ID}/projects`);
+    return JSON.stringify({ projects: data.projects });
+  },
+});
+
+export const list_project_files = tool({
+  description: `List files in a Figma project. Returns file name, key (ID), thumbnail URL, and last modified time.`,
+  inputSchema: z.object({
+    project_id: z.string().describe("Project ID from list_team_projects"),
+  }),
+  execute: async ({ project_id }) => {
+    const data = await figmaFetch<{
+      files: Array<{
+        key: string;
+        name: string;
+        thumbnail_url: string;
+        last_modified: string;
+      }>;
+    }>(`/projects/${project_id}/files`);
+    return JSON.stringify({
+      files: data.files.map((f) => ({
+        key: f.key,
+        name: f.name,
+        url: figmaFileUrl(f.key),
+        thumbnail_url: f.thumbnail_url,
+        last_modified: f.last_modified,
+      })),
+    });
+  },
+});
+
+export const get_file_metadata = tool({
+  description: `Get a Figma file's metadata — name, last modified, version, and top-level pages/frames. A shallow fetch that does not download the full node tree.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key (from URL or list_project_files)"),
+  }),
+  execute: async ({ file_key }) => {
+    const data = await figmaFetch<{
+      name: string;
+      lastModified: string;
+      version: string;
+      document: { children: Array<{ id: string; name: string; type: string }> };
+    }>(`/files/${file_key}?depth=1`);
+    return JSON.stringify({
+      name: data.name,
+      url: figmaFileUrl(file_key),
+      last_modified: data.lastModified,
+      version: data.version,
+      pages: data.document.children.map((c) => ({
+        id: c.id,
+        name: c.name,
+        type: c.type,
+      })),
+    });
+  },
+});
+
+export const get_current_user = tool({
+  description: `Get the Figma user the bot is authenticated as. Returns user ID, handle, and email.`,
+  inputSchema: z.object({}),
+  execute: async () => {
+    const data = await figmaFetch<{
+      id: string;
+      handle: string;
+      email: string;
+      img_url: string;
+    }>("/me");
+    return JSON.stringify({
+      id: data.id,
+      handle: data.handle,
+      email: data.email,
+    });
+  },
+});

--- a/src/lib/ai/tools/figma/client.ts
+++ b/src/lib/ai/tools/figma/client.ts
@@ -1,0 +1,28 @@
+import { env } from "../../../../env.ts";
+
+const BASE_URL = "https://api.figma.com/v1";
+
+export async function figmaFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
+  const headers = new Headers(options?.headers);
+  headers.set("X-Figma-Token", env.FIGMA_ACCESS_TOKEN);
+  if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+    signal: options?.signal ?? AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Figma API ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function figmaFileUrl(fileKey: string, nodeId?: string): string {
+  const base = `https://www.figma.com/file/${fileKey}`;
+  return nodeId ? `${base}?node-id=${encodeURIComponent(nodeId)}` : base;
+}

--- a/src/lib/ai/tools/figma/comments.ts
+++ b/src/lib/ai/tools/figma/comments.ts
@@ -1,0 +1,72 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { figmaFetch, figmaFileUrl } from "./client.ts";
+
+export const list_file_comments = tool({
+  description: `List all comments on a Figma file. Returns comment text, author, timestamp, resolved status, and pinned node (if any). Comments are ordered newest-first.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+  }),
+  execute: async ({ file_key }) => {
+    const data = await figmaFetch<{
+      comments: Array<{
+        id: string;
+        message: string;
+        created_at: string;
+        resolved_at: string | null;
+        user: { handle: string; id: string };
+        client_meta: { node_id?: string; node_offset?: unknown } | null;
+        parent_id: string;
+        order_id: string;
+      }>;
+    }>(`/files/${file_key}/comments`);
+    return JSON.stringify({
+      file_url: figmaFileUrl(file_key),
+      comments: data.comments.map((c) => ({
+        id: c.id,
+        message: c.message,
+        author: c.user.handle,
+        created_at: c.created_at,
+        resolved: !!c.resolved_at,
+        parent_id: c.parent_id || null,
+        node_id: c.client_meta?.node_id ?? null,
+      })),
+    });
+  },
+});
+
+export const post_file_comment = tool({
+  description: `Post a comment on a Figma file. Can optionally pin it to a specific node or reply to an existing comment thread.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+    message: z.string().describe("Comment text"),
+    comment_id: z
+      .string()
+      .optional()
+      .describe("Parent comment ID to reply to (for threaded replies)"),
+    node_id: z.string().optional().describe("Node ID to pin the comment to"),
+  }),
+  execute: async ({ file_key, message, comment_id, node_id }) => {
+    const body: Record<string, unknown> = { message };
+    if (comment_id) body.comment_id = comment_id;
+    if (node_id) body.client_meta = { node_id, node_offset: { x: 0, y: 0 } };
+
+    const data = await figmaFetch<{
+      id: string;
+      message: string;
+      created_at: string;
+      user: { handle: string };
+    }>(`/files/${file_key}/comments`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    return JSON.stringify({
+      id: data.id,
+      message: data.message,
+      author: data.user.handle,
+      created_at: data.created_at,
+      file_url: figmaFileUrl(file_key),
+    });
+  },
+});

--- a/src/lib/ai/tools/figma/components.ts
+++ b/src/lib/ai/tools/figma/components.ts
@@ -1,0 +1,143 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { env } from "../../../../env.ts";
+import { figmaFetch, figmaFileUrl } from "./client.ts";
+
+export const list_file_components = tool({
+  description: `List all components defined in a Figma file. Returns component name, key, description, and containing frame.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+  }),
+  execute: async ({ file_key }) => {
+    const data = await figmaFetch<{
+      meta: {
+        components: Array<{
+          key: string;
+          name: string;
+          description: string;
+          node_id: string;
+          containing_frame: { name: string; nodeId: string } | null;
+        }>;
+      };
+    }>(`/files/${file_key}/components`);
+    return JSON.stringify({
+      file_url: figmaFileUrl(file_key),
+      components: data.meta.components.map((c) => ({
+        key: c.key,
+        name: c.name,
+        description: c.description,
+        node_id: c.node_id,
+        containing_frame: c.containing_frame?.name ?? null,
+      })),
+    });
+  },
+});
+
+export const list_team_components = tool({
+  description: `List all published components in the Purdue Hackers team library. These are shared components available across all team files.`,
+  inputSchema: z.object({
+    page_size: z.number().max(100).optional().describe("Results per page"),
+    cursor: z.string().optional().describe("Pagination cursor from previous response"),
+  }),
+  execute: async ({ page_size, cursor }) => {
+    const params = new URLSearchParams();
+    if (page_size) params.set("page_size", String(page_size));
+    if (cursor) params.set("after", cursor);
+    const query = params.toString();
+
+    const data = await figmaFetch<{
+      meta: {
+        components: Array<{
+          key: string;
+          name: string;
+          description: string;
+          file_key: string;
+          node_id: string;
+          thumbnail_url: string;
+        }>;
+        cursor: Record<string, number>;
+      };
+    }>(`/teams/${env.FIGMA_TEAM_ID}/components${query ? `?${query}` : ""}`);
+    return JSON.stringify({
+      components: data.meta.components.map((c) => ({
+        key: c.key,
+        name: c.name,
+        description: c.description,
+        file_url: figmaFileUrl(c.file_key, c.node_id),
+        thumbnail_url: c.thumbnail_url,
+      })),
+      cursor: data.meta.cursor,
+    });
+  },
+});
+
+export const list_file_styles = tool({
+  description: `List all styles (colors, text, effects, grids) defined in a Figma file.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+  }),
+  execute: async ({ file_key }) => {
+    const data = await figmaFetch<{
+      meta: {
+        styles: Array<{
+          key: string;
+          name: string;
+          description: string;
+          style_type: string;
+          node_id: string;
+        }>;
+      };
+    }>(`/files/${file_key}/styles`);
+    return JSON.stringify({
+      file_url: figmaFileUrl(file_key),
+      styles: data.meta.styles.map((s) => ({
+        key: s.key,
+        name: s.name,
+        description: s.description,
+        type: s.style_type,
+        node_id: s.node_id,
+      })),
+    });
+  },
+});
+
+export const list_team_styles = tool({
+  description: `List all published styles in the Purdue Hackers team library. Includes colors, typography, effects, and grid styles shared across files.`,
+  inputSchema: z.object({
+    page_size: z.number().max(100).optional().describe("Results per page"),
+    cursor: z.string().optional().describe("Pagination cursor from previous response"),
+  }),
+  execute: async ({ page_size, cursor }) => {
+    const params = new URLSearchParams();
+    if (page_size) params.set("page_size", String(page_size));
+    if (cursor) params.set("after", cursor);
+    const query = params.toString();
+
+    const data = await figmaFetch<{
+      meta: {
+        styles: Array<{
+          key: string;
+          name: string;
+          description: string;
+          style_type: string;
+          file_key: string;
+          node_id: string;
+          thumbnail_url: string;
+        }>;
+        cursor: Record<string, number>;
+      };
+    }>(`/teams/${env.FIGMA_TEAM_ID}/styles${query ? `?${query}` : ""}`);
+    return JSON.stringify({
+      styles: data.meta.styles.map((s) => ({
+        key: s.key,
+        name: s.name,
+        description: s.description,
+        type: s.style_type,
+        file_url: figmaFileUrl(s.file_key, s.node_id),
+        thumbnail_url: s.thumbnail_url,
+      })),
+      cursor: data.meta.cursor,
+    });
+  },
+});

--- a/src/lib/ai/tools/figma/files.ts
+++ b/src/lib/ai/tools/figma/files.ts
@@ -1,0 +1,85 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { figmaFetch, figmaFileUrl } from "./client.ts";
+
+export const get_file_nodes = tool({
+  description: `Get specific nodes (frames, components, groups) from a Figma file by their IDs. Returns node properties including name, type, bounding box, and children. Use get_file_metadata first to discover page/frame IDs.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+    node_ids: z.array(z.string()).describe('Node IDs to fetch (format: "X:Y")'),
+    depth: z.number().optional().describe("How deep to traverse children (omit for full depth)"),
+  }),
+  execute: async ({ file_key, node_ids, depth }) => {
+    const ids = node_ids.join(",");
+    const depthParam = depth !== undefined ? `&depth=${depth}` : "";
+    const data = await figmaFetch<{
+      nodes: Record<string, { document: unknown } | null>;
+    }>(`/files/${file_key}/nodes?ids=${encodeURIComponent(ids)}${depthParam}`);
+    return JSON.stringify({
+      nodes: Object.entries(data.nodes).map(([id, node]) => ({
+        id,
+        url: figmaFileUrl(file_key, id),
+        ...(node ? { document: node.document } : { error: "Node not found" }),
+      })),
+    });
+  },
+});
+
+export const export_file_images = tool({
+  description: `Export/render Figma nodes as images. Returns temporary URLs for PNG, SVG, JPG, or PDF. Use this to share design screenshots in Discord. URLs expire after 14 days.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+    node_ids: z.array(z.string()).describe("Node IDs to export"),
+    format: z.enum(["png", "svg", "jpg", "pdf"]).default("png").describe("Image format"),
+    scale: z
+      .number()
+      .min(0.01)
+      .max(4)
+      .optional()
+      .describe("Scale factor (0.01–4, default 1). Only applies to png/jpg."),
+  }),
+  execute: async ({ file_key, node_ids, format, scale }) => {
+    const ids = node_ids.join(",");
+    const scaleParam = scale !== undefined ? `&scale=${scale}` : "";
+    const data = await figmaFetch<{
+      images: Record<string, string | null>;
+    }>(`/images/${file_key}?ids=${encodeURIComponent(ids)}&format=${format}${scaleParam}`);
+    return JSON.stringify({
+      images: Object.entries(data.images).map(([id, url]) => ({
+        node_id: id,
+        url: url ?? null,
+        figma_url: figmaFileUrl(file_key, id),
+      })),
+    });
+  },
+});
+
+export const list_file_versions = tool({
+  description: `List version history of a Figma file. Returns version ID, label, description, creator, and timestamp. Useful for "what changed recently?" queries.`,
+  inputSchema: z.object({
+    file_key: z.string().describe("Figma file key"),
+    page_size: z.number().max(100).optional().describe("Number of versions to return"),
+  }),
+  execute: async ({ file_key, page_size }) => {
+    const pageSizeParam = page_size ? `?page_size=${page_size}` : "";
+    const data = await figmaFetch<{
+      versions: Array<{
+        id: string;
+        label: string;
+        description: string;
+        created_at: string;
+        user: { handle: string; id: string };
+      }>;
+    }>(`/files/${file_key}/versions${pageSizeParam}`);
+    return JSON.stringify({
+      versions: data.versions.map((v) => ({
+        id: v.id,
+        label: v.label,
+        description: v.description,
+        created_at: v.created_at,
+        created_by: v.user.handle,
+      })),
+    });
+  },
+});

--- a/src/lib/ai/tools/figma/index.ts
+++ b/src/lib/ai/tools/figma/index.ts
@@ -1,0 +1,4 @@
+export * from "./base.ts";
+export * from "./files.ts";
+export * from "./comments.ts";
+export * from "./components.ts";


### PR DESCRIPTION
## Summary

- Adds a new Figma delegate domain with 13 tools across 3 sub-skills (files, comments, components) plus 4 base discovery tools
- Implements a thin `fetch`-based Figma REST API client authenticated via personal access token
- Registers the domain in the orchestrator and delegation system, with full SKILL.md progressive disclosure
- Includes formatting/linting fixes across docs and package.json

## Test plan

- [x] `bun format` passes
- [x] `bun lint` passes (0 warnings, 0 errors)
- [x] `bun typecheck` passes
- [x] `bun run test` passes (27 files, 186 tests)
- [x] `bun test:coverage` passes (94.34% statements)
- [x] `bun knip` passes (no unused exports)
- [ ] Set `FIGMA_ACCESS_TOKEN` and `FIGMA_TEAM_ID` env vars and verify end-to-end in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)