### PR TITLE
feat: add Sentry custom metrics for application observability

### DIFF
--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -319,6 +319,31 @@ describe("streamTurn: tool event edge cases", () => {
     vi.restoreAllMocks();
   });
 
+  it("handles undefined totalTokens in usage", async () => {
+    const orchestrator = await import("./orchestrator");
+    vi.spyOn(orchestrator, "createOrchestrator").mockReturnValue(
+      mockOrchestrator(["Ok."], {
+        totalUsage: Promise.resolve({
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: undefined,
+        }),
+      }) as any,
+    );
+
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", "hello", ctx.toJSON());
+
+    expect(result.text).toBe("Ok.");
+    const edits = discord.callsTo("channels.editMessage");
+    const lastEdit = edits[edits.length - 1];
+    const body = lastEdit[2] as { content: string };
+    expect(body.content).toContain("0 tokens");
+
+    vi.restoreAllMocks();
+  });
+
   it("falls back to time-only footer when metadata promises reject", async () => {
     const orchestrator = await import("./orchestrator");
     vi.spyOn(orchestrator, "createOrchestrator").mockReturnValue(

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -3,6 +3,8 @@ import type { API } from "@discordjs/core/http-only";
 import { isTextUIPart, type UIMessage } from "ai";
 import { log } from "evlog";
 
+import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
+
 import type { SerializedAgentContext, Attachment, SubagentMetrics } from "./types.ts";
 
 import { AgentContext } from "./context.ts";
@@ -86,14 +88,23 @@ export async function streamTurn(
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
     const orchestratorToolCalls = steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
+    const totalTokens = (totalUsage.totalTokens ?? 0) + subagentMetrics.totalTokens;
+    const toolCallCount = orchestratorToolCalls + subagentMetrics.toolCallCount;
     await renderer.finalize({
       elapsedMs,
-      totalTokens: (totalUsage.totalTokens ?? 0) + subagentMetrics.totalTokens,
-      toolCallCount: orchestratorToolCalls + subagentMetrics.toolCallCount,
+      totalTokens,
+      toolCallCount,
       stepCount: steps.length,
     });
+
+    countMetric("ai.turn.completed");
+    recordDuration("ai.turn.duration", elapsedMs);
+    recordDistribution("ai.turn.tokens", totalTokens);
+    recordDistribution("ai.turn.tool_calls", toolCallCount);
+    recordDistribution("ai.turn.steps", steps.length);
   } catch (err) {
     log.warn("streaming", `Failed to collect metadata: ${String(err)}`);
+    countMetric("ai.turn.metadata_error");
     await renderer.finalize({
       elapsedMs,
       totalTokens: undefined,

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -97,8 +97,6 @@ export async function streamTurn(
       stepCount: steps.length,
     });
 
-    countMetric("ai.turn.completed");
-    recordDuration("ai.turn.duration", elapsedMs);
     recordDistribution("ai.turn.tokens", totalTokens);
     recordDistribution("ai.turn.tool_calls", toolCallCount);
     recordDistribution("ai.turn.steps", steps.length);
@@ -112,6 +110,9 @@ export async function streamTurn(
       stepCount: 0,
     });
   }
+
+  countMetric("ai.turn.completed");
+  recordDuration("ai.turn.duration", elapsedMs);
 
   log.info("streaming", `Turn complete, ${renderer.content.length} chars, ${elapsedMs}ms`);
 

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -85,14 +85,18 @@ export function createDelegationTool(spec: SubagentSpec, role: UserRole, metrics
       }
 
       const [usage, steps] = await Promise.all([result.totalUsage, result.steps]);
-      const subagentTokens = usage.totalTokens ?? 0;
-      const subagentToolCalls = steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
-      metrics.totalTokens += subagentTokens;
-      metrics.toolCallCount += subagentToolCalls;
+      const tokensBefore = metrics.totalTokens;
+      const toolCallsBefore = metrics.toolCallCount;
+      metrics.totalTokens += usage.totalTokens ?? 0;
+      metrics.toolCallCount += steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
 
       countMetric("ai.subagent.completed", { domain: spec.name });
-      recordDistribution("ai.subagent.tokens", subagentTokens, { domain: spec.name });
-      recordDistribution("ai.subagent.tool_calls", subagentToolCalls, { domain: spec.name });
+      recordDistribution("ai.subagent.tokens", metrics.totalTokens - tokensBefore, {
+        domain: spec.name,
+      });
+      recordDistribution("ai.subagent.tool_calls", metrics.toolCallCount - toolCallsBefore, {
+        domain: spec.name,
+      });
     },
     toModelOutput: ({ output }) => {
       const message = output as UIMessage | undefined;

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -9,6 +9,8 @@ import {
 } from "ai";
 import { z } from "zod";
 
+import { countMetric, recordDistribution } from "@/lib/metrics";
+
 import type { SubagentSpec, SubagentMetrics } from "./types.ts";
 
 import { SUBAGENT_MODEL, SUBAGENT_PREAMBLE, UserRole } from "./constants.ts";
@@ -83,8 +85,14 @@ export function createDelegationTool(spec: SubagentSpec, role: UserRole, metrics
       }
 
       const [usage, steps] = await Promise.all([result.totalUsage, result.steps]);
-      metrics.totalTokens += usage.totalTokens ?? 0;
-      metrics.toolCallCount += steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
+      const subagentTokens = usage.totalTokens ?? 0;
+      const subagentToolCalls = steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
+      metrics.totalTokens += subagentTokens;
+      metrics.toolCallCount += subagentToolCalls;
+
+      countMetric("ai.subagent.completed", { domain: spec.name });
+      recordDistribution("ai.subagent.tokens", subagentTokens, { domain: spec.name });
+      recordDistribution("ai.subagent.tool_calls", subagentToolCalls, { domain: spec.name });
     },
     toModelOutput: ({ output }) => {
       const message = output as UIMessage | undefined;

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  metrics: { count: vi.fn(), distribution: vi.fn() },
+}));
+
+import * as Sentry from "@sentry/nextjs";
+
+import { countMetric, recordDuration, recordDistribution } from "./metrics";
+
+describe("metrics", () => {
+  it("countMetric calls Sentry.metrics.count", () => {
+    countMetric("test.event", { key: "value" });
+    expect(Sentry.metrics.count).toHaveBeenCalledWith("test.event", 1, {
+      attributes: { key: "value" },
+    });
+  });
+
+  it("countMetric works without attributes", () => {
+    countMetric("test.bare");
+    expect(Sentry.metrics.count).toHaveBeenCalledWith("test.bare", 1, {
+      attributes: undefined,
+    });
+  });
+
+  it("recordDuration calls Sentry.metrics.distribution with millisecond unit", () => {
+    recordDuration("test.duration", 123, { op: "run" });
+    expect(Sentry.metrics.distribution).toHaveBeenCalledWith("test.duration", 123, {
+      unit: "millisecond",
+      attributes: { op: "run" },
+    });
+  });
+
+  it("recordDistribution calls Sentry.metrics.distribution without unit", () => {
+    recordDistribution("test.dist", 42, { domain: "ai" });
+    expect(Sentry.metrics.distribution).toHaveBeenCalledWith("test.dist", 42, {
+      attributes: { domain: "ai" },
+    });
+  });
+});

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,15 @@
+import * as Sentry from "@sentry/nextjs";
+
+type Attrs = Record<string, string | number>;
+
+export function countMetric(name: string, attrs?: Attrs) {
+  Sentry.metrics.count(name, 1, { attributes: attrs });
+}
+
+export function recordDuration(name: string, ms: number, attrs?: Attrs) {
+  Sentry.metrics.distribution(name, ms, { unit: "millisecond", attributes: attrs });
+}
+
+export function recordDistribution(name: string, value: number, attrs?: Attrs) {
+  Sentry.metrics.distribution(name, value, { attributes: attrs });
+}

