### PR TITLE
fix: flush Sentry metrics via @vercel/functions waitUntil

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { waitUntil } from "@vercel/functions";
 
 Sentry.init({
   dsn:
@@ -15,4 +16,14 @@ Sentry.init({
     Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
     Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 5000 }),
   ],
+});
+
+// Sentry v10's `vercelWaitUntil` is a no-op in Node runtime (see
+// @sentry/core/utils/vercelWaitUntil.js: `if (typeof EdgeRuntime !== 'string') return;`),
+// so the SDK's per-request metric flush never runs on Fluid Compute and buffered
+// trace_metric envelopes are lost when the function is suspended. Bridge the gap by
+// scheduling a real `@vercel/functions` waitUntil on every metric capture; outside a
+// request context waitUntil is a safe no-op.
+Sentry.getClient()?.on("afterCaptureMetric", () => {
+  waitUntil(Sentry.flush(2000).catch(() => false));
 });


### PR DESCRIPTION
## Summary
- Production was emitting application metrics (`interaction.command`, `event.processed`, `ai.turn.completed`, etc.) but Sentry received zero trace_metric envelopes over 7 days — only manual API probes landed.
- Root cause: `@sentry/core@10.48`'s `vercelWaitUntil` short-circuits in Node runtime (`if (typeof EdgeRuntime !== 'string') return;`), so the SDK's per-request flush in `wrapRouteHandlerWithSentry` is a no-op on Fluid Compute and the metric buffer is lost when the function suspends.
- Fix: register an `afterCaptureMetric` listener in `sentry.server.config.ts` that schedules `Sentry.flush(2000)` through `@vercel/functions`' real `waitUntil`, keeping the invocation alive until the envelope ships (no-op outside a request context).

## Test plan
- [x] `bun format`, `bun lint`, `bun typecheck`, `bun run test` (233 passed), `bun test:coverage` (98.99%), `bun knip` — all green
- [ ] After deploy, confirm `interaction.command`, `event.processed`, etc. appear in the `tracemetrics` dataset within a few minutes of traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)