### PR TITLE
feat: ping Discord gateway after production deploy

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -1,0 +1,15 @@
+name: Post-Deploy Gateway Ping
+
+on:
+  deployment_status:
+
+jobs:
+  ping-gateway:
+    name: Ping Discord Gateway
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Production'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping gateway endpoint
+        run: curl -fsSL https://wack.purduehackers.com/api/discord/gateway


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that sends a GET request to the Discord gateway endpoint (`/api/discord/gateway`) immediately after a successful Vercel production deployment
- Complements the existing 9-minute cron so the bot reconnects right away after deploys instead of waiting for the next cron tick
- Only triggers on production deploys (not previews) via the `deployment_status` event

## Test plan
- [ ] Merge into main and verify the workflow runs after Vercel deploy succeeds
- [ ] Confirm it does not trigger on preview deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)