--- a/src/server/process-event.ts
+++ b/src/server/process-event.ts
@@ -49,22 +49,27 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
 
   const startTime = Date.now();
   const lockChannel = getMessageChannelId(packet);
-  if (lockChannel) {
-    const token = await store.acquireLock(lockChannel);
-    if (!token) {
-      log.warn("events", `Lock held for ${lockChannel}, dropping ${packet.type}`);
-      countMetric("event.lock_contention", { type: packet.type });
-      return;
-    }
-    try {
+  try {
+    if (lockChannel) {
+      const token = await store.acquireLock(lockChannel);
+      if (!token) {
+        log.warn("events", `Lock held for ${lockChannel}, dropping ${packet.type}`);
+        countMetric("event.lock_contention", { type: packet.type });
+        return;
+      }
+      try {
+        await router.dispatch(packet, ctx);
+      } finally {
+        await store.releaseLock(lockChannel, token);
+      }
+    } else {
       await router.dispatch(packet, ctx);
-    } finally {
-      await store.releaseLock(lockChannel, token);
     }
-  } else {
-    await router.dispatch(packet, ctx);
+    countMetric("event.processed", { type: packet.type });
+  } catch (err) {
+    countMetric("event.error", { type: packet.type });
+    throw err;
+  } finally {
+    recordDuration("event.process_duration", Date.now() - startTime, { type: packet.type });
   }
-
-  countMetric("event.processed", { type: packet.type });
-  recordDuration("event.process_duration", Date.now() - startTime, { type: packet.type });
 }

--- a/src/server/process-event.ts
+++ b/src/server/process-event.ts
@@ -6,6 +6,7 @@ import type { Packet } from "@/lib/protocol/types";
 
 import { ConversationStore } from "@/bot/store";
 import { env } from "@/env";
+import { countMetric, recordDuration } from "@/lib/metrics";
 
 import { router } from "./routes/handlers";
 
@@ -36,6 +37,7 @@ function getMessageChannelId(packet: Packet): string | null {
 export async function processEvent(packet: Packet, store: ConversationStore): Promise<void> {
   if (!(await store.dedup(getDedupKey(packet)))) {
     log.debug("events", `Dedup hit, skipping ${packet.type}`);
+    countMetric("event.dedup_hit", { type: packet.type });
     return;
   }
 
@@ -45,11 +47,13 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
     botUserId: env.DISCORD_CLIENT_ID,
   };
 
+  const startTime = Date.now();
   const lockChannel = getMessageChannelId(packet);
   if (lockChannel) {
     const token = await store.acquireLock(lockChannel);
     if (!token) {
       log.warn("events", `Lock held for ${lockChannel}, dropping ${packet.type}`);
+      countMetric("event.lock_contention", { type: packet.type });
       return;
     }
     try {
@@ -60,4 +64,7 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
   } else {
     await router.dispatch(packet, ctx);
   }
+
+  countMetric("event.processed", { type: packet.type });
+  recordDuration("event.process_duration", Date.now() - startTime, { type: packet.type });
 }

--- a/src/server/routes/crons.ts
+++ b/src/server/routes/crons.ts
@@ -30,11 +30,16 @@ route.get("/crons/:name", async (c) => {
 
   const startTime = Date.now();
   const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
-  await cron.handle(discord);
-
-  countMetric("cron.completed", { name });
-  recordDuration("cron.duration", Date.now() - startTime, { name });
-  return c.json({ ok: true, cron: name });
+  try {
+    await cron.handle(discord);
+    countMetric("cron.completed", { name });
+    return c.json({ ok: true, cron: name });
+  } catch (err) {
+    countMetric("cron.error", { name });
+    throw err;
+  } finally {
+    recordDuration("cron.duration", Date.now() - startTime, { name });
+  }
 });
 
 export default route;

--- a/src/server/routes/crons.ts
+++ b/src/server/routes/crons.ts
@@ -7,6 +7,7 @@ import type { CronHandler } from "@/bot/crons/types";
 
 import * as crons from "@/bot/handlers/crons";
 import { env } from "@/env";
+import { countMetric, recordDuration } from "@/lib/metrics";
 
 const cronMap = new Map((Object.values(crons) as CronHandler[]).map((c) => [c.name, c]));
 
@@ -27,8 +28,12 @@ route.get("/crons/:name", async (c) => {
 
   log.info("crons", `Running ${name}`);
 
+  const startTime = Date.now();
   const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
   await cron.handle(discord);
+
+  countMetric("cron.completed", { name });
+  recordDuration("cron.duration", Date.now() - startTime, { name });
   return c.json({ ok: true, cron: name });
 });
 

--- a/src/server/routes/interactions.ts
+++ b/src/server/routes/interactions.ts
@@ -12,6 +12,7 @@ import { parseOptions } from "@/bot/commands/registry";
 import * as components from "@/bot/components";
 import * as commands from "@/bot/handlers/commands";
 import { env } from "@/env";
+import { countMetric } from "@/lib/metrics";
 import { InteractionType, InteractionResponseType } from "@/lib/protocol/constants";
 import { verifyInteraction } from "@/lib/protocol/verify";
 
@@ -46,6 +47,7 @@ route.post("/interactions", async (c) => {
     }
 
     log.info("interactions", `Executing /${name}`);
+    countMetric("interaction.command", { command: name });
 
     const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
     waitUntil(
@@ -57,6 +59,7 @@ route.post("/interactions", async (c) => {
         })
         .catch((err) => {
           log.error("interactions", `/${name} failed: ${err}`);
+          countMetric("interaction.command_error", { command: name });
           discord.interactions
             .editReply(interaction.application_id, interaction.token, {
               content: `Error executing /${name}.`,
@@ -79,6 +82,7 @@ route.post("/interactions", async (c) => {
 
     if (handler) {
       log.info("interactions", `Handling component ${prefix}`);
+      countMetric("interaction.component", { prefix });
       const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
       waitUntil(
         handler.handle({ interaction, discord, customId }).catch((err) => {

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -7,6 +7,7 @@ import type { SerializedAgentContext } from "@/lib/ai/types";
 
 import { ConversationStore } from "@/bot/store";
 import { streamTurn } from "@/lib/ai/streaming";
+import { countMetric } from "@/lib/metrics";
 
 import type { ChatPayload } from "./types";
 
@@ -42,6 +43,7 @@ export async function chatWorkflow(payload: ChatPayload) {
   const { workflowRunId } = getWorkflowMetadata();
 
   log.info("workflow", `Chat started: ${workflowRunId}`);
+  countMetric("workflow.chat.started");
 
   await runTurn(channelId, content, context);
 
@@ -50,11 +52,13 @@ export async function chatWorkflow(payload: ChatPayload) {
   for await (const event of hook) {
     if (event.type === "done") {
       log.info("workflow", `Chat ended by user: ${workflowRunId}`);
+      countMetric("workflow.chat.ended");
       break;
     }
     if (!event.content) continue;
 
     log.info("workflow", `Follow-up from ${event.authorUsername}: ${workflowRunId}`);
+    countMetric("workflow.chat.followup");
     await runTurn(channelId, event.content, context);
   }
 


### PR DESCRIPTION
## Summary
- Adds a thin metrics utility (`src/lib/metrics.ts`) wrapping `Sentry.metrics.count` and `Sentry.metrics.distribution` for counters, durations, and distributions.
- Instruments AI turns (token usage, duration, tool calls, steps), subagent delegation, Discord event processing (dedup hits, lock contention), slash commands, component interactions, cron jobs, and chat workflow lifecycle.
- All metrics use low-cardinality attributes (packet type, command name, domain, cron name) for safe dashboard filtering.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` — 0 warnings, 0 errors
- [x] `bun run test` — 226 tests pass
- [x] `bun test:coverage` — 98.79% statements
- [x] `bun knip` — clean
- [ ] Deploy and verify metrics appear in Sentry dashboard under Metrics