### PR TITLE
fix: use X-Figma-Token header for Figma PAT auth

### DIFF
--- a/src/lib/ai/tools/figma/client.ts
+++ b/src/lib/ai/tools/figma/client.ts
@@ -25,7 +25,7 @@ class FigmaClient {
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${env.FIGMA_ACCESS_TOKEN}`,
+      "X-Figma-Token": env.FIGMA_ACCESS_TOKEN,
     };
     if (body !== undefined) {
       headers["Content-Type"] = "application/json";


### PR DESCRIPTION
## Summary

- Figma personal access tokens (`figd_...`) require the `X-Figma-Token` header, not `Authorization: Bearer` which is only for OAuth tokens
- This one-line fix in `client.ts` resolves 403 errors from all Figma API calls

## Test plan

- [x] All checks pass (format, lint, typecheck, test, coverage, knip)
- [ ] Verify Figma API calls return 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)