### PR TITLE
chore: use default Node.js runtime for Vercel Functions

### DIFF
--- a/vercel.ts
+++ b/vercel.ts
@@ -2,7 +2,6 @@ import { type VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
   framework: "nextjs",
-  bunVersion: "1.x",
   crons: [
     {
       path: "/api/discord/gateway",


### PR DESCRIPTION
## Summary
- Removed `bunVersion: "1.x"` from `vercel.ts` so Vercel Functions fall back to the default Node.js runtime.

## Test plan
- [x] `bun format`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test`
- [x] `bun test:coverage`
- [x] `bun knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)