### PR TITLE
fix: skip thread messages unless bot is explicitly mentioned

### DIFF
--- a/src/server/routes/handlers.test.ts
+++ b/src/server/routes/handlers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { handlerCtx, messagePacket } from "@/lib/test/fixtures";
+
+vi.mock("workflow/api", () => ({
+  resumeHook: vi.fn().mockResolvedValue(undefined),
+  start: vi.fn().mockResolvedValue({ runId: "run-1" }),
+}));
+
+vi.mock("@/bot/handlers/events", () => ({
+  handleMention: vi.fn(),
+}));
+
+const { router } = await import("./handlers");
+const { resumeHook } = await import("workflow/api");
+
+const BOT = "bot-123";
+
+describe("message handler – thread filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores non-mention messages inside a thread", async () => {
+    const ctx = handlerCtx(BOT);
+    await ctx.store.set({
+      workflowRunId: "wf-1",
+      channelId: "ch-1",
+      threadId: "ch-1",
+      startedAt: new Date().toISOString(),
+    });
+
+    await router.dispatch(
+      messagePacket("hello", { thread: { parentId: "p1", parentName: "parent" } }),
+      ctx,
+    );
+
+    expect(resumeHook).not.toHaveBeenCalled();
+  });
+
+  it("forwards non-mention messages in a channel with an active conversation", async () => {
+    const ctx = handlerCtx(BOT);
+    await ctx.store.set({
+      workflowRunId: "wf-2",
+      channelId: "ch-1",
+      startedAt: new Date().toISOString(),
+    });
+
+    await router.dispatch(messagePacket("hello"), ctx);
+
+    expect(resumeHook).toHaveBeenCalledOnce();
+  });
+});

--- a/src/server/routes/handlers.ts
+++ b/src/server/routes/handlers.ts
@@ -17,6 +17,7 @@ router.onMessage(async (packet, ctx) => {
   // with the mention prefix stripped. Forwarding again here would duplicate
   // the turn and push the un-stripped content into the conversation.
   if (isBotMention(packet.data.content, ctx.botUserId)) return;
+  if (packet.data.thread) return;
 
   const channelId = packet.data.channel.id;
   const threadId = packet.data.thread ? packet.data.channel.id : undefined;


### PR DESCRIPTION
## Summary
- The bot previously responded to all messages in a thread once it had an active conversation there. Now it only responds when explicitly `@mentioned` again.
- One-line guard added to the message handler in `handlers.ts` to skip messages that are inside a thread.
- The mention handler already supports re-mentions in threads, so no other changes needed.

## Test plan
- [x] Added `handlers.test.ts` verifying thread messages without mentions are ignored
- [x] Added test verifying channel messages with active conversations still forward normally
- [x] All checks pass: format, lint, typecheck, test, coverage, knip

🤖 Generated with [Claude Code](https://claude.com/claude-code)