### PR TITLE
refactor: extract MessageRenderer class, split long messages

### DIFF
--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -121,6 +121,14 @@ describe("MessageRenderer.splitText", () => {
     expect(chunks[4].endsWith("…")).toBe(true);
   });
 
+  it("handles text that splits with empty remainder", () => {
+    // "a".repeat(10) split at maxLength=10: first chunk is exactly 10, remainder is empty
+    const text = "a".repeat(10) + " " + "b".repeat(5);
+    const chunks = MessageRenderer.splitText(text, 10);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[1]).toBe("b".repeat(5));
+  });
+
   it("respects custom maxLength", () => {
     const text = "a".repeat(20);
     const chunks = MessageRenderer.splitText(text, 10);
@@ -167,6 +175,15 @@ describe("MessageRenderer.splitWithFooter", () => {
     }
     expect(result[result.length - 1]).toContain(footer);
   });
+
+  it("enforces MAX_MESSAGES cap even when re-splitting for footer", () => {
+    // 9500 chars of no-space text forces 5 chunks from splitText,
+    // then re-splitting the last chunk could exceed 5 total
+    const text = "a".repeat(9500);
+    const result = MessageRenderer.splitWithFooter(text, footer);
+    expect(result.length).toBeLessThanOrEqual(5);
+    expect(result[result.length - 1]).toContain(footer);
+  });
 });
 
 describe("MessageRenderer instance", () => {
@@ -191,6 +208,28 @@ describe("MessageRenderer instance", () => {
     expect(renderer.content).toBe("Hello world!");
   });
 
+  it("flush skips edit when content is unchanged", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    // Append empty string — text stays "", render returns "> Thinking..." (same as lastRendered)
+    await renderer.appendText("");
+
+    // Only the init createMessage, no edits since rendered content didn't change
+    const edits = discord.callsTo("channels.editMessage");
+    expect(edits).toHaveLength(0);
+
+    vi.restoreAllMocks();
+  });
+
   it("appendText triggers rate-limited edit", async () => {
     const discord = createMockAPI();
     const renderer = new MessageRenderer(asAPI(discord), "ch-1");
@@ -207,6 +246,33 @@ describe("MessageRenderer instance", () => {
 
     const edits = discord.callsTo("channels.editMessage");
     expect(edits.length).toBeGreaterThanOrEqual(1);
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe("MessageRenderer: mid-stream truncation", () => {
+  it("truncates long text during streaming to MAX_LENGTH", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    await renderer.appendText("a".repeat(2500));
+
+    const edits = discord.callsTo("channels.editMessage");
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    // Should be truncated to exactly 1900 chars (1899 + ellipsis)
+    expect(body.content).toHaveLength(1900);
+    expect(body.content.endsWith("…")).toBe(true);
 
     vi.restoreAllMocks();
   });

--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { FooterMeta } from "./types.ts";
+
+import { createMockAPI, asAPI } from "../test/fixtures/index.ts";
+import { MessageRenderer } from "./message-renderer.ts";
+
+describe("MessageRenderer.formatFooter", () => {
+  it("shows all metadata when present", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 3200,
+        totalTokens: 1423,
+        toolCallCount: 4,
+        stepCount: 3,
+      }),
+    ).toBe("-# 3.2s · 1,423 tokens · 4 tool calls · 3 steps");
+  });
+
+  it("omits tool calls when zero", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 1000,
+        totalTokens: 500,
+        toolCallCount: 0,
+        stepCount: 1,
+      }),
+    ).toBe("-# 1.0s · 500 tokens");
+  });
+
+  it("omits steps when only 1", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 2500,
+        totalTokens: 800,
+        toolCallCount: 2,
+        stepCount: 1,
+      }),
+    ).toBe("-# 2.5s · 800 tokens · 2 tool calls");
+  });
+
+  it("uses singular for 1 tool call", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 1000,
+        totalTokens: 100,
+        toolCallCount: 1,
+        stepCount: 2,
+      }),
+    ).toBe("-# 1.0s · 100 tokens · 1 tool call · 2 steps");
+  });
+
+  it("omits tokens when undefined", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 500,
+        totalTokens: undefined,
+        toolCallCount: 0,
+        stepCount: 1,
+      }),
+    ).toBe("-# 0.5s");
+  });
+});
+
+describe("MessageRenderer.splitText", () => {
+  it("returns short text as single chunk", () => {
+    expect(MessageRenderer.splitText("hello")).toEqual(["hello"]);
+  });
+
+  it("returns empty string as single chunk", () => {
+    expect(MessageRenderer.splitText("")).toEqual([""]);
+  });
+
+  it("returns text at exactly max length as single chunk", () => {
+    const text = "a".repeat(1900);
+    expect(MessageRenderer.splitText(text)).toEqual([text]);
+  });
+
+  it("splits at paragraph boundaries", () => {
+    const p1 = "a".repeat(1000);
+    const p2 = "b".repeat(1000);
+    const text = `${p1}\n\n${p2}`;
+    const chunks = MessageRenderer.splitText(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(p1);
+    expect(chunks[1]).toBe(p2);
+  });
+
+  it("splits at sentence boundaries when no paragraph break", () => {
+    const s1 = "a".repeat(950) + ".";
+    const s2 = "b".repeat(1000);
+    const text = `${s1} ${s2}`;
+    const chunks = MessageRenderer.splitText(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(s1);
+    expect(chunks[1]).toBe(s2);
+  });
+
+  it("splits at word boundaries when no sentence break", () => {
+    const w1 = "word ".repeat(380).trimEnd(); // ~1899 chars
+    const text = w1 + " extra";
+    const result = MessageRenderer.splitText(text);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    for (const segment of result) {
+      expect(segment.length).toBeLessThanOrEqual(1901); // 1900 + ellipsis
+    }
+  });
+
+  it("hard-splits text with no spaces", () => {
+    const text = "a".repeat(3800);
+    const chunks = MessageRenderer.splitText(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(1900);
+    expect(chunks[1]).toHaveLength(1900);
+  });
+
+  it("caps at 5 messages with truncation", () => {
+    const text = "a".repeat(10_000);
+    const chunks = MessageRenderer.splitText(text);
+    expect(chunks).toHaveLength(5);
+    expect(chunks[4].endsWith("…")).toBe(true);
+  });
+
+  it("respects custom maxLength", () => {
+    const text = "a".repeat(20);
+    const chunks = MessageRenderer.splitText(text, 10);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(10);
+    expect(chunks[1]).toHaveLength(10);
+  });
+});
+
+describe("MessageRenderer.splitWithFooter", () => {
+  const footer = "-# 1.0s · 100 tokens";
+
+  it("appends footer to short text in single chunk", () => {
+    const result = MessageRenderer.splitWithFooter("Hello!", footer);
+    expect(result).toEqual([`Hello!\n\n${footer}`]);
+  });
+
+  it("splits long text and places footer on last chunk", () => {
+    const longText = "a".repeat(3000);
+    const result = MessageRenderer.splitWithFooter(longText, footer);
+    expect(result.length).toBeGreaterThan(1);
+    // Only last chunk has footer
+    expect(result[result.length - 1].endsWith(footer)).toBe(true);
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(result[i]).not.toContain(footer);
+    }
+  });
+
+  it("preserves text exactly at available limit", () => {
+    const available = 1900 - footer.length - 2; // 2 for "\n\n"
+    const text = "a".repeat(available);
+    const result = MessageRenderer.splitWithFooter(text, footer);
+    expect(result).toEqual([`${text}\n\n${footer}`]);
+    expect(result[0]).toHaveLength(1900);
+  });
+
+  it("handles footer pushing last chunk over limit", () => {
+    // Text that splits into chunks where the last chunk is too long for footer
+    const text = "a".repeat(1900) + "b".repeat(1890);
+    const result = MessageRenderer.splitWithFooter(text, footer);
+    // Every chunk should fit within 1900 chars
+    for (const chunk of result) {
+      expect(chunk.length).toBeLessThanOrEqual(1901); // allow for ellipsis
+    }
+    expect(result[result.length - 1]).toContain(footer);
+  });
+});
+
+describe("MessageRenderer instance", () => {
+  it("init creates thinking placeholder", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+
+    const sends = discord.callsTo("channels.createMessage");
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toEqual(["ch-1", { content: "> Thinking..." }]);
+  });
+
+  it("appendText accumulates text", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+
+    await renderer.appendText("Hello ");
+    await renderer.appendText("world!");
+
+    expect(renderer.content).toBe("Hello world!");
+  });
+
+  it("appendText triggers rate-limited edit", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    await renderer.appendText("Hello");
+
+    const edits = discord.callsTo("channels.editMessage");
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe("MessageRenderer: components", () => {
+  it("showToolCall renders activity line", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    await renderer.showToolCall("search");
+
+    const edits = discord.callsTo("channels.editMessage");
+    const editBodies = edits.map((e) => (e[2] as { content: string }).content);
+    expect(editBodies.some((c) => c.includes("Calling `search`..."))).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  it("showSubagentPreview renders quoted preview", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    await renderer.showSubagentPreview("Searching...");
+
+    const edits = discord.callsTo("channels.editMessage");
+    const editBodies = edits.map((e) => (e[2] as { content: string }).content);
+    expect(editBodies.some((c) => c.includes("> Searching..."))).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  it("clearActivity clears activity and preview state", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+
+    const realNow = Date.now;
+    let now = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 2000;
+      return now;
+    });
+
+    await renderer.init();
+    await renderer.showToolCall("search");
+    renderer.clearActivity();
+    await renderer.appendText("Done");
+
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toBe("Done");
+    expect(body.content).not.toContain("Calling");
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe("MessageRenderer: finalize", () => {
+  it("finalize edits single message with footer for short text", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+    await renderer.appendText("Hello!");
+
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toContain("Hello!");
+    expect(body.content).toContain("-# 1.0s · 100 tokens");
+  });
+
+  it("finalize creates additional messages for long text", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+    await renderer.appendText("a".repeat(3000));
+
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    // Initial "Thinking..." + overflow chunk(s)
+    const sends = discord.callsTo("channels.createMessage");
+    expect(sends.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("finalize includes task ID in footer", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1", { taskId: "task-42" });
+    await renderer.init();
+    await renderer.appendText("Hello!");
+
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toContain("-# Task: task-42");
+    expect(body.content).toMatch(/-# .+s · .+\n-# Task: task-42/);
+  });
+});
+
+describe("MessageRenderer: finalize edge cases", () => {
+  it("finalize uses fallback text when no content", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+
+    const meta: FooterMeta = {
+      elapsedMs: 500,
+      totalTokens: undefined,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toContain("I didn't have anything to say.");
+  });
+
+  it("finalize falls back to createMessage when edit fails", async () => {
+    const discord = createMockAPI();
+    discord.channels.editMessage = async () => {
+      throw new Error("rate limited");
+    };
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+    await renderer.appendText("Hello!");
+
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    const sends = discord.callsTo("channels.createMessage");
+    // Initial + fallback
+    expect(sends.length).toBeGreaterThanOrEqual(2);
+    const lastSend = sends[sends.length - 1];
+    expect((lastSend[1] as { content: string }).content).toContain("Hello!");
+  });
+});

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -1,0 +1,206 @@
+import type { API } from "@discordjs/core/http-only";
+
+import { log } from "evlog";
+
+import type { FooterMeta } from "./types.ts";
+
+const EDIT_INTERVAL_MS = 1500;
+const MAX_LENGTH = 1900;
+const MAX_MESSAGES = 5;
+
+export class MessageRenderer {
+  private messageId: string | null = null;
+  private text = "";
+  private activity: string | null = null;
+  private subagentPreview = "";
+  private taskId: string | undefined;
+  private lastEdit = 0;
+  private lastRendered = "";
+
+  constructor(
+    private discord: API,
+    private channelId: string,
+    options?: { taskId?: string },
+  ) {
+    this.taskId = options?.taskId;
+  }
+
+  /** Get the accumulated text. */
+  get content(): string {
+    return this.text;
+  }
+
+  /** Create initial placeholder message. */
+  async init(): Promise<void> {
+    const msg = await this.discord.channels.createMessage(this.channelId, {
+      content: "> Thinking...",
+    });
+    this.messageId = msg.id;
+    this.lastRendered = "> Thinking...";
+    this.lastEdit = Date.now();
+  }
+
+  /** Append streamed text. Clears activity/preview since text is arriving. */
+  async appendText(delta: string): Promise<void> {
+    this.text += delta;
+    this.activity = null;
+    this.subagentPreview = "";
+    await this.flush();
+  }
+
+  /** Show tool call activity indicator. */
+  async showToolCall(toolName: string): Promise<void> {
+    this.activity = `Calling \`${toolName}\`...`;
+    this.subagentPreview = "";
+    await this.flush();
+  }
+
+  /** Show subagent progress preview. */
+  async showSubagentPreview(text: string): Promise<void> {
+    this.subagentPreview = text;
+    await this.flush();
+  }
+
+  /** Clear activity state (e.g. after non-preliminary tool-result). */
+  clearActivity(): void {
+    this.activity = null;
+    this.subagentPreview = "";
+  }
+
+  /** Finalize: render footer, split across messages, send. */
+  async finalize(meta: FooterMeta): Promise<void> {
+    let footer = MessageRenderer.formatFooter(meta);
+    if (this.taskId) footer += `\n-# Task: ${this.taskId}`;
+
+    const finalText = this.text || "I didn't have anything to say.";
+    const chunks = MessageRenderer.splitWithFooter(finalText, footer);
+
+    // Edit the original message with the first chunk
+    try {
+      await this.discord.channels.editMessage(this.channelId, this.messageId!, {
+        content: chunks[0],
+      });
+    } catch (err) {
+      log.warn("streaming", `Final edit failed, sending new message: ${String(err)}`);
+      await this.discord.channels.createMessage(this.channelId, { content: chunks[0] });
+    }
+
+    // Send additional messages for overflow chunks
+    for (let i = 1; i < chunks.length; i++) {
+      await this.discord.channels.createMessage(this.channelId, { content: chunks[i] });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static utilities
+  // ---------------------------------------------------------------------------
+
+  static formatFooter({ elapsedMs, totalTokens, toolCallCount, stepCount }: FooterMeta): string {
+    const parts = [`${(elapsedMs / 1000).toFixed(1)}s`];
+
+    if (totalTokens != null) parts.push(`${totalTokens.toLocaleString("en-US")} tokens`);
+    if (toolCallCount === 1) parts.push("1 tool call");
+    else if (toolCallCount > 1) parts.push(`${toolCallCount} tool calls`);
+    if (stepCount > 1) parts.push(`${stepCount} steps`);
+
+    return `-# ${parts.join(" · ")}`;
+  }
+
+  /** Split text into chunks that each fit within maxLength. */
+  static splitText(text: string, maxLength = MAX_LENGTH): string[] {
+    if (text.length <= maxLength) return [text];
+
+    const chunks: string[] = [];
+
+    let remaining = text;
+    while (remaining.length > maxLength) {
+      if (chunks.length >= MAX_MESSAGES - 1) {
+        // Last allowed chunk — truncate with ellipsis
+        chunks.push(remaining.slice(0, maxLength - 1) + "…");
+        return chunks;
+      }
+
+      const slice = remaining.slice(0, maxLength);
+
+      // Find best split point: paragraph > sentence > word > hard
+      let splitAt = slice.lastIndexOf("\n\n");
+      if (splitAt <= 0) {
+        // Sentence boundaries — look for ". ", "! ", "? "
+        for (const sep of [". ", "! ", "? "]) {
+          const idx = slice.lastIndexOf(sep);
+          if (idx > 0) {
+            splitAt = idx + sep.length - 1; // keep the punctuation, split after it
+            break;
+          }
+        }
+      }
+      if (splitAt <= 0) splitAt = slice.lastIndexOf(" ");
+      if (splitAt <= 0) splitAt = maxLength; // hard split
+
+      chunks.push(remaining.slice(0, splitAt).trimEnd());
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+
+    if (remaining) chunks.push(remaining);
+    return chunks;
+  }
+
+  /** Split text and append footer to the last chunk. */
+  static splitWithFooter(text: string, footer: string): string[] {
+    const separator = "\n\n";
+    const footerSize = separator.length + footer.length;
+    const available = MAX_LENGTH - footerSize;
+
+    // Simple case: everything fits in one message
+    if (text.length <= available) {
+      return [text + separator + footer];
+    }
+
+    // Split the text, reserving space in the last chunk for the footer
+    const chunks = MessageRenderer.splitText(text, MAX_LENGTH);
+
+    // Check if footer fits on the last chunk
+    const lastChunk = chunks[chunks.length - 1];
+    if (lastChunk.length <= available) {
+      chunks[chunks.length - 1] = lastChunk + separator + footer;
+    } else {
+      // Re-split the last chunk to make room for footer
+      chunks.pop();
+      const reSplit = MessageRenderer.splitText(lastChunk, available);
+      for (const part of reSplit) {
+        chunks.push(part);
+      }
+      chunks[chunks.length - 1] += separator + footer;
+    }
+
+    return chunks;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private rendering
+  // ---------------------------------------------------------------------------
+
+  /** Rate-limited mid-stream edit. */
+  private async flush(): Promise<void> {
+    if (Date.now() - this.lastEdit < EDIT_INTERVAL_MS) return;
+    const content = this.render();
+    if (content === this.lastRendered) return;
+    this.lastEdit = Date.now();
+    this.lastRendered = content;
+    try {
+      await this.discord.channels.editMessage(this.channelId, this.messageId!, { content });
+    } catch (err) {
+      log.warn("streaming", `Edit failed mid-stream: ${String(err)}`);
+    }
+  }
+
+  /** Compose components into a single Discord message string (mid-stream). */
+  private render(): string {
+    const parts: string[] = [];
+    if (this.activity) parts.push(`-# ${this.activity}`);
+    if (this.subagentPreview) parts.push(`> ${this.subagentPreview.replaceAll("\n", "\n> ")}`);
+    if (this.text) parts.push(this.text);
+    const body = parts.join("\n\n") || "> Thinking...";
+    return body.length > MAX_LENGTH ? body.slice(0, MAX_LENGTH) + "…" : body;
+  }
+}

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -170,6 +170,11 @@ export class MessageRenderer {
       for (const part of reSplit) {
         chunks.push(part);
       }
+      // Enforce MAX_MESSAGES cap — merge overflow into the last allowed chunk
+      if (chunks.length > MAX_MESSAGES) {
+        const overflow = chunks.splice(MAX_MESSAGES - 1);
+        chunks.push(overflow.join(" ").slice(0, available - 1) + "…");
+      }
       chunks[chunks.length - 1] += separator + footer;
     }
 
@@ -201,6 +206,6 @@ export class MessageRenderer {
     if (this.subagentPreview) parts.push(`> ${this.subagentPreview.replaceAll("\n", "\n> ")}`);
     if (this.text) parts.push(this.text);
     const body = parts.join("\n\n") || "> Thinking...";
-    return body.length > MAX_LENGTH ? body.slice(0, MAX_LENGTH) + "…" : body;
+    return body.length > MAX_LENGTH ? body.slice(0, MAX_LENGTH - 1) + "…" : body;
   }
 }

--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -294,6 +294,30 @@ describe("streamTurn: tool events and metadata", () => {
 
     vi.restoreAllMocks();
   });
+});
+
+describe("streamTurn: tool event edge cases", () => {
+  it("ignores empty subagent preview from preliminary tool-result", async () => {
+    const orchestrator = await import("./orchestrator");
+    vi.spyOn(orchestrator, "createOrchestrator").mockReturnValue(
+      mockOrchestrator(["Done."], {
+        extraEvents: [
+          {
+            type: "tool-result",
+            preliminary: true,
+            output: { parts: [{ type: "text", text: "" }] },
+          },
+        ],
+      }) as any,
+    );
+
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", "hello", ctx.toJSON());
+
+    expect(result.text).toBe("Done.");
+    vi.restoreAllMocks();
+  });
 
   it("falls back to time-only footer when metadata promises reject", async () => {
     const orchestrator = await import("./orchestrator");

--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -2,13 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import { createMockAPI, asAPI, messagePacket } from "../test/fixtures/index.ts";
 import { AgentContext } from "./context.ts";
-import {
-  truncate,
-  truncateWithFooter,
-  buildPrompt,
-  streamTurn,
-  formatFooter,
-} from "./streaming.ts";
+import { buildPrompt, streamTurn } from "./streaming.ts";
 
 type StreamEvent = Record<string, unknown>;
 
@@ -56,26 +50,6 @@ function mockOrchestrator(
 vi.mock("./orchestrator", () => ({
   createOrchestrator: vi.fn(() => mockOrchestrator(["Hello ", "world!"])),
 }));
-
-describe("truncate", () => {
-  it("returns short text unchanged", () => {
-    expect(truncate("hello")).toBe("hello");
-  });
-
-  it("truncates text exceeding 1900 chars", () => {
-    const result = truncate("a".repeat(2000));
-    expect(result).toHaveLength(1901);
-    expect(result.endsWith("…")).toBe(true);
-  });
-
-  it("returns exactly 1900 chars unchanged", () => {
-    expect(truncate("a".repeat(1900))).toHaveLength(1900);
-  });
-
-  it("returns empty string unchanged", () => {
-    expect(truncate("")).toBe("");
-  });
-});
 
 function getMessageContent(result: ReturnType<typeof buildPrompt>) {
   if (!("messages" in result) || !result.messages) throw new Error("expected messages");
@@ -238,6 +212,26 @@ describe("streamTurn: basic streaming", () => {
   });
 });
 
+describe("streamTurn: multi-message splitting", () => {
+  it("splits long responses across multiple messages", async () => {
+    const orchestrator = await import("./orchestrator");
+    const longText = "a".repeat(3000);
+    vi.spyOn(orchestrator, "createOrchestrator").mockReturnValue(
+      mockOrchestrator([longText]) as any,
+    );
+
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    await streamTurn(asAPI(discord), "ch-1", "hello", ctx.toJSON());
+
+    // Initial "Thinking..." + at least one overflow chunk
+    const sends = discord.callsTo("channels.createMessage");
+    expect(sends.length).toBeGreaterThanOrEqual(2);
+
+    vi.restoreAllMocks();
+  });
+});
+
 describe("streamTurn: tool events and metadata", () => {
   it("shows tool activity for tool-input-start events", async () => {
     const orchestrator = await import("./orchestrator");
@@ -322,62 +316,5 @@ describe("streamTurn: tool events and metadata", () => {
     expect(body.content).toMatch(/-# \d+\.\ds$/);
 
     vi.restoreAllMocks();
-  });
-});
-
-describe("formatFooter", () => {
-  it("shows all metadata when present", () => {
-    expect(
-      formatFooter({ elapsedMs: 3200, totalTokens: 1423, toolCallCount: 4, stepCount: 3 }),
-    ).toBe("-# 3.2s · 1,423 tokens · 4 tool calls · 3 steps");
-  });
-
-  it("omits tool calls when zero", () => {
-    expect(
-      formatFooter({ elapsedMs: 1000, totalTokens: 500, toolCallCount: 0, stepCount: 1 }),
-    ).toBe("-# 1.0s · 500 tokens");
-  });
-
-  it("omits steps when only 1", () => {
-    expect(
-      formatFooter({ elapsedMs: 2500, totalTokens: 800, toolCallCount: 2, stepCount: 1 }),
-    ).toBe("-# 2.5s · 800 tokens · 2 tool calls");
-  });
-
-  it("uses singular for 1 tool call", () => {
-    expect(
-      formatFooter({ elapsedMs: 1000, totalTokens: 100, toolCallCount: 1, stepCount: 2 }),
-    ).toBe("-# 1.0s · 100 tokens · 1 tool call · 2 steps");
-  });
-
-  it("omits tokens when undefined", () => {
-    expect(
-      formatFooter({ elapsedMs: 500, totalTokens: undefined, toolCallCount: 0, stepCount: 1 }),
-    ).toBe("-# 0.5s");
-  });
-});
-
-describe("truncateWithFooter", () => {
-  const footer = "-# 1.0s · 100 tokens";
-
-  it("appends footer to short text", () => {
-    const result = truncateWithFooter("Hello!", footer);
-    expect(result).toBe(`Hello!\n\n${footer}`);
-  });
-
-  it("truncates body when text + footer exceeds limit", () => {
-    const longText = "a".repeat(1900);
-    const result = truncateWithFooter(longText, footer);
-    expect(result.length).toBeLessThanOrEqual(1900);
-    expect(result).toContain("…");
-    expect(result.endsWith(`\n\n${footer}`)).toBe(true);
-  });
-
-  it("preserves text exactly at available limit", () => {
-    const available = 1900 - footer.length - 2; // 2 for "\n\n"
-    const text = "a".repeat(available);
-    const result = truncateWithFooter(text, footer);
-    expect(result).toBe(`${text}\n\n${footer}`);
-    expect(result.length).toBe(1900);
   });
 });

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -6,39 +6,10 @@ import { log } from "evlog";
 import type { SerializedAgentContext, Attachment, SubagentMetrics } from "./types.ts";
 
 import { AgentContext } from "./context.ts";
+import { MessageRenderer } from "./message-renderer.ts";
 import { createOrchestrator } from "./orchestrator.ts";
 
-const EDIT_INTERVAL_MS = 1500;
-const MAX_LENGTH = 1900;
-
-interface FooterMeta {
-  elapsedMs: number;
-  totalTokens: number | undefined;
-  toolCallCount: number;
-  stepCount: number;
-}
-
-export function formatFooter({ elapsedMs, totalTokens, toolCallCount, stepCount }: FooterMeta) {
-  const parts = [`${(elapsedMs / 1000).toFixed(1)}s`];
-
-  if (totalTokens != null) parts.push(`${totalTokens.toLocaleString("en-US")} tokens`);
-  if (toolCallCount === 1) parts.push("1 tool call");
-  else if (toolCallCount > 1) parts.push(`${toolCallCount} tool calls`);
-  if (stepCount > 1) parts.push(`${stepCount} steps`);
-
-  return `-# ${parts.join(" · ")}`;
-}
-
-export function truncateWithFooter(text: string, footer: string): string {
-  const separator = "\n\n";
-  const available = MAX_LENGTH - footer.length - separator.length;
-  const body = text.length > available ? text.slice(0, available - 1) + "…" : text;
-  return body + separator + footer;
-}
-
-export function truncate(text: string): string {
-  return text.length > MAX_LENGTH ? text.slice(0, MAX_LENGTH) + "…" : text;
-}
+export { MessageRenderer } from "./message-renderer.ts";
 
 export function buildPrompt(content: string, attachments?: Attachment[]) {
   if (!attachments?.length) return { prompt: content };
@@ -71,15 +42,6 @@ function previewSubagentText(message: UIMessage): string {
   return last?.text ?? "";
 }
 
-/** Compose the Discord message body from the orchestrator's current activity. */
-function render(state: { text: string; activity: string | null; subagentPreview: string }): string {
-  const parts: string[] = [];
-  if (state.activity) parts.push(`-# ${state.activity}`);
-  if (state.subagentPreview) parts.push(`> ${state.subagentPreview.replaceAll("\n", "\n> ")}`);
-  if (state.text) parts.push(state.text);
-  return truncate(parts.join("\n\n") || "> Thinking...");
-}
-
 export async function streamTurn(
   discord: API,
   channelId: string,
@@ -90,55 +52,29 @@ export async function streamTurn(
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const subagentMetrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
   const agent = createOrchestrator(agentCtx, subagentMetrics);
-  const msg = await discord.channels.createMessage(channelId, { content: "> Thinking..." });
+  const renderer = new MessageRenderer(discord, channelId, { taskId });
+
+  await renderer.init();
 
   log.info("streaming", `Turn started in ${channelId}`);
 
   const startTime = Date.now();
   const result = await agent.stream(buildPrompt(content, agentCtx.attachments));
 
-  const state = { text: "", activity: null as string | null, subagentPreview: "" };
-  let lastEdit = Date.now();
-  let lastRendered = "> Thinking...";
-
-  const flush = async () => {
-    if (Date.now() - lastEdit < EDIT_INTERVAL_MS) return;
-    const content = render(state);
-    if (content === lastRendered) return;
-    lastEdit = Date.now();
-    lastRendered = content;
-    try {
-      await discord.channels.editMessage(channelId, msg.id, { content });
-    } catch (err) {
-      log.warn("streaming", `Edit failed mid-stream: ${String(err)}`);
-    }
-  };
-
   for await (const event of result.fullStream) {
     switch (event.type) {
       case "text-delta":
-        state.text += event.text;
-        state.activity = null;
-        state.subagentPreview = "";
-        await flush();
+        await renderer.appendText(event.text);
         break;
       case "tool-input-start":
-        state.activity = `Calling \`${event.toolName}\`...`;
-        state.subagentPreview = "";
-        await flush();
+        await renderer.showToolCall(event.toolName);
         break;
       case "tool-result":
-        // Subagent delegation tools yield UIMessage snapshots as preliminary
-        // results. Pull out the latest text so the user sees subagent progress.
         if (event.preliminary && event.output && typeof event.output === "object") {
           const preview = previewSubagentText(event.output as UIMessage);
-          if (preview) {
-            state.subagentPreview = preview;
-            await flush();
-          }
+          if (preview) await renderer.showSubagentPreview(preview);
         } else {
-          state.activity = null;
-          state.subagentPreview = "";
+          renderer.clearActivity();
         }
         break;
       default:
@@ -147,11 +83,10 @@ export async function streamTurn(
   }
 
   const elapsedMs = Date.now() - startTime;
-  let footer: string;
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
     const orchestratorToolCalls = steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
-    footer = formatFooter({
+    await renderer.finalize({
       elapsedMs,
       totalTokens: (totalUsage.totalTokens ?? 0) + subagentMetrics.totalTokens,
       toolCallCount: orchestratorToolCalls + subagentMetrics.toolCallCount,
@@ -159,21 +94,15 @@ export async function streamTurn(
     });
   } catch (err) {
     log.warn("streaming", `Failed to collect metadata: ${String(err)}`);
-    footer = formatFooter({ elapsedMs, totalTokens: undefined, toolCallCount: 0, stepCount: 0 });
+    await renderer.finalize({
+      elapsedMs,
+      totalTokens: undefined,
+      toolCallCount: 0,
+      stepCount: 0,
+    });
   }
 
-  if (taskId) footer += `\n-# Task: ${taskId}`;
+  log.info("streaming", `Turn complete, ${renderer.content.length} chars, ${elapsedMs}ms`);
 
-  const finalText = state.text || "I didn't have anything to say.";
-  const final = truncateWithFooter(finalText, footer);
-  try {
-    await discord.channels.editMessage(channelId, msg.id, { content: final });
-  } catch (err) {
-    log.warn("streaming", `Final edit failed, sending new message: ${String(err)}`);
-    await discord.channels.createMessage(channelId, { content: final });
-  }
-
-  log.info("streaming", `Turn complete, ${state.text.length} chars, ${elapsedMs}ms`);
-
-  return { text: state.text };
+  return { text: renderer.content };
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -37,6 +37,13 @@ export interface SerializedAgentContext {
   recentMessages?: RecentMessage[];
 }
 
+export interface FooterMeta {
+  elapsedMs: number;
+  totalTokens: number | undefined;
+  toolCallCount: number;
+  stepCount: number;
+}
+
 /** Mutable accumulator for subagent token/tool-call metrics. */
 export interface SubagentMetrics {
   totalTokens: number;

--- a/src/workflows/task.test.ts
+++ b/src/workflows/task.test.ts
@@ -39,7 +39,12 @@ vi.mock("@/lib/tasks/cron", () => ({
 
 vi.mock("@/lib/ai/streaming", () => ({
   streamTurn: vi.fn(async () => ({ text: "Agent reply." })),
-  truncateWithFooter: vi.fn((text: string, footer: string) => `${text}\n\n${footer}`),
+}));
+
+vi.mock("@/lib/ai/message-renderer", () => ({
+  MessageRenderer: {
+    splitWithFooter: vi.fn((text: string, footer: string) => [`${text}\n\n${footer}`]),
+  },
 }));
 
 const { taskWorkflow } = await import("./task.ts");

--- a/src/workflows/task.ts
+++ b/src/workflows/task.ts
@@ -6,7 +6,8 @@ import { sleep, getWorkflowMetadata } from "workflow";
 import type { TaskMeta } from "@/lib/tasks/types";
 
 import { AgentContext } from "@/lib/ai/context";
-import { streamTurn, truncateWithFooter } from "@/lib/ai/streaming";
+import { MessageRenderer } from "@/lib/ai/message-renderer";
+import { streamTurn } from "@/lib/ai/streaming";
 import { nextOccurrence } from "@/lib/tasks/cron";
 import { saveTask, removeTask, getTask } from "@/lib/tasks/registry";
 
@@ -38,9 +39,9 @@ async function executeAction(meta: TaskMeta) {
   const taskFooter = `-# Task: ${meta.id}`;
 
   if (meta.action.type === "message") {
-    await discord.channels.createMessage(meta.action.channelId, {
-      content: truncateWithFooter(meta.action.content, taskFooter),
-    });
+    for (const msg of MessageRenderer.splitWithFooter(meta.action.content, taskFooter)) {
+      await discord.channels.createMessage(meta.action.channelId, { content: msg });
+    }
     log.info("task-workflow", `Sent message for task ${meta.id}`);
   } else if (meta.action.type === "agent") {
     const now = new Date();


### PR DESCRIPTION
## Summary

- Introduces a `MessageRenderer` class (`src/lib/ai/message-renderer.ts`) that centralizes all Discord message UI logic — thinking state, tool call activity, subagent preview, text accumulation, footer rendering, and rate-limited streaming edits.
- Replaces truncation with intelligent multi-message splitting (paragraph > sentence > word boundaries, capped at 5 messages).
- Simplifies `streamTurn` into a thin event-dispatch loop that delegates all rendering to `MessageRenderer`.
- Scheduled task messages in `task.ts` also use splitting instead of truncation.

## Test plan

- [x] All 221 existing + new tests pass (`bun run test`)
- [x] Coverage meets 90% threshold (`bun test:coverage`)
- [x] `bun typecheck`, `bun lint`, `bun format`, `bun knip` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)