### PR TITLE
feat: include task ID footer in scheduled task messages

### DIFF
--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -166,6 +166,20 @@ describe("streamTurn: basic streaming", () => {
     expect(body.content).toMatch(/-# .+s · 150 tokens/);
   });
 
+  it("includes task ID in footer when taskId is provided", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+
+    await streamTurn(asAPI(discord), "ch-1", "hello", ctx.toJSON(), "task-abc-123");
+
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toContain("-# Task: task-abc-123");
+    // Task footer should be on a separate line from the metadata footer
+    expect(body.content).toMatch(/-# .+s · .+\n-# Task: task-abc-123/);
+  });
+
   it("falls back to createMessage when editMessage fails", async () => {
     const discord = createMockAPI();
     discord.channels.editMessage = async () => {

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -85,6 +85,7 @@ export async function streamTurn(
   channelId: string,
   content: string,
   serializedContext: SerializedAgentContext,
+  taskId?: string,
 ): Promise<{ text: string }> {
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const subagentMetrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
@@ -160,6 +161,8 @@ export async function streamTurn(
     log.warn("streaming", `Failed to collect metadata: ${String(err)}`);
     footer = formatFooter({ elapsedMs, totalTokens: undefined, toolCallCount: 0, stepCount: 0 });
   }
+
+  if (taskId) footer += `\n-# Task: ${taskId}`;
 
   const finalText = state.text || "I didn't have anything to say.";
   const final = truncateWithFooter(finalText, footer);

--- a/src/workflows/task.test.ts
+++ b/src/workflows/task.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/ai/streaming", () => ({
 }));
 
 const { taskWorkflow } = await import("./task.ts");
-const streaming = await import("@/lib/ai/streaming.ts");
+const streaming = await import("@/lib/ai/streaming");
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/src/workflows/task.test.ts
+++ b/src/workflows/task.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCreateMessage = vi.fn(async (_ch: string, body: { content: string }) => ({
+  id: "msg-1",
+  content: body.content,
+  channel_id: _ch,
+}));
+
+vi.mock("@discordjs/core/http-only", () => {
+  class MockAPI {
+    channels = { createMessage: mockCreateMessage };
+  }
+  return { API: MockAPI };
+});
+
+vi.mock("@discordjs/rest", () => {
+  class MockREST {
+    setToken() {
+      return this;
+    }
+  }
+  return { REST: MockREST };
+});
+
+vi.mock("workflow", () => ({
+  sleep: vi.fn(),
+  getWorkflowMetadata: vi.fn(() => ({ workflowRunId: "task-run-42" })),
+}));
+
+vi.mock("@/lib/tasks/registry", () => ({
+  saveTask: vi.fn(),
+  removeTask: vi.fn(),
+  getTask: vi.fn(),
+}));
+
+vi.mock("@/lib/tasks/cron", () => ({
+  nextOccurrence: vi.fn(() => new Date(Date.now() + 60_000)),
+}));
+
+vi.mock("@/lib/ai/streaming", () => ({
+  streamTurn: vi.fn(async () => ({ text: "Agent reply." })),
+  truncateWithFooter: vi.fn((text: string, footer: string) => `${text}\n\n${footer}`),
+}));
+
+const { taskWorkflow } = await import("./task.ts");
+const streaming = await import("@/lib/ai/streaming.ts");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("taskWorkflow: message action footer", () => {
+  it("includes task ID footer for message actions", async () => {
+    const { saveTask } = await import("@/lib/tasks/registry");
+
+    await taskWorkflow({
+      meta: {
+        description: "Daily reminder",
+        action: { type: "message", channelId: "ch-1", content: "Hello!" },
+        schedule: { type: "once", at: new Date(Date.now() + 60_000).toISOString() },
+        context: { userId: "u-1", channelId: "ch-1" },
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    expect(saveTask).toHaveBeenCalled();
+    expect(mockCreateMessage).toHaveBeenCalledOnce();
+
+    const [channelId, body] = mockCreateMessage.mock.calls[0];
+    expect(channelId).toBe("ch-1");
+    expect(body.content).toContain("Hello!");
+    expect(body.content).toContain("-# Task: task-run-42");
+  });
+});
+
+describe("taskWorkflow: agent action footer", () => {
+  it("passes task ID to streamTurn for agent actions", async () => {
+    await taskWorkflow({
+      meta: {
+        description: "Daily summary",
+        action: { type: "agent", channelId: "ch-1", prompt: "Summarize today" },
+        schedule: { type: "once", at: new Date(Date.now() + 60_000).toISOString() },
+        context: { userId: "u-1", channelId: "ch-1" },
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    expect(streaming.streamTurn).toHaveBeenCalledWith(
+      expect.anything(), // discord API
+      "ch-1",
+      "Summarize today",
+      expect.any(Object), // serialized context
+      "task-run-42", // task ID
+    );
+  });
+});

--- a/src/workflows/task.ts
+++ b/src/workflows/task.ts
@@ -6,7 +6,7 @@ import { sleep, getWorkflowMetadata } from "workflow";
 import type { TaskMeta } from "@/lib/tasks/types";
 
 import { AgentContext } from "@/lib/ai/context";
-import { streamTurn } from "@/lib/ai/streaming";
+import { streamTurn, truncateWithFooter } from "@/lib/ai/streaming";
 import { nextOccurrence } from "@/lib/tasks/cron";
 import { saveTask, removeTask, getTask } from "@/lib/tasks/registry";
 
@@ -35,9 +35,11 @@ async function executeAction(meta: TaskMeta) {
   "use step";
   const discord = new API(new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN!));
 
+  const taskFooter = `-# Task: ${meta.id}`;
+
   if (meta.action.type === "message") {
     await discord.channels.createMessage(meta.action.channelId, {
-      content: meta.action.content,
+      content: truncateWithFooter(meta.action.content, taskFooter),
     });
     log.info("task-workflow", `Sent message for task ${meta.id}`);
   } else if (meta.action.type === "agent") {
@@ -54,7 +56,7 @@ async function executeAction(meta: TaskMeta) {
         day: "numeric",
       }),
     });
-    await streamTurn(discord, meta.action.channelId, meta.action.prompt, context.toJSON());
+    await streamTurn(discord, meta.action.channelId, meta.action.prompt, context.toJSON(), meta.id);
     log.info("task-workflow", `Ran agent for task ${meta.id}`);
   }
 }


### PR DESCRIPTION
## Summary
- Appends `-# Task: <id>` as a small-text footer to every Discord message sent by a scheduled or recurring task, so users can identify the originating task and cancel it
- For "message" actions, the footer is appended via `truncateWithFooter`; for "agent" actions, the task ID is passed through `streamTurn` and added below the existing metadata footer
- Adds tests for both paths in `streaming.test.ts` and a new `task.test.ts`

## Test plan
- [x] Existing `streamTurn` tests still pass (no taskId = no change)
- [x] New test: `streamTurn` with `taskId` includes `-# Task: <id>` on a separate footer line
- [x] New test: message action creates message with task footer
- [x] New test: agent action passes task ID to `streamTurn`
- [x] `bun format`, `bun lint`, `bun typecheck`, `bun test:coverage`, `bun knip` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)