### PR TITLE
feat: add Discord invite and Linear team management tools

### DIFF
--- a/src/lib/ai/skills/discord/SKILL.md
+++ b/src/lib/ai/skills/discord/SKILL.md
@@ -21,6 +21,7 @@ When delegated to, you have access to these skill bundles (loaded via `load_skil
 - events: List, create, edit, and delete scheduled events
 - threads: List, create, edit, and delete threads
 - emojis: Manage custom emojis and stickers
+- invites: List, create, and delete server invites
 
 ## Terminology
 
@@ -37,4 +38,4 @@ Map synonyms silently:
 - Always confirm destructive actions before proceeding.
 - Messages are limited to 2000 characters.
 - Only take server management actions (creating/editing/deleting channels, roles, etc.) when explicitly requested. Never speculatively create or modify resources.
-- Cannot: ban/kick members, manage permissions, timeout/mute, manage invites.
+- Cannot: ban/kick members, manage permissions, timeout/mute.

--- a/src/lib/ai/skills/discord/skills/invites/SKILL.md
+++ b/src/lib/ai/skills/discord/skills/invites/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: invites
+description: List, create, and delete server invites.
+criteria: Use when the user wants to manage server invites — listing active invites, creating new ones, or revoking existing ones.
+tools: [list_invites, create_invite, delete_invite]
+minRole: admin
+mode: inline
+---
+
+<listing>
+- list_invites returns all active server invites with codes, channels, creators, usage stats, and expiry.
+- Present invites in a table: code, channel, creator, uses/max, expires.
+</listing>
+
+<creating>
+- create_invite requires a channel ID — ask which channel if not specified.
+- Default: 24h expiry, unlimited uses, non-temporary.
+- Set max_uses for one-time invites. Set max_age to 0 for permanent invites.
+- temporary invites auto-kick members who don't get a role before disconnecting.
+- Always return the full URL (discord.gg/CODE) so it can be shared immediately.
+</creating>
+
+<deleting>
+- delete_invite revokes an invite by code. Use list_invites first to find available codes.
+- Always confirm before revoking — this is irreversible.
+</deleting>

--- a/src/lib/ai/skills/linear/SKILL.md
+++ b/src/lib/ai/skills/linear/SKILL.md
@@ -25,6 +25,7 @@ When delegated to, you have access to these skill bundles (loaded via `load_skil
 - reminders: Set reminders on issues, documents, projects, or initiatives
 - customer-requests: Create, update, list, and analyze customer requests
 - users: List, inspect, and manage workspace users — profiles, teams, workload, invites
+- teams: List team members and manage team membership
 
 ## Terminology
 

--- a/src/lib/ai/skills/linear/skills/teams/SKILL.md
+++ b/src/lib/ai/skills/linear/skills/teams/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: teams
+description: List team members and manage team membership.
+criteria: Use when the user wants to see who is on a team, add a user to a team, or remove a user from a team.
+tools: [list_team_members, add_user_to_team, remove_user_from_team]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+- list_team_members returns all members of a team with name, email, role flags, and active status.
+- Resolve team name to ID first via suggest_property_values if only a name is given.
+</listing>
+
+<managing>
+Admin tools — only use when explicitly asked.
+
+- add_user_to_team adds a workspace member to a team. Resolve both user and team IDs first.
+- remove_user_from_team removes a user from a team. Always confirm identity and team before removing.
+- Never act on ambiguous input — resolve the user and team first.
+  </managing>

--- a/src/lib/ai/tools/discord/index.ts
+++ b/src/lib/ai/tools/discord/index.ts
@@ -7,3 +7,4 @@ export * from "./webhooks.ts";
 export * from "./events.ts";
 export * from "./threads.ts";
 export * from "./emojis.ts";
+export * from "./invites.ts";

--- a/src/lib/ai/tools/discord/invites.ts
+++ b/src/lib/ai/tools/discord/invites.ts
@@ -1,0 +1,97 @@
+import { tool } from "ai";
+import { Routes } from "discord-api-types/v10";
+import { z } from "zod";
+
+import { env } from "../../../../env.ts";
+import { admin } from "../../skills/index.ts";
+import { discord } from "./client.ts";
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+export const list_invites = admin(
+  tool({
+    description:
+      "List all active server invites with their codes, channels, creators, usage counts, and expiry dates.",
+    inputSchema: z.object({}),
+    execute: async () => {
+      const invites = (await discord.get(Routes.guildInvites(env.DISCORD_GUILD_ID))) as any[];
+      return JSON.stringify(
+        invites.map((inv) => ({
+          code: inv.code,
+          channel: inv.channel ? { id: inv.channel.id, name: inv.channel.name } : null,
+          inviter: inv.inviter ? { id: inv.inviter.id, username: inv.inviter.username } : null,
+          uses: inv.uses,
+          maxUses: inv.max_uses,
+          maxAge: inv.max_age,
+          temporary: inv.temporary,
+          expiresAt: inv.expires_at ?? null,
+        })),
+      );
+    },
+  }),
+);
+
+export const create_invite = admin(
+  tool({
+    description:
+      "Create a new server invite for a specific channel. Returns the invite code and URL.",
+    inputSchema: z.object({
+      channel_id: z.string().describe("Channel ID to create the invite for"),
+      max_age: z
+        .number()
+        .min(0)
+        .optional()
+        .describe("Duration in seconds before expiry, 0 for never (default 86400 = 24h)"),
+      max_uses: z
+        .number()
+        .min(0)
+        .optional()
+        .describe("Max number of uses, 0 for unlimited (default 0)"),
+      temporary: z
+        .boolean()
+        .optional()
+        .describe("Whether this invite grants temporary membership (default false)"),
+      unique: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, create a fresh invite instead of reusing a similar one (default false)",
+        ),
+      reason: z.string().optional().describe("Audit log reason"),
+    }),
+    execute: async ({ channel_id, max_age, max_uses, temporary, unique, reason }) => {
+      const invite = (await discord.post(Routes.channelInvites(channel_id), {
+        body: { max_age, max_uses, temporary, unique },
+        reason: reason ?? undefined,
+      })) as any;
+      return JSON.stringify({
+        code: invite.code,
+        url: `https://discord.gg/${invite.code}`,
+        channelId: invite.channel?.id ?? channel_id,
+        maxAge: invite.max_age,
+        maxUses: invite.max_uses,
+        temporary: invite.temporary,
+        expiresAt: invite.expires_at ?? null,
+      });
+    },
+  }),
+);
+
+export const delete_invite = admin(
+  tool({
+    description:
+      "Revoke an active invite by its code. Use list_invites first to find available codes.",
+    inputSchema: z.object({
+      code: z.string().describe("Invite code to delete (e.g. 'abc123' from discord.gg/abc123)"),
+      reason: z.string().optional().describe("Audit log reason"),
+    }),
+    execute: async ({ code, reason }) => {
+      await discord.delete(Routes.invite(code), {
+        reason: reason ?? undefined,
+      });
+      return JSON.stringify({ success: true, deleted: code });
+    },
+  }),
+);

