### PR TITLE
feat: add /restart-bot organizer command

### DIFF
--- a/src/bot/handlers/commands/index.ts
+++ b/src/bot/handlers/commands/index.ts
@@ -3,3 +3,4 @@ export * from "./door-opener";
 export * from "./privacy";
 export * from "./delete-ship";
 export * from "./hack-night";
+export * from "./restart-bot";

--- a/src/bot/handlers/commands/restart-bot/index.ts
+++ b/src/bot/handlers/commands/restart-bot/index.ts
@@ -1,0 +1,41 @@
+import { SlashCommandBuilder } from "discord.js";
+import { log } from "evlog";
+
+import { defineCommand } from "@/bot/commands/define";
+import { isOrganizer, respond } from "@/bot/commands/helpers";
+import { env } from "@/env";
+
+const FAILURE_MSG = "Failed to restart the bot. Try again later.";
+
+function gatewayUrl(): string {
+  const host = env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL;
+  if (!host) return "http://localhost:3000/api/discord/gateway";
+  return `https://${host}/api/discord/gateway`;
+}
+
+export const restartBot = defineCommand({
+  builder: new SlashCommandBuilder()
+    .setName("restart-bot")
+    .setDescription("Restart the discord gateway listener (organizers only)"),
+  async execute(ctx) {
+    if (!isOrganizer(ctx)) {
+      await respond(ctx, "You need the Organizer role to use this command.");
+      return;
+    }
+
+    try {
+      const res = await fetch(gatewayUrl(), { method: "GET" });
+
+      if (!res.ok) {
+        log.warn("restart-bot", `Gateway returned ${res.status}`);
+        await respond(ctx, FAILURE_MSG);
+        return;
+      }
+
+      await respond(ctx, "Bot restart triggered.");
+    } catch (err) {
+      log.warn("restart-bot", `Gateway request failed: ${String(err)}`);
+      await respond(ctx, FAILURE_MSG);
+    }
+  },
+});

--- a/src/bot/handlers/commands/restart-bot/index.ts
+++ b/src/bot/handlers/commands/restart-bot/index.ts
@@ -6,6 +6,7 @@ import { isOrganizer, respond } from "@/bot/commands/helpers";
 import { env } from "@/env";
 
 const FAILURE_MSG = "Failed to restart the bot. Try again later.";
+const GATEWAY_TIMEOUT_MS = 10_000;
 
 function gatewayUrl(): string {
   const host = env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL;
@@ -24,7 +25,15 @@ export const restartBot = defineCommand({
     }
 
     try {
-      const res = await fetch(gatewayUrl(), { method: "GET" });
+      const res = await fetch(gatewayUrl(), {
+        method: "GET",
+        cache: "no-store",
+        headers: {
+          "Cache-Control": "no-store, no-cache, max-age=0",
+          Pragma: "no-cache",
+        },
+        signal: AbortSignal.timeout(GATEWAY_TIMEOUT_MS),
+      });
 
       if (!res.ok) {
         log.warn("restart-bot", `Gateway returned ${res.status}`);


### PR DESCRIPTION
## Summary
- Adds a new `/restart-bot` slash command that sends `GET /api/discord/gateway` to spin up a fresh gateway listener.
- Organizer-only: checks the caller's role via `isOrganizer(ctx)` and refuses otherwise.
- Targets `VERCEL_PROJECT_PRODUCTION_URL` with fallback to `VERCEL_URL`, then localhost for dev.

## Test plan
- [ ] Build runs `scripts/register-commands.ts` and registers `/restart-bot` with Discord
- [ ] Non-organizer invocation returns the permission error message
- [ ] Organizer invocation triggers a new gateway listener and replies "Bot restart triggered."

🤖 Generated with [Claude Code](https://claude.com/claude-code)