### PR TITLE
fix: stop immediately archiving and locking checkpoint/ship threads

### DIFF
--- a/src/bot/handlers/events/auto-thread/index.ts
+++ b/src/bot/handlers/events/auto-thread/index.ts
@@ -129,7 +129,5 @@ export const autoThread = defineEvent({
         });
       }
     }
-
-    await ctx.discord.channels.edit(thread.id, { archived: true, locked: true });
   },
 });


### PR DESCRIPTION
## Summary

- Removes the `channels.edit({ archived: true, locked: true })` call that ran immediately after creating threads in checkpoint and ship channels
- This was causing every new thread to be instantly archived and locked, preventing users from interacting
- Threads already have `auto_archive_duration: 4320` (3 days) set at creation, so they will still auto-archive after inactivity

## Test plan

- [ ] Post a checkpoint with a URL/attachment and verify the thread stays open
- [ ] Post a ship with a URL/attachment and verify the thread stays open
- [ ] Verify users can reply in the created threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)