--- a/src/lib/ai/tools/linear/index.ts
+++ b/src/lib/ai/tools/linear/index.ts
@@ -11,3 +11,4 @@ export * from "./initiative-updates.ts";
 export * from "./reminders.ts";
 export * from "./customer-requests.ts";
 export * from "./users.ts";
+export * from "./teams.ts";

--- a/src/lib/ai/tools/linear/teams.ts
+++ b/src/lib/ai/tools/linear/teams.ts
@@ -1,0 +1,76 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { admin } from "../../skills/index.ts";
+import { linear } from "./client.ts";
+
+export const list_team_members = tool({
+  description:
+    "List all members of a Linear team. Returns name, display name, email, admin flag, and active status.",
+  inputSchema: z.object({
+    team_id: z.string().describe("Team UUID"),
+  }),
+  execute: async ({ team_id }) => {
+    const team = await linear.team(team_id);
+    const members = await team.members();
+    return JSON.stringify(
+      members.nodes.map((u) => ({
+        id: u.id,
+        name: u.name,
+        displayName: u.displayName,
+        email: u.email,
+        admin: u.admin,
+        active: u.active,
+      })),
+    );
+  },
+});
+
+export const add_user_to_team = admin(
+  tool({
+    description:
+      "Add a user to a Linear team. Resolve user and team IDs first via list_users and suggest_property_values.",
+    inputSchema: z.object({
+      team_id: z.string().describe("Team UUID"),
+      user_id: z.string().describe("User UUID to add"),
+    }),
+    execute: async ({ team_id, user_id }) => {
+      const payload = await linear.createTeamMembership({
+        teamId: team_id,
+        userId: user_id,
+      });
+      const membership = await payload.teamMembership;
+      return JSON.stringify({
+        success: payload.success,
+        membershipId: membership?.id ?? null,
+        teamId: team_id,
+        userId: user_id,
+      });
+    },
+  }),
+);
+
+export const remove_user_from_team = admin(
+  tool({
+    description:
+      "Remove a user from a Linear team. Resolve user and team IDs first via list_users and suggest_property_values.",
+    inputSchema: z.object({
+      team_id: z.string().describe("Team UUID"),
+      user_id: z.string().describe("User UUID to remove"),
+    }),
+    execute: async ({ team_id, user_id }) => {
+      const user = await linear.user(user_id);
+      const memberships = await user.teamMemberships();
+
+      for (const m of memberships.nodes) {
+        const team = await m.team;
+        if (team && team.id === team_id) {
+          const payload = await linear.deleteTeamMembership(m.id);
+          return JSON.stringify({ success: payload.success });
+        }
+      }
+
+      return JSON.stringify({ error: "User is not a member of this team" });
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- Add 3 Discord invite management tools (`list_invites`, `create_invite`, `delete_invite`) — all admin-gated
- Add 3 Linear team membership tools (`list_team_members`, `add_user_to_team`, `remove_user_from_team`)
- Register new skills with SKILL.md files and update parent skill docs
- Remove "manage invites" from Discord's "Cannot" list

## Test plan

- [ ] Verify `bun typecheck`, `bun lint`, `bun run test`, `bun knip` all pass
- [ ] Test Discord invite tools against a staging server
- [ ] Test Linear team tools against a sandbox workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)