### PR TITLE
fix: include thread message context on mention

### DIFF
--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -17,7 +17,6 @@ async function fetchRecentMessages(
   discord: API,
   channelId: string,
   beforeMessageId: string,
-  botUserId: string,
 ): Promise<RecentMessage[] | undefined> {
   try {
     const raw = await discord.channels.getMessages(channelId, {
@@ -25,9 +24,9 @@ async function fetchRecentMessages(
       limit: MAX_RECENT_MESSAGES,
     });
 
-    // Discord returns newest-first; filter and keep chronological order
+    // Discord returns newest-first; keep chronological order
     const messages: RecentMessage[] = raw
-      .filter((m) => m.author.id !== botUserId && m.content?.trim())
+      .filter((m) => m.content?.trim())
       .reverse()
       .map((m) => ({
         author: (m.author as any).global_name ?? m.author.username,
@@ -107,12 +106,7 @@ export async function handleMention(
 
   const agentContext = AgentContext.fromPacket(packet);
 
-  const recentMessages = await fetchRecentMessages(
-    ctx.discord,
-    sourceChannelId,
-    data.id,
-    ctx.botUserId,
-  );
+  const recentMessages = await fetchRecentMessages(ctx.discord, sourceChannelId, data.id);
 
   log.info("mention", `Starting workflow for ${data.author.username} in ${data.channel.name}`);
 

--- a/src/lib/ai/context.test.ts
+++ b/src/lib/ai/context.test.ts
@@ -161,4 +161,26 @@ describe("AgentContext.buildInstructions", () => {
     expect(result).toContain("thread:");
     expect(result).toContain("parent_channel");
   });
+
+  it("uses recent_thread_messages tag when in a thread", () => {
+    const ctx = AgentContext.fromJSON({
+      ...AgentContext.fromPacket(
+        messagePacket("hello", { thread: { parentId: "p1", parentName: "parent" } }),
+      ).toJSON(),
+      recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }],
+    });
+    const result = ctx.buildInstructions("Base.");
+    expect(result).toContain("<recent_thread_messages>");
+    expect(result).not.toContain("<recent_channel_messages>");
+  });
+
+  it("uses recent_channel_messages tag when not in a thread", () => {
+    const ctx = AgentContext.fromJSON({
+      ...AgentContext.fromPacket(messagePacket("hello")).toJSON(),
+      recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }],
+    });
+    const result = ctx.buildInstructions("Base.");
+    expect(result).toContain("<recent_channel_messages>");
+    expect(result).not.toContain("<recent_thread_messages>");
+  });
 });

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -113,10 +113,11 @@ export class AgentContext {
       ? `\nthread:\n  name: ${JSON.stringify(this.thread.name)}\n  id: "${this.thread.id}"\n  parent_channel: "#${this.thread.parentChannel.name}"`
       : "";
 
+    const msgTag = this.thread ? "recent_thread_messages" : "recent_channel_messages";
     const recentMsgs = this.recentMessages?.length
-      ? `\n\n<recent_channel_messages>\n${this.recentMessages
+      ? `\n\n<${msgTag}>\n${this.recentMessages
           .map((m) => `[${m.timestamp}] ${m.author}: ${m.content}`)
-          .join("\n")}\n</recent_channel_messages>`
+          .join("\n")}\n</${msgTag}>`
       : "";
 
     return `<execution_context>


### PR DESCRIPTION
## Summary
- When the bot is mentioned in a thread, `fetchRecentMessages` now includes bot messages so the agent sees the full conversation history (previously bot messages were filtered out, causing the agent to lose context)
- Uses a distinct `<recent_thread_messages>` tag in the context block to differentiate thread context from channel context
- Adds tests for the thread vs channel message tag behavior

## Test plan
- [x] `bun format` — clean
- [x] `bun lint` — 0 warnings, 0 errors
- [x] `bun typecheck` — clean
- [x] `bun run test` — 233 passed
- [x] `bun test:coverage` — 98.99% statements
- [x] `bun knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)