### PR TITLE
fix: ship storage, add video support and delete handler

### DIFF
--- a/src/bot/handlers/events/index.ts
+++ b/src/bot/handlers/events/index.ts
@@ -4,5 +4,6 @@ export * from "./voice-transcription";
 export * from "./dashboard";
 export * from "./auto-thread";
 export * from "./ship-scraper";
+export * from "./ship-scraper/delete";
 export * from "./hack-night-upload";
 export * from "./hack-night-reaction";

--- a/src/bot/handlers/events/ship-scraper/delete.ts
+++ b/src/bot/handlers/events/ship-scraper/delete.ts
@@ -1,0 +1,24 @@
+import { log } from "evlog";
+
+import { defineEvent } from "@/bot/events/define";
+import { ShipDatabase } from "@/bot/integrations/ships";
+import { env } from "@/env";
+import { DISCORD_IDS } from "@/lib/protocol/constants";
+
+export const shipMessageDelete = defineEvent({
+  type: "messageDelete",
+  async handle(packet) {
+    if (packet.data.channelId !== DISCORD_IDS.channels.SHIP) return;
+
+    const shipDb = new ShipDatabase(
+      env.SHIP_DATABASE_TURSO_DATABASE_URL,
+      env.SHIP_DATABASE_TURSO_AUTH_TOKEN,
+    );
+
+    const deletedId = await shipDb.deleteByMessageId(packet.data.id);
+
+    if (deletedId) {
+      log.info("ship-scraper", `Deleted ship ${deletedId} (message ${packet.data.id})`);
+    }
+  },
+});

--- a/src/bot/handlers/events/ship-scraper/delete.ts
+++ b/src/bot/handlers/events/ship-scraper/delete.ts
@@ -1,6 +1,7 @@
 import { log } from "evlog";
 
 import { defineEvent } from "@/bot/events/define";
+import { R2Storage } from "@/bot/integrations/r2";
 import { ShipDatabase } from "@/bot/integrations/ships";
 import { env } from "@/env";
 import { DISCORD_IDS } from "@/lib/protocol/constants";
@@ -15,10 +16,32 @@ export const shipMessageDelete = defineEvent({
       env.SHIP_DATABASE_TURSO_AUTH_TOKEN,
     );
 
-    const deletedId = await shipDb.deleteByMessageId(packet.data.id);
+    try {
+      const deleted = await shipDb.deleteByMessageId(packet.data.id);
+      if (!deleted) return;
 
-    if (deletedId) {
-      log.info("ship-scraper", `Deleted ship ${deletedId} (message ${packet.data.id})`);
+      log.info("ship-scraper", `Deleted ship ${deleted.id} (message ${packet.data.id})`);
+
+      if (deleted.attachmentKeys.length > 0) {
+        const r2 = new R2Storage(
+          env.R2_ACCOUNT_ID,
+          env.R2_ACCESS_KEY_ID,
+          env.R2_SECRET_ACCESS_KEY,
+          env.SHIP_R2_BUCKET_NAME,
+        );
+        for (const key of deleted.attachmentKeys) {
+          await r2.deleteKey(key);
+        }
+        log.info(
+          "ship-scraper",
+          `Cleaned up ${deleted.attachmentKeys.length} R2 objects for ship ${deleted.id}`,
+        );
+      }
+    } catch (err) {
+      log.warn(
+        "ship-scraper",
+        `Failed to delete ship for message ${packet.data.id}: ${String(err)}`,
+      );
     }
   },
 });

--- a/src/bot/handlers/events/ship-scraper/index.ts
+++ b/src/bot/handlers/events/ship-scraper/index.ts
@@ -30,25 +30,41 @@ function collectFromSnapshots(data: MessageData): {
   return { content, attachments };
 }
 
