### PR TITLE
feat: register hack night crons in vercel.ts via handler manifest

### DIFF
--- a/src/bot/crons/config.test.ts
+++ b/src/bot/crons/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+import * as crons from "@/bot/handlers/crons";
+
+import type { CronHandler } from "./types";
+
+import { buildCronRoutes } from "./config";
+
+describe("buildCronRoutes", () => {
+  it("maps every registered cron handler to a Vercel cron route", () => {
+    const registered = Object.values(crons) as CronHandler[];
+    const routes = buildCronRoutes();
+
+    expect(routes).toHaveLength(registered.length);
+    for (const cron of registered) {
+      expect(routes).toContainEqual({
+        path: `/api/crons/${cron.name}`,
+        schedule: cron.schedule,
+      });
+    }
+  });
+});

--- a/src/bot/crons/config.ts
+++ b/src/bot/crons/config.ts
@@ -1,0 +1,14 @@
+import type { CronJob } from "@vercel/config/v1/types";
+
+import * as crons from "@/bot/handlers/crons";
+
+import type { CronHandler } from "./types";
+
+const CRON_ROUTE_PREFIX = "/api/crons";
+
+export function buildCronRoutes(): CronJob[] {
+  return (Object.values(crons) as CronHandler[]).map((cron) => ({
+    path: `${CRON_ROUTE_PREFIX}/${cron.name}`,
+    schedule: cron.schedule,
+  }));
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -41,4 +41,5 @@ export const env = createEnv({
   },
   extends: [vercel()],
   runtimeEnv: process.env,
+  skipValidation: process.env.SKIP_ENV_VALIDATION === "1",
 });

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,5 +1,7 @@
 import { type VercelConfig } from "@vercel/config/v1";
 
+import { buildCronRoutes } from "@/bot/crons/config";
+
 export const config: VercelConfig = {
   framework: "nextjs",
   crons: [
@@ -7,6 +9,7 @@ export const config: VercelConfig = {
       path: "/api/discord/gateway",
       schedule: "*/9 * * * *",
     },
+    ...buildCronRoutes(),
   ],
   functions: {
     "src/app/api/tasks/route.ts": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     exclude: ["src/**/*.integration.test.ts"],
+    env: {
+      SKIP_ENV_VALIDATION: "1",
+    },
     coverage: {
       provider: "istanbul",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Adds `buildCronRoutes()` (`src/bot/crons/config.ts`) that iterates the registered cron handlers and produces Vercel `CronJob[]` entries for `/api/crons/:name`.
- `vercel.ts` now spreads those entries into `crons`, wiring up `hack-night-create` (Fri 8 PM), `hack-night-cleanup` (Sun 6 PM), and `heartbeat` (hourly), which were defined but never scheduled.
- Adds `SKIP_ENV_VALIDATION=1` support in `src/env.ts` and sets it in `vitest.config.ts` so tests can import handlers without tripping zod validation on missing env vars.

## Test plan
- [x] `bun format`, `bun lint`, `bun typecheck`
- [x] `bun run test` (234 passed) and `bun test:coverage`
- [x] `bun knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)