-async function uploadImages(
+function isMedia(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  return contentType.startsWith("image/") || contentType.startsWith("video/");
+}
+
+async function uploadMedia(
   r2: R2Storage,
   messageId: string,
-  imageList: Attachment[],
-): Promise<Array<{ key: string; type: string; filename: string }>> {
-  const uploaded: Array<{ key: string; type: string; filename: string }> = [];
+  mediaList: Attachment[],
+): Promise<
+  Array<{ key: string; type: string; filename: string; width?: number; height?: number }>
+> {
+  const uploaded: Array<{
+    key: string;
+    type: string;
+    filename: string;
+    width?: number;
+    height?: number;
+  }> = [];
 
-  for (const item of imageList) {
-    if (!item.contentType?.startsWith("image/")) continue;
+  for (const item of mediaList) {
+    if (!isMedia(item.contentType)) continue;
 
     try {
       const buffer = await r2.downloadBuffer(item.url);
-      const fname = `${messageId}-${item.filename}`;
+      const defaultName = item.contentType?.startsWith("video/") ? "video.mp4" : "image.jpg";
+      const fname = `${messageId}-${item.filename ?? defaultName}`;
       const key = `images/ships/${fname}`;
-      await r2.uploadBuffer(key, buffer, item.contentType ?? "image/jpeg");
+      await r2.uploadBuffer(key, buffer, item.contentType ?? "application/octet-stream");
       uploaded.push({
         key,
-        type: item.contentType ?? "image/jpeg",
-        filename: item.filename,
+        type: item.contentType ?? "application/octet-stream",
+        filename: item.filename ?? defaultName,
+        width: item.width ?? undefined,
+        height: item.height ?? undefined,
       });
     } catch (err) {
       log.warn("ship-scraper", `Failed to upload ${item.filename}: ${String(err)}`);
@@ -81,7 +97,7 @@ export const shipScraper = defineEvent({
       env.SHIP_DATABASE_TURSO_AUTH_TOKEN,
     );
 
-    const uploadedAttachments = await uploadImages(r2, messageId, attachments);
+    const uploadedAttachments = await uploadMedia(r2, messageId, attachments);
 
     const firstLine = content.split("\n")[0]?.trim() ?? "";
     const title = firstLine.length > 100 ? firstLine.slice(0, 100) + "..." : firstLine || null;

--- a/src/bot/integrations/ships/client.ts
+++ b/src/bot/integrations/ships/client.ts
@@ -10,10 +10,12 @@ export class ShipDatabase {
   }
 
   async insertShip(ship: ShipRecord): Promise<string> {
-    const result = await this.db.execute({
-      sql: `INSERT INTO ship (user_id, username, avatar_url, message_id, title, content, attachments, shipped_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    const id = crypto.randomUUID();
+    await this.db.execute({
+      sql: `INSERT INTO ship (id, user_id, username, avatar_url, message_id, title, content, attachments, shipped_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
       args: [
+        id,
         ship.userId,
         ship.username,
         ship.avatarUrl,
@@ -23,13 +25,15 @@ export class ShipDatabase {
         JSON.stringify(ship.attachments),
       ],
     });
-    return String(result.lastInsertRowid);
+    return id;
   }
 
-  async deleteByMessageId(messageId: string): Promise<void> {
-    await this.db.execute({
-      sql: "DELETE FROM ship WHERE message_id = ?",
+  async deleteByMessageId(messageId: string): Promise<string | null> {
+    const result = await this.db.execute({
+      sql: "DELETE FROM ship WHERE message_id = ? RETURNING id",
       args: [messageId],
     });
+    const row = result.rows[0];
+    return row ? (row.id as string) : null;
   }
 }

--- a/src/bot/integrations/ships/client.ts
+++ b/src/bot/integrations/ships/client.ts
@@ -28,12 +28,24 @@ export class ShipDatabase {
     return id;
   }
 
-  async deleteByMessageId(messageId: string): Promise<string | null> {
+  async deleteByMessageId(
+    messageId: string,
+  ): Promise<{ id: string; attachmentKeys: string[] } | null> {
     const result = await this.db.execute({
-      sql: "DELETE FROM ship WHERE message_id = ? RETURNING id",
+      sql: "DELETE FROM ship WHERE message_id = ? RETURNING id, attachments",
       args: [messageId],
     });
     const row = result.rows[0];
-    return row ? (row.id as string) : null;
+    if (!row) return null;
+
+    let attachmentKeys: string[] = [];
+    try {
+      const parsed = JSON.parse(row.attachments as string) as Array<{ key: string }>;
+      attachmentKeys = parsed.map((a) => a.key);
+    } catch {
+      // attachments column may be empty or malformed
+    }
+
+    return { id: row.id as string, attachmentKeys };
   }
 }

--- a/src/bot/integrations/ships/types.ts
+++ b/src/bot/integrations/ships/types.ts
@@ -2,6 +2,8 @@ export interface ShipAttachment {
   key: string;
   type: string;
   filename: string;
+  width?: number;
+  height?: number;
 }
 
 export interface ShipRecord {

--- a/src/lib/protocol/packets.ts
+++ b/src/lib/protocol/packets.ts
@@ -9,6 +9,8 @@ const MessageDataAttachment = z.object({
   filename: z.string(),
   contentType: z.string().optional(),
   size: z.number(),
+  width: z.number().optional(),
+  height: z.number().optional(),
 });
 
 const MessageDataAuthor = z.object({

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -125,6 +125,8 @@ function bindMessageHandlers(client: Client, publish: Publish): void {
           filename: a.name,
           contentType: a.contentType ?? undefined,
           size: a.size,
+          width: a.width ?? undefined,
+          height: a.height ?? undefined,
         })),
         author: {
           id: message.author.id,
@@ -157,6 +159,8 @@ function bindMessageHandlers(client: Client, publish: Publish): void {
             filename: a.name,
             contentType: a.contentType ?? undefined,
             size: a.size,
+            width: a.width ?? undefined,
+            height: a.height ?? undefined,
           })),
         })),
       },


### PR DESCRIPTION
## Summary

- **Fix ship INSERT failing** — the `id` column was missing from the INSERT, causing `NOT NULL constraint failed: ship.id` on every ship save. Now generates a UUID via `crypto.randomUUID()`.
- **Add video upload support** — ship scraper now handles `video/*` MIME types alongside `image/*`, and stores `width`/`height` attachment metadata (migrating features from #45).
- **Add ship message delete handler** — automatically deletes a ship from the DB when its Discord message is deleted, and `deleteByMessageId` now returns the deleted ship ID (migrating #48).
- **Pass attachment dimensions end-to-end** — gateway, packet schema, and scraper all carry `width`/`height` from Discord through to the database.

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes (0 warnings)
- [x] `bun format` clean
- [x] `bun run test` — 226 tests pass
- [x] `bun test:coverage` — 98.75% statements
- [x] `bun knip` — no unused exports
- [ ] Deploy and verify a ship message is stored successfully (no more NOT NULL error in Vercel logs)
- [ ] Verify video attachments are uploaded to R2
- [ ] Verify deleting a ship message in Discord removes it from the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)