### PR TITLE
feat: add /Inspect Context message command for context budget breakdown

### DIFF
--- a/src/bot/commands/define.ts
+++ b/src/bot/commands/define.ts
@@ -2,11 +2,13 @@ import type { CommandBuilder, SlashCommand, SlashCommandContext } from "./types"
 
 export function defineCommand(cmd: {
   builder: CommandBuilder;
+  ephemeral?: boolean;
   execute: (ctx: SlashCommandContext) => Promise<void>;
 }): SlashCommand {
   return {
     name: cmd.builder.name,
     builder: cmd.builder,
+    ephemeral: cmd.ephemeral,
     execute: cmd.execute,
   };
 }

--- a/src/bot/commands/types.ts
+++ b/src/bot/commands/types.ts
@@ -1,5 +1,6 @@
 import type { API } from "@discordjs/core/http-only";
 import type {
+  ContextMenuCommandBuilder,
   SlashCommandBuilder,
   SlashCommandOptionsOnlyBuilder,
   SlashCommandSubcommandsOnlyBuilder,
@@ -10,7 +11,8 @@ import type { DiscordInteraction } from "@/lib/protocol/types";
 export type CommandBuilder =
   | SlashCommandBuilder
   | SlashCommandOptionsOnlyBuilder
-  | SlashCommandSubcommandsOnlyBuilder;
+  | SlashCommandSubcommandsOnlyBuilder
+  | ContextMenuCommandBuilder;
 
 export interface SlashCommandContext {
   interaction: DiscordInteraction;
@@ -21,5 +23,7 @@ export interface SlashCommandContext {
 export interface SlashCommand {
   name: string;
   builder: CommandBuilder;
+  /** When true, defer the interaction response with the Ephemeral flag so only the invoker sees it. */
+  ephemeral?: boolean;
   execute(ctx: SlashCommandContext): Promise<void>;
 }

--- a/src/bot/context-snapshot.test.ts
+++ b/src/bot/context-snapshot.test.ts
@@ -25,7 +25,7 @@ const sampleSnapshot: ContextSnapshot = {
     { role: "user", content: "hi" },
     { role: "assistant", content: "hello" },
   ],
-  lastTurnUsage: {
+  totalUsage: {
     inputTokens: 100,
     outputTokens: 50,
     totalTokens: 150,

--- a/src/bot/context-snapshot.test.ts
+++ b/src/bot/context-snapshot.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createMemoryRedis } from "@/lib/test/fixtures";
+
+import type { ContextSnapshot } from "./context-snapshot";
+
+import { ContextSnapshotStore } from "./context-snapshot";
+
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
+
+const sampleSnapshot: ContextSnapshot = {
+  model: "anthropic/claude-sonnet-4.6",
+  context: {
+    userId: "u-1",
+    username: "rayhan",
+    nickname: "Rayhan",
+    channel: { id: "ch-1", name: "bot-testing" },
+    date: "Wednesday, April 15, 2026",
+  },
+  systemPrompt: "You are a helpful assistant...",
+  tools: [{ name: "currentTime", description: "Get the current time.", inputSchema: {} }],
+  messages: [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+  ],
+  lastTurnUsage: {
+    inputTokens: 100,
+    outputTokens: 50,
+    totalTokens: 150,
+    subagentTokens: 0,
+    toolCallCount: 1,
+    stepCount: 2,
+  },
+  turnCount: 1,
+  updatedAt: "2026-04-15T12:00:00.000Z",
+};
+
+describe("ContextSnapshotStore", () => {
+  it("sets and gets a snapshot keyed by channel only", async () => {
+    const store = new ContextSnapshotStore(createMemoryRedis());
+    await store.set("ch-1", undefined, sampleSnapshot);
+    const out = await store.get("ch-1");
+    expect(out?.model).toBe("anthropic/claude-sonnet-4.6");
+    expect(out?.messages).toHaveLength(2);
+  });
+
+  it("uses threadId as the key when provided", async () => {
+    const store = new ContextSnapshotStore(createMemoryRedis());
+    await store.set("ch-1", "thread-9", sampleSnapshot);
+    expect(await store.get("ch-1", "thread-9")).not.toBeNull();
+    expect(await store.get("ch-1")).toBeNull();
+  });
+
+  it("returns null for missing snapshot", async () => {
+    const store = new ContextSnapshotStore(createMemoryRedis());
+    expect(await store.get("nope")).toBeNull();
+  });
+
+  it("deletes a snapshot", async () => {
+    const store = new ContextSnapshotStore(createMemoryRedis());
+    await store.set("ch-1", undefined, sampleSnapshot);
+    await store.delete("ch-1");
+    expect(await store.get("ch-1")).toBeNull();
+  });
+
+  it("uses Redis.fromEnv when no redis argument is provided", async () => {
+    const defaultStore = new ContextSnapshotStore();
+    expect(await defaultStore.get("nonexistent")).toBeNull();
+  });
+});

--- a/src/bot/context-snapshot.ts
+++ b/src/bot/context-snapshot.ts
@@ -1,0 +1,35 @@
+import { Redis } from "@upstash/redis";
+
+import type { ContextSnapshot, RedisLike } from "./types";
+
+export type { ContextSnapshot, ToolDefSnapshot } from "./types";
+
+const TTL = 60 * 60;
+
+export class ContextSnapshotStore {
+  private redis: RedisLike;
+
+  constructor(redis?: RedisLike) {
+    this.redis = redis ?? Redis.fromEnv();
+  }
+
+  private key(channelId: string, threadId?: string): string {
+    return `context-snapshot:${threadId ?? channelId}`;
+  }
+
+  async get(channelId: string, threadId?: string): Promise<ContextSnapshot | null> {
+    return this.redis.get<ContextSnapshot>(this.key(channelId, threadId));
+  }
+
+  async set(
+    channelId: string,
+    threadId: string | undefined,
+    snapshot: ContextSnapshot,
+  ): Promise<void> {
+    await this.redis.set(this.key(channelId, threadId), snapshot, { ex: TTL });
+  }
+
+  async delete(channelId: string, threadId?: string): Promise<void> {
+    await this.redis.del(this.key(channelId, threadId));
+  }
+}

--- a/src/bot/handlers/commands/index.ts
+++ b/src/bot/handlers/commands/index.ts
@@ -4,3 +4,4 @@ export * from "./privacy";
 export * from "./delete-ship";
 export * from "./hack-night";
 export * from "./restart-bot";
+export * from "./inspect-context";

--- a/src/bot/handlers/commands/inspect-context/index.ts
+++ b/src/bot/handlers/commands/inspect-context/index.ts
@@ -44,6 +44,17 @@ export const inspectContext = defineCommand({
     }
 
     const breakdown = await breakdownFromSnapshot(snap);
-    await respond(ctx, renderContextReport(breakdown));
+    const messages = renderContextReport(breakdown);
+    const [firstMessage, ...followUpMessages] = messages;
+    await respond(ctx, firstMessage);
+    for (const followUp of followUpMessages) {
+      // Followups must set the EPHEMERAL flag explicitly (64); it doesn't
+      // inherit from the deferred reply.
+      await ctx.discord.interactions.followUp(
+        ctx.interaction.application_id,
+        ctx.interaction.token,
+        { content: followUp, flags: 64 },
+      );
+    }
   },
 });

--- a/src/bot/handlers/commands/inspect-context/index.ts
+++ b/src/bot/handlers/commands/inspect-context/index.ts
@@ -1,0 +1,49 @@
+import { ApplicationCommandType, ContextMenuCommandBuilder } from "discord.js";
+
+import { defineCommand } from "@/bot/commands/define";
+import { isOrganizer, respond } from "@/bot/commands/helpers";
+import { ContextSnapshotStore } from "@/bot/context-snapshot";
+import { ConversationStore } from "@/bot/store";
+import { breakdownFromSnapshot } from "@/lib/ai/inspect-context";
+
+import { renderContextReport } from "./render";
+
+export const inspectContext = defineCommand({
+  builder: new ContextMenuCommandBuilder()
+    .setName("Inspect Context")
+    .setType(ApplicationCommandType.Message),
+  ephemeral: true,
+  async execute(ctx) {
+    if (!isOrganizer(ctx)) {
+      await respond(ctx, "You need the Organizer role to use this command.");
+      return;
+    }
+
+    const channelId = ctx.interaction.channel_id;
+    if (!channelId) {
+      await respond(ctx, "Missing channel context on this interaction.");
+      return;
+    }
+
+    const convState = await new ConversationStore().get(channelId);
+    if (!convState) {
+      await respond(
+        ctx,
+        "No active conversation in this channel/thread. Mention the bot first to start one.",
+      );
+      return;
+    }
+
+    const snap = await new ContextSnapshotStore().get(channelId);
+    if (!snap) {
+      await respond(
+        ctx,
+        "Conversation exists but no snapshot is available yet. Wait for the next turn to complete, then try again.",
+      );
+      return;
+    }
+
+    const breakdown = await breakdownFromSnapshot(snap);
+    await respond(ctx, renderContextReport(breakdown));
+  },
+});

--- a/src/bot/handlers/commands/inspect-context/render.test.ts
+++ b/src/bot/handlers/commands/inspect-context/render.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+
+import type { ContextBreakdown } from "@/lib/ai/inspect-context";
+
+import { renderContextReport } from "./render";
+
+const modelInfo = {
+  id: "claude-sonnet-4-6-20260301",
+  provider: "anthropic",
+  limit: { context: 200_000, output: 64_000 },
+  cost: { input: 3, output: 15 },
+};
+
+const baseBreakdown: ContextBreakdown = {
+  model: "anthropic/claude-sonnet-4.6",
+  modelInfo,
+  categories: [
+    { label: "System prompt", chars: 4000, estimatedTokens: 1000 },
+    { label: "Tools", chars: 12_000, estimatedTokens: 3000 },
+    { label: "Conversation history", chars: 24_000, estimatedTokens: 6000 },
+  ],
+  estimatedInputTokens: 10_000,
+  lastTurnUsage: {
+    inputTokens: 12_482,
+    outputTokens: 543,
+    totalTokens: 13_025,
+    subagentTokens: 0,
+    toolCallCount: 2,
+    stepCount: 3,
+  },
+  turnCount: 14,
+  messageCount: 38,
+  lastTurnCostUsd: { input: 0.037446, output: 0.008145, total: 0.045591 },
+};
+
+describe("renderContextReport", () => {
+  it("includes the model id and turn number header", () => {
+    const out = renderContextReport(baseBreakdown);
+    expect(out).toContain("turn #14");
+    expect(out).toContain("anthropic/claude-sonnet-4.6");
+    expect(out).toContain("claude-sonnet-4-6-20260301");
+  });
+
+  it("shows context window and per-category lines", () => {
+    const out = renderContextReport(baseBreakdown);
+    expect(out).toContain("200,000 tokens");
+    expect(out).toContain("**System prompt**");
+    expect(out).toContain("**Tools**");
+    expect(out).toContain("**Conversation history**");
+    expect(out).toContain("38 messages");
+  });
+
+  it("includes last-turn usage and cost when available", () => {
+    const out = renderContextReport(baseBreakdown);
+    expect(out).toContain("input 12,482");
+    expect(out).toContain("output 543");
+    expect(out).toContain("tools 2");
+    expect(out).toContain("steps 3");
+    expect(out).toContain("$0.0456");
+  });
+
+  it("omits cost line when modelInfo is null", () => {
+    const out = renderContextReport({
+      ...baseBreakdown,
+      modelInfo: null,
+      lastTurnCostUsd: undefined,
+    });
+    expect(out).toContain("unknown (model not in models.dev catalog)");
+    expect(out).not.toContain("Last turn cost");
+  });
+
+  it("omits free-space line when modelInfo is null", () => {
+    const out = renderContextReport({
+      ...baseBreakdown,
+      modelInfo: null,
+      lastTurnCostUsd: undefined,
+    });
+    expect(out).not.toContain("Free space");
+  });
+
+  it("includes subagent tokens when present", () => {
+    const out = renderContextReport({
+      ...baseBreakdown,
+      lastTurnUsage: { ...baseBreakdown.lastTurnUsage, subagentTokens: 800 },
+    });
+    expect(out).toContain("subagents 800");
+  });
+
+  it("stays under Discord's 2000 char limit", () => {
+    const out = renderContextReport(baseBreakdown);
+    expect(out.length).toBeLessThan(2000);
+  });
+});

--- a/src/bot/handlers/commands/inspect-context/render.test.ts
+++ b/src/bot/handlers/commands/inspect-context/render.test.ts
@@ -34,11 +34,17 @@ const baseBreakdown: ContextBreakdown = {
 };
 
 describe("renderContextReport", () => {
-  it("includes the model id and turn number header", () => {
+  it("includes the model id and exchange count header", () => {
     const out = renderContextReport(baseBreakdown);
-    expect(out).toContain("turn #14");
+    expect(out).toContain("after 14 exchanges");
     expect(out).toContain("anthropic/claude-sonnet-4.6");
     expect(out).toContain("claude-sonnet-4-6-20260301");
+  });
+
+  it("singularizes the exchange count when there is only one", () => {
+    const out = renderContextReport({ ...baseBreakdown, turnCount: 1 });
+    expect(out).toContain("after 1 exchange");
+    expect(out).not.toContain("1 exchanges");
   });
 
   it("shows context window and per-category lines", () => {

--- a/src/bot/handlers/commands/inspect-context/render.test.ts
+++ b/src/bot/handlers/commands/inspect-context/render.test.ts
@@ -16,84 +16,226 @@ const baseBreakdown: ContextBreakdown = {
   modelInfo,
   categories: [
     { label: "System prompt", chars: 4000, estimatedTokens: 1000 },
-    { label: "Tools", chars: 12_000, estimatedTokens: 3000 },
+    {
+      label: "Tools",
+      chars: 2000,
+      estimatedTokens: 500,
+      items: [
+        { name: "currentTime", estimatedTokens: 80 },
+        { name: "documentation", estimatedTokens: 150 },
+        { name: "scheduleTask", estimatedTokens: 120 },
+        { name: "listScheduledTasks", estimatedTokens: 70 },
+        { name: "cancelTask", estimatedTokens: 80 },
+      ],
+    },
+    {
+      label: "Delegate agents",
+      chars: 3500,
+      estimatedTokens: 875,
+      items: [
+        {
+          name: "delegate_linear",
+          estimatedTokens: 180,
+          skills: [
+            { name: "issues", estimatedTokens: 430 },
+            { name: "projects", estimatedTokens: 280 },
+            { name: "comments", estimatedTokens: 150 },
+          ],
+        },
+        {
+          name: "delegate_github",
+          estimatedTokens: 150,
+          skills: [
+            { name: "pulls", estimatedTokens: 380 },
+            { name: "issues", estimatedTokens: 320 },
+          ],
+        },
+        { name: "delegate_discord", estimatedTokens: 140, skills: [] },
+        { name: "delegate_notion", estimatedTokens: 150 },
+      ],
+    },
     { label: "Conversation history", chars: 24_000, estimatedTokens: 6000 },
   ],
-  estimatedInputTokens: 10_000,
-  lastTurnUsage: {
-    inputTokens: 12_482,
-    outputTokens: 543,
-    totalTokens: 13_025,
+  estimatedInputTokens: 8375,
+  totalUsage: {
+    inputTokens: 142_830,
+    outputTokens: 8340,
+    totalTokens: 151_170,
     subagentTokens: 0,
-    toolCallCount: 2,
-    stepCount: 3,
+    toolCallCount: 32,
+    stepCount: 41,
   },
   turnCount: 14,
   messageCount: 38,
-  lastTurnCostUsd: { input: 0.037446, output: 0.008145, total: 0.045591 },
+  totalCostUsd: { input: 0.42849, output: 0.1251, total: 0.55359 },
 };
 
-describe("renderContextReport", () => {
+function joinPages(breakdown: ContextBreakdown): string {
+  return renderContextReport(breakdown).join("\n");
+}
+
+describe("renderContextReport — summary section", () => {
   it("includes the model id and exchange count header", () => {
-    const out = renderContextReport(baseBreakdown);
+    const out = joinPages(baseBreakdown);
     expect(out).toContain("after 14 exchanges");
     expect(out).toContain("anthropic/claude-sonnet-4.6");
     expect(out).toContain("claude-sonnet-4-6-20260301");
   });
 
   it("singularizes the exchange count when there is only one", () => {
-    const out = renderContextReport({ ...baseBreakdown, turnCount: 1 });
+    const out = joinPages({ ...baseBreakdown, turnCount: 1 });
     expect(out).toContain("after 1 exchange");
     expect(out).not.toContain("1 exchanges");
   });
 
-  it("shows context window and per-category lines", () => {
-    const out = renderContextReport(baseBreakdown);
+  it("shows context window and per-category lines with item counts", () => {
+    const out = joinPages(baseBreakdown);
     expect(out).toContain("200,000 tokens");
     expect(out).toContain("**System prompt**");
     expect(out).toContain("**Tools**");
+    expect(out).toContain("5 entries");
+    expect(out).toContain("**Delegate agents**");
+    expect(out).toContain("4 entries");
     expect(out).toContain("**Conversation history**");
     expect(out).toContain("38 messages");
   });
 
-  it("includes last-turn usage and cost when available", () => {
-    const out = renderContextReport(baseBreakdown);
-    expect(out).toContain("input 12,482");
-    expect(out).toContain("output 543");
-    expect(out).toContain("tools 2");
-    expect(out).toContain("steps 3");
-    expect(out).toContain("$0.0456");
+  it("includes conversation totals and cumulative cost", () => {
+    const out = joinPages(baseBreakdown);
+    expect(out).toContain("`Conversation totals` (sum of every turn, from API):");
+    expect(out).toContain("142,830 input");
+    expect(out).toContain("8,340 output");
+    expect(out).toContain("32 tool calls");
+    expect(out).toContain("41 steps");
+    expect(out).toContain("`Conversation cost`:");
+    expect(out).toContain("$0.5536");
+  });
+
+  it("calls out the breakdown as a next-turn projection", () => {
+    const out = joinPages(baseBreakdown);
+    expect(out).toContain(
+      "Estimated next-request breakdown — what the model would see on the next turn (chars/4):",
+    );
   });
 
   it("omits cost line when modelInfo is null", () => {
-    const out = renderContextReport({
+    const out = joinPages({
       ...baseBreakdown,
       modelInfo: null,
-      lastTurnCostUsd: undefined,
+      totalCostUsd: undefined,
     });
     expect(out).toContain("unknown (model not in models.dev catalog)");
-    expect(out).not.toContain("Last turn cost");
+    expect(out).not.toContain("Conversation cost");
   });
 
   it("omits free-space line when modelInfo is null", () => {
-    const out = renderContextReport({
+    const out = joinPages({
       ...baseBreakdown,
       modelInfo: null,
-      lastTurnCostUsd: undefined,
+      totalCostUsd: undefined,
     });
     expect(out).not.toContain("Free space");
   });
 
   it("includes subagent tokens when present", () => {
-    const out = renderContextReport({
+    const out = joinPages({
       ...baseBreakdown,
-      lastTurnUsage: { ...baseBreakdown.lastTurnUsage, subagentTokens: 800 },
+      totalUsage: { ...baseBreakdown.totalUsage, subagentTokens: 4830 },
     });
-    expect(out).toContain("subagents 800");
+    expect(out).toContain("4,830 subagent");
   });
 
-  it("stays under Discord's 2000 char limit", () => {
-    const out = renderContextReport(baseBreakdown);
-    expect(out.length).toBeLessThan(2000);
+  it("keeps every message under Discord's 2000 char limit", () => {
+    const messages = renderContextReport(baseBreakdown);
+    for (const messageBody of messages) {
+      expect(messageBody.length).toBeLessThan(2000);
+    }
+  });
+});
+
+describe("renderContextReport — details section", () => {
+  it("emits a flat tools section with per-tool tokens", () => {
+    const out = joinPages(baseBreakdown);
+    expect(out).toContain("**Tools** (5)");
+    expect(out).toContain("`currentTime`: ~80 tokens");
+  });
+
+  it("nests loadable skills under each delegate with per-skill tokens", () => {
+    const out = joinPages(baseBreakdown);
+    expect(out).toContain("**Delegate agents** (4, with loadable subskills)");
+    expect(out).toContain("`delegate_linear`: ~180 tokens");
+    expect(out).toContain("Loadable skills (3):");
+    expect(out).toContain("• `issues`: ~430 tokens");
+    expect(out).toContain("• `projects`: ~280 tokens");
+  });
+
+  it("singularizes the loadable-skill heading when a delegate has one skill", () => {
+    const out = joinPages({
+      ...baseBreakdown,
+      categories: baseBreakdown.categories.map((c) =>
+        c.label === "Delegate agents"
+          ? {
+              ...c,
+              items: [
+                {
+                  name: "delegate_x",
+                  estimatedTokens: 100,
+                  skills: [{ name: "only-one", estimatedTokens: 50 }],
+                },
+              ],
+            }
+          : c,
+      ),
+    });
+    expect(out).toContain("Loadable skill (1):");
+    expect(out).not.toContain("Loadable skills (1):");
+  });
+
+  it("shows 'none' when a delegate has no loadable skills for the role", () => {
+    const out = joinPages(baseBreakdown);
+    // delegate_discord has skills: [] in the fixture
+    expect(out).toContain("`delegate_discord`: ~140 tokens");
+    expect(out).toContain("Loadable skills: none");
+  });
+
+  it("shows 'none' when a delegate has no skills field at all", () => {
+    const out = joinPages(baseBreakdown);
+    // delegate_notion has no `skills` field in the fixture
+    expect(out).toContain("`delegate_notion`: ~150 tokens");
+  });
+
+  it("omits delegate detail when no delegate items exist", () => {
+    const out = joinPages({
+      ...baseBreakdown,
+      categories: baseBreakdown.categories.map((c) =>
+        c.label === "Delegate agents" ? { ...c, items: [] } : c,
+      ),
+    });
+    expect(out).not.toContain("with loadable subskills");
+  });
+});
+
+describe("renderContextReport — pagination", () => {
+  it("returns multiple pages when content exceeds a single message", () => {
+    // Build a delegate with a huge skill list to force paging.
+    const fatSkills = Array.from({ length: 200 }, (_, i) => ({
+      name: `skill_${i}`,
+      estimatedTokens: 50,
+    }));
+    const messages = renderContextReport({
+      ...baseBreakdown,
+      categories: baseBreakdown.categories.map((c) =>
+        c.label === "Delegate agents"
+          ? {
+              ...c,
+              items: [{ name: "delegate_huge", estimatedTokens: 100, skills: fatSkills }],
+            }
+          : c,
+      ),
+    });
+    expect(messages.length).toBeGreaterThan(1);
+    for (const messageBody of messages) {
+      expect(messageBody.length).toBeLessThan(2000);
+    }
   });
 });

--- a/src/bot/handlers/commands/inspect-context/render.ts
+++ b/src/bot/handlers/commands/inspect-context/render.ts
@@ -1,6 +1,7 @@
-import type { ContextBreakdown } from "@/lib/ai/inspect-context";
+import type { CategoryBreakdown, CategoryItem, ContextBreakdown } from "@/lib/ai/inspect-context";
 
 const HEADER_PREFIX = "**Context Usage**";
+const DISCORD_MAX = 1900; // leave headroom under Discord's 2000 hard limit
 
 function formatTokens(n: number): string {
   return n.toLocaleString("en-US");
@@ -15,11 +16,57 @@ function formatPercent(part: number, whole: number): string {
   return `${((part / whole) * 100).toFixed(1)}%`;
 }
 
-export function renderContextReport(breakdown: ContextBreakdown): string {
-  const { model, modelInfo, categories, estimatedInputTokens, lastTurnUsage, lastTurnCostUsd } =
+function categorySuffix(c: CategoryBreakdown, messageCount: number): string {
+  if (c.label === "Conversation history") {
+    return ` — ${messageCount} messages`;
+  }
+  if (c.items?.length) {
+    const noun = c.items.length === 1 ? "entry" : "entries";
+    return ` — ${c.items.length} ${noun}`;
+  }
+  return "";
+}
+
+function pluralize(n: number, singular: string, plural = `${singular}s`): string {
+  return n === 1 ? singular : plural;
+}
+
+/**
+ * Pack independent chunks into Discord-sized message pages. Each page stays
+ * under DISCORD_MAX chars; chunks are kept whole (never split mid-chunk).
+ */
+function packPages(blocks: string[]): string[] {
+  const pages: string[] = [];
+  let current = "";
+  for (const next of blocks) {
+    if (!next) continue;
+    const sep = current ? "\n\n" : "";
+    if (current.length + sep.length + next.length <= DISCORD_MAX) {
+      current += sep + next;
+    } else {
+      if (current) pages.push(current);
+      current = next;
+    }
+  }
+  if (current) pages.push(current);
+  return pages;
+}
+
+export function renderContextReport(breakdown: ContextBreakdown): string[] {
+  const blocks: string[] = [renderSummary(breakdown), ...renderDetailBlocks(breakdown)];
+  return packPages(blocks);
+}
+
+function renderSummary(breakdown: ContextBreakdown): string {
+  const lines: string[] = [];
+  appendSummaryLines(lines, breakdown);
+  return lines.join("\n");
+}
+
+function appendSummaryLines(lines: string[], breakdown: ContextBreakdown): void {
+  const { model, modelInfo, categories, estimatedInputTokens, totalUsage, totalCostUsd } =
     breakdown;
 
-  const lines: string[] = [];
   const exchanges = breakdown.turnCount === 1 ? "1 exchange" : `${breakdown.turnCount} exchanges`;
   lines.push(`${HEADER_PREFIX} (after ${exchanges})`);
 
@@ -33,33 +80,34 @@ export function renderContextReport(breakdown: ContextBreakdown): string {
   }
 
   const usageParts: string[] = [];
-  if (lastTurnUsage.inputTokens != null) {
-    usageParts.push(`input ${formatTokens(lastTurnUsage.inputTokens)}`);
+  if (totalUsage.inputTokens != null) {
+    usageParts.push(`${formatTokens(totalUsage.inputTokens)} input`);
   }
-  if (lastTurnUsage.outputTokens != null) {
-    usageParts.push(`output ${formatTokens(lastTurnUsage.outputTokens)}`);
+  if (totalUsage.outputTokens != null) {
+    usageParts.push(`${formatTokens(totalUsage.outputTokens)} output`);
   }
-  if (lastTurnUsage.subagentTokens > 0) {
-    usageParts.push(`subagents ${formatTokens(lastTurnUsage.subagentTokens)}`);
+  if (totalUsage.subagentTokens > 0) {
+    usageParts.push(`${formatTokens(totalUsage.subagentTokens)} subagent`);
   }
-  usageParts.push(`tools ${lastTurnUsage.toolCallCount}`);
-  usageParts.push(`steps ${lastTurnUsage.stepCount}`);
-  lines.push(`\`Last turn\` (from API): ${usageParts.join(" · ")}`);
+  usageParts.push(`${totalUsage.toolCallCount} tool calls`);
+  usageParts.push(`${totalUsage.stepCount} steps`);
+  lines.push(`\`Conversation totals\` (sum of every turn, from API): ${usageParts.join(" · ")}`);
 
-  if (lastTurnCostUsd) {
+  if (totalCostUsd) {
     lines.push(
-      `\`Last turn cost\`: ${formatCost(lastTurnCostUsd.total)} (input ${formatCost(lastTurnCostUsd.input)} + output ${formatCost(lastTurnCostUsd.output)})`,
+      `\`Conversation cost\`: ${formatCost(totalCostUsd.total)} (input ${formatCost(totalCostUsd.input)} + output ${formatCost(totalCostUsd.output)})`,
     );
   }
 
   lines.push("");
-  lines.push("Estimated input breakdown (chars/4):");
+  lines.push(
+    "Estimated next-request breakdown — what the model would see on the next turn (chars/4):",
+  );
 
   const window = modelInfo?.limit.context;
   for (const c of categories) {
     const percent = window ? ` (${formatPercent(c.estimatedTokens, window)})` : "";
-    const suffix =
-      c.label === "Conversation history" ? ` — ${breakdown.messageCount} messages` : "";
+    const suffix = categorySuffix(c, breakdown.messageCount);
     lines.push(`• **${c.label}**: ~${formatTokens(c.estimatedTokens)} tokens${percent}${suffix}`);
   }
 
@@ -72,6 +120,69 @@ export function renderContextReport(breakdown: ContextBreakdown): string {
     const free = Math.max(window - estimatedInputTokens, 0);
     lines.push(`• **Free space**: ~${formatTokens(free)} tokens (${formatPercent(free, window)})`);
   }
+}
 
+/**
+ * Build one block per detail category. Each delegate item also emits its own
+ * standalone block so packPages can flush a page boundary between delegates if
+ * the cumulative content would overflow Discord's 1900-char chunk size.
+ */
+function renderDetailBlocks(breakdown: ContextBreakdown): string[] {
+  const out: string[] = [];
+  for (const category of breakdown.categories) {
+    if (!category.items?.length) continue;
+    if (category.label === "Delegate agents") {
+      out.push(...renderDelegateBlocks(category.items));
+    } else {
+      out.push(renderFlatCategory(category));
+    }
+  }
+  return out;
+}
+
+function renderFlatCategory(category: CategoryBreakdown): string {
+  const lines: string[] = [`**${category.label}** (${category.items?.length ?? 0})`];
+  for (const item of category.items ?? []) {
+    lines.push(`• \`${item.name}\`: ~${formatTokens(item.estimatedTokens)} tokens`);
+  }
   return lines.join("\n");
+}
+
+function renderDelegateBlocks(delegateItems: NonNullable<CategoryBreakdown["items"]>): string[] {
+  const out: string[] = [`**Delegate agents** (${delegateItems.length}, with loadable subskills)`];
+  for (const delegate of delegateItems) {
+    out.push(...renderDelegateChunks(delegate));
+  }
+  return out;
+}
+
+function renderDelegateChunks(delegate: CategoryItem): string[] {
+  const headLines: string[] = [
+    `\`${delegate.name}\`: ~${formatTokens(delegate.estimatedTokens)} tokens`,
+  ];
+  if (!delegate.skills?.length) {
+    headLines.push("Loadable skills: none");
+    return [headLines.join("\n")];
+  }
+
+  const noun = pluralize(delegate.skills.length, "skill");
+  headLines.push(`Loadable ${noun} (${delegate.skills.length}):`);
+
+  const skillLines = delegate.skills.map(
+    (s) => `• \`${s.name}\`: ~${formatTokens(s.estimatedTokens)} tokens`,
+  );
+
+  const out: string[] = [];
+  let current = headLines.join("\n");
+  for (const line of skillLines) {
+    const candidate = `${current}\n${line}`;
+    if (candidate.length <= DISCORD_MAX) {
+      current = candidate;
+    } else {
+      out.push(current);
+      current = `\`${delegate.name}\` (continued)\n${line}`;
+    }
+  }
+  out.push(current);
+  return out;
 }

--- a/src/bot/handlers/commands/inspect-context/render.ts
+++ b/src/bot/handlers/commands/inspect-context/render.ts
@@ -20,7 +20,8 @@ export function renderContextReport(breakdown: ContextBreakdown): string {
     breakdown;
 
   const lines: string[] = [];
-  lines.push(`${HEADER_PREFIX} (turn #${breakdown.turnCount})`);
+  const exchanges = breakdown.turnCount === 1 ? "1 exchange" : `${breakdown.turnCount} exchanges`;
+  lines.push(`${HEADER_PREFIX} (after ${exchanges})`);
 
   const modelIdSuffix = modelInfo ? ` (${modelInfo.id})` : "";
   lines.push(`\`Model\`: ${model}${modelIdSuffix}`);

--- a/src/bot/handlers/commands/inspect-context/render.ts
+++ b/src/bot/handlers/commands/inspect-context/render.ts
@@ -1,6 +1,6 @@
 import type { ContextBreakdown } from "@/lib/ai/inspect-context";
 
-const HEADER_PREFIX = "**Context Usage** — live snapshot";
+const HEADER_PREFIX = "**Context Usage**";
 
 function formatTokens(n: number): string {
   return n.toLocaleString("en-US");
@@ -71,11 +71,6 @@ export function renderContextReport(breakdown: ContextBreakdown): string {
     const free = Math.max(window - estimatedInputTokens, 0);
     lines.push(`• **Free space**: ~${formatTokens(free)} tokens (${formatPercent(free, window)})`);
   }
-
-  lines.push("");
-  lines.push(
-    "-# Per-category counts estimated with chars/4. Last-turn totals and dollar cost are exact (from API usage × models.dev pricing).",
-  );
 
   return lines.join("\n");
 }

--- a/src/bot/handlers/commands/inspect-context/render.ts
+++ b/src/bot/handlers/commands/inspect-context/render.ts
@@ -58,14 +58,9 @@ export function renderContextReport(breakdown: ContextBreakdown): string[] {
 }
 
 function renderSummary(breakdown: ContextBreakdown): string {
-  const lines: string[] = [];
-  appendSummaryLines(lines, breakdown);
-  return lines.join("\n");
-}
-
-function appendSummaryLines(lines: string[], breakdown: ContextBreakdown): void {
   const { model, modelInfo, categories, estimatedInputTokens, totalUsage, totalCostUsd } =
     breakdown;
+  const lines: string[] = [];
 
   const exchanges = breakdown.turnCount === 1 ? "1 exchange" : `${breakdown.turnCount} exchanges`;
   lines.push(`${HEADER_PREFIX} (after ${exchanges})`);
@@ -120,6 +115,8 @@ function appendSummaryLines(lines: string[], breakdown: ContextBreakdown): void 
     const free = Math.max(window - estimatedInputTokens, 0);
     lines.push(`• **Free space**: ~${formatTokens(free)} tokens (${formatPercent(free, window)})`);
   }
+
+  return lines.join("\n");
 }
 
 /**

--- a/src/bot/handlers/commands/inspect-context/render.ts
+++ b/src/bot/handlers/commands/inspect-context/render.ts
@@ -1,0 +1,81 @@
+import type { ContextBreakdown } from "@/lib/ai/inspect-context";
+
+const HEADER_PREFIX = "**Context Usage** — live snapshot";
+
+function formatTokens(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function formatCost(n: number): string {
+  return `$${n.toFixed(4)}`;
+}
+
+function formatPercent(part: number, whole: number): string {
+  if (whole <= 0) return "";
+  return `${((part / whole) * 100).toFixed(1)}%`;
+}
+
+export function renderContextReport(breakdown: ContextBreakdown): string {
+  const { model, modelInfo, categories, estimatedInputTokens, lastTurnUsage, lastTurnCostUsd } =
+    breakdown;
+
+  const lines: string[] = [];
+  lines.push(`${HEADER_PREFIX} (turn #${breakdown.turnCount})`);
+
+  const modelIdSuffix = modelInfo ? ` (${modelInfo.id})` : "";
+  lines.push(`\`Model\`: ${model}${modelIdSuffix}`);
+
+  if (modelInfo) {
+    lines.push(`\`Window\`: ${formatTokens(modelInfo.limit.context)} tokens`);
+  } else {
+    lines.push(`\`Window\`: unknown (model not in models.dev catalog)`);
+  }
+
+  const usageParts: string[] = [];
+  if (lastTurnUsage.inputTokens != null) {
+    usageParts.push(`input ${formatTokens(lastTurnUsage.inputTokens)}`);
+  }
+  if (lastTurnUsage.outputTokens != null) {
+    usageParts.push(`output ${formatTokens(lastTurnUsage.outputTokens)}`);
+  }
+  if (lastTurnUsage.subagentTokens > 0) {
+    usageParts.push(`subagents ${formatTokens(lastTurnUsage.subagentTokens)}`);
+  }
+  usageParts.push(`tools ${lastTurnUsage.toolCallCount}`);
+  usageParts.push(`steps ${lastTurnUsage.stepCount}`);
+  lines.push(`\`Last turn\` (from API): ${usageParts.join(" · ")}`);
+
+  if (lastTurnCostUsd) {
+    lines.push(
+      `\`Last turn cost\`: ${formatCost(lastTurnCostUsd.total)} (input ${formatCost(lastTurnCostUsd.input)} + output ${formatCost(lastTurnCostUsd.output)})`,
+    );
+  }
+
+  lines.push("");
+  lines.push("Estimated input breakdown (chars/4):");
+
+  const window = modelInfo?.limit.context;
+  for (const c of categories) {
+    const percent = window ? ` (${formatPercent(c.estimatedTokens, window)})` : "";
+    const suffix =
+      c.label === "Conversation history" ? ` — ${breakdown.messageCount} messages` : "";
+    lines.push(`• **${c.label}**: ~${formatTokens(c.estimatedTokens)} tokens${percent}${suffix}`);
+  }
+
+  const totalPercent = window ? ` (${formatPercent(estimatedInputTokens, window)})` : "";
+  lines.push(
+    `• **Total input (estimated)**: ~${formatTokens(estimatedInputTokens)} tokens${totalPercent}`,
+  );
+
+  if (window) {
+    const free = Math.max(window - estimatedInputTokens, 0);
+    lines.push(`• **Free space**: ~${formatTokens(free)} tokens (${formatPercent(free, window)})`);
+  }
+
+  lines.push("");
+  lines.push(
+    "-# Per-category counts estimated with chars/4. Last-turn totals and dollar cost are exact (from API usage × models.dev pricing).",
+  );
+
+  return lines.join("\n");
+}

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -83,6 +83,7 @@ export async function handleMention(
   const run = await start(chatWorkflow, [
     {
       channelId: conversationChannelId,
+      threadId: conversationThreadId,
       content,
       context: turnContext,
     },

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -42,6 +42,10 @@ export interface ToolDefSnapshot {
  * chat workflow after each turn completes; read by the /Inspect Context message
  * command. Stored under a separate Redis key from `ConversationState` to keep
  * the hot-path state lean.
+ *
+ * `totalUsage` is cumulative across every turn the workflow has run so far —
+ * it answers "what has this conversation cost in total?" — not just the most
+ * recent turn.
  */
 export interface ContextSnapshot {
   model: string;
@@ -49,7 +53,7 @@ export interface ContextSnapshot {
   systemPrompt: string;
   tools: ToolDefSnapshot[];
   messages: ChatMessage[];
-  lastTurnUsage: TurnUsage;
+  totalUsage: TurnUsage;
   turnCount: number;
   updatedAt: string;
 }

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -1,5 +1,7 @@
 import type { API } from "@discordjs/core/http-only";
 
+import type { ChatMessage, SerializedAgentContext, TurnUsage } from "@/lib/ai/types";
+
 import type { ConversationStore } from "./store";
 
 export interface HandlerContext {
@@ -21,4 +23,33 @@ export interface RedisLike {
   del(key: string): Promise<unknown>;
   expire(key: string, seconds: number): Promise<unknown>;
   eval(script: string, keys: string[], args: string[]): Promise<unknown>;
+}
+
+/**
+ * Serialized tool definition captured at snapshot time. Mirrors the tool-surface
+ * shape the orchestrator exposes to the AI SDK (name, description, JSON-schema
+ * input). Stored verbatim so the inspector can render and measure exactly what
+ * the model sees.
+ */
+export interface ToolDefSnapshot {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+/**
+ * Per-turn snapshot of everything the orchestrator receives. Written by the
+ * chat workflow after each turn completes; read by the /Inspect Context message
+ * command. Stored under a separate Redis key from `ConversationState` to keep
+ * the hot-path state lean.
+ */
+export interface ContextSnapshot {
+  model: string;
+  context: SerializedAgentContext;
+  systemPrompt: string;
+  tools: ToolDefSnapshot[];
+  messages: ChatMessage[];
+  lastTurnUsage: TurnUsage;
+  turnCount: number;
+  updatedAt: string;
 }

--- a/src/lib/ai/constants.ts
+++ b/src/lib/ai/constants.ts
@@ -46,3 +46,40 @@ Your final message MUST contain exactly two sections:
 `;
 
 export const SUBAGENT_MODEL = "anthropic/claude-haiku-4.5";
+
+export const ORCHESTRATOR_MODEL = "anthropic/claude-sonnet-4.6";
+
+export const SYSTEM_PROMPT = `<identity>
+You are a helpful assistant for Purdue Hackers, embedded in Discord. You speak as "I" and keep responses concise and actionable.
+</identity>
+
+<date>
+Today is {{DATE}}.
+</date>
+
+<tools>
+You have direct access to these tools:
+
+- **currentTime** — get the current timestamp.
+- **documentation** — look up Purdue Hackers info (events, projects, history, culture, docs). Prefer this over notion for general informational questions. Relay the tool's answer directly without paraphrasing.
+- **scheduleTask / listScheduledTasks / cancelTask** — schedule one-time or recurring messages and agent prompts. Use action_type "message" for static content, "agent" for dynamic content. Always confirm the schedule with the user before creating it. Default the channel and user to the execution context. Recurring tasks use 5-field cron (minute hour day month weekday).
+- **delegate_linear / delegate_github / delegate_discord / delegate_notion** — forward a task to a focused domain subagent. Forward the user's wording verbatim; the subagent needs the exact phrasing. Wait for the subagent's final result.
+
+Only delegate when the user's request clearly requires a domain-specific action (e.g. creating a channel, filing an issue, querying a database). If the message is casual, ambiguous, or conversational, respond directly — do not delegate.
+
+Plan multi-step requests before starting. For requests that span multiple domains, delegate each in turn.
+</tools>
+
+<tone>
+- Concise and direct. No preamble, no filler.
+- Never open with "Great question!", "Sure!", "Certainly!", or similar. Start with the answer or action.
+- Warm but straightforward. First person: "I found...", "Here's...", "Done."
+- Discord has a 2000-character limit. Keep responses well under it.
+- For simple confirmations: one sentence. For data: clean bullet list.
+</tone>
+
+<formatting>
+- Use Discord-compatible Markdown. Bullet lists use -.
+- Include URLs when referencing entities. Never expose raw UUIDs.
+- Never echo API keys, tokens, or secrets.
+</formatting>`;

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -152,7 +152,12 @@ export class AgentContext {
     return `${baseInstructions.replace("{{DATE}}", this.date)}\n\n${this.contextBlock()}`;
   }
 
-  private contextBlock(): string {
+  /**
+   * Render the YAML execution-context block appended to the system prompt.
+   * Public so the context inspector can snapshot the exact block the orchestrator
+   * saw without duplicating the YAML layout.
+   */
+  contextBlock(): string {
     const thread = this.thread
       ? `\nthread:\n  name: ${JSON.stringify(this.thread.name)}\n  id: "${this.thread.id}"\n  parent_channel: "#${this.thread.parentChannel.name}"`
       : "";

--- a/src/lib/ai/delegates.test.ts
+++ b/src/lib/ai/delegates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { UserRole } from "@/lib/ai/constants";
+import { TurnUsageTracker } from "@/lib/ai/turn-usage";
 
 // Mock the generated manifest so tests aren't coupled to the real skill set.
 vi.mock("@/lib/ai/skills/generated/manifest", () => ({
@@ -86,14 +87,14 @@ const createDelegationToolMock = vi.mocked(createDelegationTool);
 describe("buildDelegationTools", () => {
   it("returns an empty set for public users (all delegate skills are gated above public)", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Public, { totalTokens: 0, toolCallCount: 0 });
+    const tools = buildDelegationTools(UserRole.Public, new TurnUsageTracker());
     expect(tools).toEqual({});
     expect(createDelegationToolMock).not.toHaveBeenCalled();
   });
 
   it("exposes only organizer-accessible delegate skills to organizers", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Organizer, { totalTokens: 0, toolCallCount: 0 });
+    const tools = buildDelegationTools(UserRole.Organizer, new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_linear",
@@ -103,7 +104,7 @@ describe("buildDelegationTools", () => {
 
   it("exposes every delegate skill to admins", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const tools = buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_github",
@@ -114,13 +115,13 @@ describe("buildDelegationTools", () => {
 
   it("skips inline-mode skills even when the role qualifies", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const tools = buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
     expect(tools).not.toHaveProperty("delegate_discord");
   });
 
   it("passes the skill description and instructions through to createDelegationTool", () => {
     createDelegationToolMock.mockClear();
-    buildDelegationTools(UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
 
     const linearCall = createDelegationToolMock.mock.calls.find(
       ([spec]) => (spec as { description: string }).description === "Linear delegate",

--- a/src/lib/ai/delegates.ts
+++ b/src/lib/ai/delegates.ts
@@ -1,7 +1,7 @@
 import type { ToolSet } from "ai";
 
 import type { UserRole } from "./constants.ts";
-import type { SubagentMetrics } from "./types.ts";
+import type { TurnUsageTracker } from "./turn-usage.ts";
 
 import { SKILL_MANIFEST as DISCORD_SUBSKILLS } from "./skills/generated/domains/discord.ts";
 import { SKILL_MANIFEST as FIGMA_SUBSKILLS } from "./skills/generated/domains/figma.ts";
@@ -72,7 +72,7 @@ const DOMAINS = {
 const registry = new SkillRegistry(SKILL_MANIFEST);
 
 /** Build delegation tools for every delegate-mode skill the role can access. */
-export function buildDelegationTools(role: UserRole, metrics: SubagentMetrics): ToolSet {
+export function buildDelegationTools(role: UserRole, tracker: TurnUsageTracker): ToolSet {
   const tools: ToolSet = {};
   for (const [name, config] of Object.entries(DOMAINS)) {
     const skill = registry.loadSkill(name, role);
@@ -85,7 +85,7 @@ export function buildDelegationTools(role: UserRole, metrics: SubagentMetrics): 
         ...config,
       },
       role,
-      metrics,
+      tracker,
     );
   }
   return tools;

--- a/src/lib/ai/inspect-context.test.ts
+++ b/src/lib/ai/inspect-context.test.ts
@@ -29,7 +29,7 @@ const baseSnap: ContextSnapshot = {
   tools: [],
   // "user: hi" = 8 chars → 2 tokens
   messages: [{ role: "user", content: "hi" }],
-  lastTurnUsage: {
+  totalUsage: {
     inputTokens: 1000,
     outputTokens: 200,
     totalTokens: 1200,
@@ -68,6 +68,7 @@ describe("breakdownFromSnapshot", () => {
     expect(out.categories.map((c) => c.label)).toEqual([
       "System prompt",
       "Tools",
+      "Delegate agents",
       "Conversation history",
     ]);
     const system = out.categories.find((c) => c.label === "System prompt");
@@ -83,59 +84,59 @@ describe("breakdownFromSnapshot", () => {
     const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
     const out = await breakdownFromSnapshot(baseSnap, fetchInfo);
     // 1000 input * $3/M = $0.003, 200 output * $15/M = $0.003, total = $0.006
-    expect(out.lastTurnCostUsd?.input).toBeCloseTo(0.003, 6);
-    expect(out.lastTurnCostUsd?.output).toBeCloseTo(0.003, 6);
-    expect(out.lastTurnCostUsd?.total).toBeCloseTo(0.006, 6);
+    expect(out.totalCostUsd?.input).toBeCloseTo(0.003, 6);
+    expect(out.totalCostUsd?.output).toBeCloseTo(0.003, 6);
+    expect(out.totalCostUsd?.total).toBeCloseTo(0.006, 6);
   });
 
   it("omits cost when modelInfo is null", async () => {
     const fetchInfo = vi.fn().mockResolvedValue(null);
     const out = await breakdownFromSnapshot(baseSnap, fetchInfo);
     expect(out.modelInfo).toBeNull();
-    expect(out.lastTurnCostUsd).toBeUndefined();
+    expect(out.totalCostUsd).toBeUndefined();
   });
 
   it("omits cost when both token counts are missing", async () => {
     const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
     const snap = {
       ...baseSnap,
-      lastTurnUsage: {
-        ...baseSnap.lastTurnUsage,
+      totalUsage: {
+        ...baseSnap.totalUsage,
         inputTokens: undefined,
         outputTokens: undefined,
       },
     };
     const out = await breakdownFromSnapshot(snap, fetchInfo);
-    expect(out.lastTurnCostUsd).toBeUndefined();
+    expect(out.totalCostUsd).toBeUndefined();
   });
 
   it("computes cost with only input tokens present", async () => {
     const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
     const snap = {
       ...baseSnap,
-      lastTurnUsage: { ...baseSnap.lastTurnUsage, outputTokens: undefined },
+      totalUsage: { ...baseSnap.totalUsage, outputTokens: undefined },
     };
     const out = await breakdownFromSnapshot(snap, fetchInfo);
-    expect(out.lastTurnCostUsd?.output).toBe(0);
-    expect(out.lastTurnCostUsd?.input).toBeCloseTo(0.003, 6);
+    expect(out.totalCostUsd?.output).toBe(0);
+    expect(out.totalCostUsd?.input).toBeCloseTo(0.003, 6);
   });
 
   it("computes cost with only output tokens present", async () => {
     const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
     const snap = {
       ...baseSnap,
-      lastTurnUsage: { ...baseSnap.lastTurnUsage, inputTokens: undefined },
+      totalUsage: { ...baseSnap.totalUsage, inputTokens: undefined },
     };
     const out = await breakdownFromSnapshot(snap, fetchInfo);
-    expect(out.lastTurnCostUsd?.input).toBe(0);
-    expect(out.lastTurnCostUsd?.output).toBeCloseTo(0.003, 6);
+    expect(out.totalCostUsd?.input).toBe(0);
+    expect(out.totalCostUsd?.output).toBeCloseTo(0.003, 6);
   });
 
   it("uses the default fetchModelInfo when no fetchInfo is passed", async () => {
     const out = await breakdownFromSnapshot(baseSnap);
     // Mocked default returns null → no model metadata in the breakdown.
     expect(out.modelInfo).toBeNull();
-    expect(out.lastTurnCostUsd).toBeUndefined();
+    expect(out.totalCostUsd).toBeUndefined();
   });
 
   it("forwards turnCount and messageCount", async () => {
@@ -152,5 +153,74 @@ describe("breakdownFromSnapshot", () => {
     const out = await breakdownFromSnapshot(snap, fetchInfo);
     expect(out.turnCount).toBe(5);
     expect(out.messageCount).toBe(3);
+  });
+});
+
+describe("breakdownFromSnapshot — tool partitioning", () => {
+  it("partitions tools into base tools and delegate agents by name prefix", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      tools: [
+        { name: "currentTime", description: "time", inputSchema: {} },
+        { name: "documentation", description: "docs", inputSchema: {} },
+        { name: "delegate_linear", description: "linear", inputSchema: {} },
+        { name: "delegate_github", description: "github", inputSchema: {} },
+      ],
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    const tools = out.categories.find((c) => c.label === "Tools");
+    const delegates = out.categories.find((c) => c.label === "Delegate agents");
+    expect(tools?.items?.map((i) => i.name)).toEqual(["currentTime", "documentation"]);
+    expect(delegates?.items?.map((i) => i.name)).toEqual(["delegate_linear", "delegate_github"]);
+    for (const item of [...(tools?.items ?? []), ...(delegates?.items ?? [])]) {
+      expect(item.estimatedTokens).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("breakdownFromSnapshot — delegate subskills", () => {
+  it("attaches no skills to delegates for a Public-tier user", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      tools: [{ name: "delegate_linear", description: "linear", inputSchema: {} }],
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    const delegates = out.categories.find((c) => c.label === "Delegate agents");
+    expect(delegates?.items?.[0].skills).toBeUndefined();
+  });
+
+  it("attaches Organizer-tier subskills to each delegate with a known domain", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      context: { ...baseSnap.context, memberRoles: ["1012751663322382438"] },
+      tools: [
+        { name: "delegate_linear", description: "linear", inputSchema: {} },
+        { name: "delegate_github", description: "github", inputSchema: {} },
+      ],
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    const delegates = out.categories.find((c) => c.label === "Delegate agents");
+    const linear = delegates?.items?.find((i) => i.name === "delegate_linear");
+    const github = delegates?.items?.find((i) => i.name === "delegate_github");
+    expect(linear?.skills?.length).toBeGreaterThan(0);
+    expect(github?.skills?.length).toBeGreaterThan(0);
+    for (const s of linear?.skills ?? []) {
+      expect(s.estimatedTokens).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns undefined skills for a delegate whose domain is not registered", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      context: { ...baseSnap.context, memberRoles: ["1012751663322382438"] },
+      tools: [{ name: "delegate_unknown", description: "?", inputSchema: {} }],
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    const delegates = out.categories.find((c) => c.label === "Delegate agents");
+    expect(delegates?.items?.[0].skills).toBeUndefined();
   });
 });

--- a/src/lib/ai/inspect-context.test.ts
+++ b/src/lib/ai/inspect-context.test.ts
@@ -4,7 +4,15 @@ import type { ContextSnapshot } from "@/bot/context-snapshot";
 
 import type { ModelInfo } from "./models-dev.ts";
 
-import { breakdownFromSnapshot, estimateTokens } from "./inspect-context.ts";
+vi.mock("./models-dev.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models-dev.ts")>();
+  return {
+    ...actual,
+    fetchModelInfo: vi.fn().mockResolvedValue(null),
+  };
+});
+
+const { breakdownFromSnapshot, estimateTokens } = await import("./inspect-context.ts");
 
 const baseSnap: ContextSnapshot = {
   model: "anthropic/claude-sonnet-4.6",
@@ -110,6 +118,24 @@ describe("breakdownFromSnapshot", () => {
     const out = await breakdownFromSnapshot(snap, fetchInfo);
     expect(out.lastTurnCostUsd?.output).toBe(0);
     expect(out.lastTurnCostUsd?.input).toBeCloseTo(0.003, 6);
+  });
+
+  it("computes cost with only output tokens present", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      lastTurnUsage: { ...baseSnap.lastTurnUsage, inputTokens: undefined },
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    expect(out.lastTurnCostUsd?.input).toBe(0);
+    expect(out.lastTurnCostUsd?.output).toBeCloseTo(0.003, 6);
+  });
+
+  it("uses the default fetchModelInfo when no fetchInfo is passed", async () => {
+    const out = await breakdownFromSnapshot(baseSnap);
+    // Mocked default returns null → no model metadata in the breakdown.
+    expect(out.modelInfo).toBeNull();
+    expect(out.lastTurnCostUsd).toBeUndefined();
   });
 
   it("forwards turnCount and messageCount", async () => {

--- a/src/lib/ai/inspect-context.test.ts
+++ b/src/lib/ai/inspect-context.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { ContextSnapshot } from "@/bot/context-snapshot";
+
+import type { ModelInfo } from "./models-dev.ts";
+
+import { breakdownFromSnapshot, estimateTokens } from "./inspect-context.ts";
+
+const baseSnap: ContextSnapshot = {
+  model: "anthropic/claude-sonnet-4.6",
+  context: {
+    userId: "u-1",
+    username: "rayhan",
+    nickname: "Rayhan",
+    channel: { id: "ch-1", name: "bot-testing" },
+    date: "Wednesday, April 15, 2026",
+  },
+  // 120 chars → 30 estimated tokens
+  systemPrompt: "a".repeat(120),
+  // JSON.stringify returns 2 chars → 1 token
+  tools: [],
+  // "user: hi" = 8 chars → 2 tokens
+  messages: [{ role: "user", content: "hi" }],
+  lastTurnUsage: {
+    inputTokens: 1000,
+    outputTokens: 200,
+    totalTokens: 1200,
+    subagentTokens: 0,
+    toolCallCount: 1,
+    stepCount: 2,
+  },
+  turnCount: 1,
+  updatedAt: "2026-04-15T12:00:00.000Z",
+};
+
+const modelInfo: ModelInfo = {
+  id: "claude-sonnet-4-6-20260301",
+  provider: "anthropic",
+  limit: { context: 200_000, output: 64_000 },
+  cost: { input: 3, output: 15 },
+};
+
+describe("estimateTokens", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("rounds up", () => {
+    expect(estimateTokens("a")).toBe(1);
+    expect(estimateTokens("aaaa")).toBe(1);
+    expect(estimateTokens("aaaaa")).toBe(2);
+  });
+});
+
+describe("breakdownFromSnapshot", () => {
+  it("builds categories and sums estimated input tokens", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const out = await breakdownFromSnapshot(baseSnap, fetchInfo);
+    expect(fetchInfo).toHaveBeenCalledWith("anthropic/claude-sonnet-4.6");
+    expect(out.categories.map((c) => c.label)).toEqual([
+      "System prompt",
+      "Tools",
+      "Conversation history",
+    ]);
+    const system = out.categories.find((c) => c.label === "System prompt");
+    const history = out.categories.find((c) => c.label === "Conversation history");
+    expect(system?.estimatedTokens).toBe(30);
+    expect(history?.estimatedTokens).toBe(2);
+    expect(out.estimatedInputTokens).toBe(
+      out.categories.reduce((sum, c) => sum + c.estimatedTokens, 0),
+    );
+  });
+
+  it("computes last-turn cost from real usage × pricing", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const out = await breakdownFromSnapshot(baseSnap, fetchInfo);
+    // 1000 input * $3/M = $0.003, 200 output * $15/M = $0.003, total = $0.006
+    expect(out.lastTurnCostUsd?.input).toBeCloseTo(0.003, 6);
+    expect(out.lastTurnCostUsd?.output).toBeCloseTo(0.003, 6);
+    expect(out.lastTurnCostUsd?.total).toBeCloseTo(0.006, 6);
+  });
+
+  it("omits cost when modelInfo is null", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(null);
+    const out = await breakdownFromSnapshot(baseSnap, fetchInfo);
+    expect(out.modelInfo).toBeNull();
+    expect(out.lastTurnCostUsd).toBeUndefined();
+  });
+
+  it("omits cost when both token counts are missing", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      lastTurnUsage: {
+        ...baseSnap.lastTurnUsage,
+        inputTokens: undefined,
+        outputTokens: undefined,
+      },
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    expect(out.lastTurnCostUsd).toBeUndefined();
+  });
+
+  it("computes cost with only input tokens present", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      lastTurnUsage: { ...baseSnap.lastTurnUsage, outputTokens: undefined },
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    expect(out.lastTurnCostUsd?.output).toBe(0);
+    expect(out.lastTurnCostUsd?.input).toBeCloseTo(0.003, 6);
+  });
+
+  it("forwards turnCount and messageCount", async () => {
+    const fetchInfo = vi.fn().mockResolvedValue(modelInfo);
+    const snap = {
+      ...baseSnap,
+      turnCount: 5,
+      messages: [
+        { role: "user" as const, content: "a" },
+        { role: "assistant" as const, content: "b" },
+        { role: "user" as const, content: "c" },
+      ],
+    };
+    const out = await breakdownFromSnapshot(snap, fetchInfo);
+    expect(out.turnCount).toBe(5);
+    expect(out.messageCount).toBe(3);
+  });
+});

--- a/src/lib/ai/inspect-context.ts
+++ b/src/lib/ai/inspect-context.ts
@@ -60,11 +60,7 @@ function toolItem(tool: ToolDefSnapshot): CategoryItem {
 
 function delegateItem(tool: ToolDefSnapshot, role: UserRole): CategoryItem {
   const domain = tool.name.slice(DELEGATE_PREFIX.length);
-  return {
-    name: tool.name,
-    estimatedTokens: estimateTokens(JSON.stringify(tool)),
-    skills: loadableSkillsFor(domain, role),
-  };
+  return { ...toolItem(tool), skills: loadableSkillsFor(domain, role) };
 }
 
 function partitionTools(tools: ToolDefSnapshot[]): {
@@ -94,20 +90,15 @@ function categoryFromTools(
   };
 }
 
-function renderMessagesText(snap: ContextSnapshot): string {
-  return snap.messages.map((m) => `${m.role}: ${m.content}`).join("\n");
-}
-
 function buildCategories(snap: ContextSnapshot, role: UserRole): CategoryBreakdown[] {
-  const systemPromptText = snap.systemPrompt;
-  const messagesText = renderMessagesText(snap);
+  const messagesText = snap.messages.map((m) => `${m.role}: ${m.content}`).join("\n");
   const { baseTools, delegates } = partitionTools(snap.tools);
 
   return [
     {
       label: "System prompt",
-      chars: systemPromptText.length,
-      estimatedTokens: estimateTokens(systemPromptText),
+      chars: snap.systemPrompt.length,
+      estimatedTokens: estimateTokens(snap.systemPrompt),
     },
     categoryFromTools("Tools", baseTools, toolItem),
     categoryFromTools("Delegate agents", delegates, (t) => delegateItem(t, role)),

--- a/src/lib/ai/inspect-context.ts
+++ b/src/lib/ai/inspect-context.ts
@@ -1,10 +1,48 @@
-import type { ContextSnapshot } from "@/bot/context-snapshot";
+import type { ContextSnapshot, ToolDefSnapshot } from "@/bot/context-snapshot";
 
-import type { CategoryBreakdown, ContextBreakdown, ModelInfo } from "./types.ts";
+import type { UserRole } from "./constants.ts";
+import type { SkillBundle } from "./skills/types.ts";
+import type { CategoryBreakdown, CategoryItem, ContextBreakdown, ModelInfo } from "./types.ts";
 
+import { AgentContext } from "./context.ts";
 import { fetchModelInfo } from "./models-dev.ts";
+import { SKILL_MANIFEST as DISCORD_SUBSKILLS } from "./skills/generated/domains/discord.ts";
+import { SKILL_MANIFEST as FIGMA_SUBSKILLS } from "./skills/generated/domains/figma.ts";
+import { SKILL_MANIFEST as GITHUB_SUBSKILLS } from "./skills/generated/domains/github.ts";
+import { SKILL_MANIFEST as LINEAR_SUBSKILLS } from "./skills/generated/domains/linear.ts";
+import { SKILL_MANIFEST as NOTION_SUBSKILLS } from "./skills/generated/domains/notion.ts";
+import { SKILL_MANIFEST as SENTRY_SUBSKILLS } from "./skills/generated/domains/sentry.ts";
+import { SkillRegistry } from "./skills/registry.ts";
 
-export type { CategoryBreakdown, ContextBreakdown, ModelInfo } from "./types.ts";
+export type { CategoryBreakdown, CategoryItem, ContextBreakdown, ModelInfo } from "./types.ts";
+
+const DELEGATE_PREFIX = "delegate_";
+
+/**
+ * Domain → subskill manifest. Subskills are loaded on demand inside delegate
+ * subagents (via load_skill); they don't enter the orchestrator's window. The
+ * inspector lists them under each delegate so organizers can see what's
+ * loadable without those tokens inflating the input estimate.
+ */
+const DOMAIN_SUBSKILLS: Record<string, Record<string, SkillBundle>> = {
+  linear: LINEAR_SUBSKILLS,
+  github: GITHUB_SUBSKILLS,
+  discord: DISCORD_SUBSKILLS,
+  notion: NOTION_SUBSKILLS,
+  figma: FIGMA_SUBSKILLS,
+  sentry: SENTRY_SUBSKILLS,
+};
+
+function loadableSkillsFor(domain: string, role: UserRole): CategoryItem[] | undefined {
+  const manifest = DOMAIN_SUBSKILLS[domain];
+  if (!manifest) return undefined;
+  const skills = new SkillRegistry(manifest).getAvailableSkills(role);
+  if (skills.length === 0) return undefined;
+  return skills.map((meta) => ({
+    name: meta.name,
+    estimatedTokens: estimateTokens(JSON.stringify(manifest[meta.name])),
+  }));
+}
 
 /** Chars/4 heuristic. Clearly labeled as estimated in the rendered output. */
 export function estimateTokens(text: string): number {
@@ -12,18 +50,58 @@ export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-function renderToolsText(snap: ContextSnapshot): string {
-  return JSON.stringify(snap.tools);
+/** Per-tool token estimate based on the JSON-serialized tool definition. */
+function toolItem(tool: ToolDefSnapshot): CategoryItem {
+  return {
+    name: tool.name,
+    estimatedTokens: estimateTokens(JSON.stringify(tool)),
+  };
+}
+
+function delegateItem(tool: ToolDefSnapshot, role: UserRole): CategoryItem {
+  const domain = tool.name.slice(DELEGATE_PREFIX.length);
+  return {
+    name: tool.name,
+    estimatedTokens: estimateTokens(JSON.stringify(tool)),
+    skills: loadableSkillsFor(domain, role),
+  };
+}
+
+function partitionTools(tools: ToolDefSnapshot[]): {
+  baseTools: ToolDefSnapshot[];
+  delegates: ToolDefSnapshot[];
+} {
+  const baseTools: ToolDefSnapshot[] = [];
+  const delegates: ToolDefSnapshot[] = [];
+  for (const t of tools) {
+    if (t.name.startsWith(DELEGATE_PREFIX)) delegates.push(t);
+    else baseTools.push(t);
+  }
+  return { baseTools, delegates };
+}
+
+function categoryFromTools(
+  label: string,
+  tools: ToolDefSnapshot[],
+  buildItem: (t: ToolDefSnapshot) => CategoryItem,
+): CategoryBreakdown {
+  const text = JSON.stringify(tools);
+  return {
+    label,
+    chars: text.length,
+    estimatedTokens: estimateTokens(text),
+    items: tools.map(buildItem),
+  };
 }
 
 function renderMessagesText(snap: ContextSnapshot): string {
   return snap.messages.map((m) => `${m.role}: ${m.content}`).join("\n");
 }
 
-function buildCategories(snap: ContextSnapshot): CategoryBreakdown[] {
+function buildCategories(snap: ContextSnapshot, role: UserRole): CategoryBreakdown[] {
   const systemPromptText = snap.systemPrompt;
-  const toolsText = renderToolsText(snap);
   const messagesText = renderMessagesText(snap);
+  const { baseTools, delegates } = partitionTools(snap.tools);
 
   return [
     {
@@ -31,11 +109,8 @@ function buildCategories(snap: ContextSnapshot): CategoryBreakdown[] {
       chars: systemPromptText.length,
       estimatedTokens: estimateTokens(systemPromptText),
     },
-    {
-      label: "Tools",
-      chars: toolsText.length,
-      estimatedTokens: estimateTokens(toolsText),
-    },
+    categoryFromTools("Tools", baseTools, toolItem),
+    categoryFromTools("Delegate agents", delegates, (t) => delegateItem(t, role)),
     {
       label: "Conversation history",
       chars: messagesText.length,
@@ -46,8 +121,8 @@ function buildCategories(snap: ContextSnapshot): CategoryBreakdown[] {
 
 function computeCost(
   modelInfo: ModelInfo | null,
-  usage: ContextSnapshot["lastTurnUsage"],
-): ContextBreakdown["lastTurnCostUsd"] | undefined {
+  usage: ContextSnapshot["totalUsage"],
+): ContextBreakdown["totalCostUsd"] | undefined {
   if (!modelInfo) return undefined;
   if (usage.inputTokens == null && usage.outputTokens == null) return undefined;
   const inputCost = ((usage.inputTokens ?? 0) * modelInfo.cost.input) / 1_000_000;
@@ -64,7 +139,8 @@ export async function breakdownFromSnapshot(
   fetchInfo: (id: string) => Promise<ModelInfo | null> = fetchModelInfo,
 ): Promise<ContextBreakdown> {
   const modelInfo = await fetchInfo(snap.model);
-  const categories = buildCategories(snap);
+  const role = AgentContext.fromJSON(snap.context).role;
+  const categories = buildCategories(snap, role);
   const estimatedInputTokens = categories.reduce((sum, c) => sum + c.estimatedTokens, 0);
 
   return {
@@ -72,9 +148,9 @@ export async function breakdownFromSnapshot(
     modelInfo,
     categories,
     estimatedInputTokens,
-    lastTurnUsage: snap.lastTurnUsage,
+    totalUsage: snap.totalUsage,
     turnCount: snap.turnCount,
     messageCount: snap.messages.length,
-    lastTurnCostUsd: computeCost(modelInfo, snap.lastTurnUsage),
+    totalCostUsd: computeCost(modelInfo, snap.totalUsage),
   };
 }

--- a/src/lib/ai/inspect-context.ts
+++ b/src/lib/ai/inspect-context.ts
@@ -1,0 +1,80 @@
+import type { ContextSnapshot } from "@/bot/context-snapshot";
+
+import type { CategoryBreakdown, ContextBreakdown, ModelInfo } from "./types.ts";
+
+import { fetchModelInfo } from "./models-dev.ts";
+
+export type { CategoryBreakdown, ContextBreakdown, ModelInfo } from "./types.ts";
+
+/** Chars/4 heuristic. Clearly labeled as estimated in the rendered output. */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+function renderToolsText(snap: ContextSnapshot): string {
+  return JSON.stringify(snap.tools);
+}
+
+function renderMessagesText(snap: ContextSnapshot): string {
+  return snap.messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+}
+
+function buildCategories(snap: ContextSnapshot): CategoryBreakdown[] {
+  const systemPromptText = snap.systemPrompt;
+  const toolsText = renderToolsText(snap);
+  const messagesText = renderMessagesText(snap);
+
+  return [
+    {
+      label: "System prompt",
+      chars: systemPromptText.length,
+      estimatedTokens: estimateTokens(systemPromptText),
+    },
+    {
+      label: "Tools",
+      chars: toolsText.length,
+      estimatedTokens: estimateTokens(toolsText),
+    },
+    {
+      label: "Conversation history",
+      chars: messagesText.length,
+      estimatedTokens: estimateTokens(messagesText),
+    },
+  ];
+}
+
+function computeCost(
+  modelInfo: ModelInfo | null,
+  usage: ContextSnapshot["lastTurnUsage"],
+): ContextBreakdown["lastTurnCostUsd"] | undefined {
+  if (!modelInfo) return undefined;
+  if (usage.inputTokens == null && usage.outputTokens == null) return undefined;
+  const inputCost = ((usage.inputTokens ?? 0) * modelInfo.cost.input) / 1_000_000;
+  const outputCost = ((usage.outputTokens ?? 0) * modelInfo.cost.output) / 1_000_000;
+  return {
+    input: inputCost,
+    output: outputCost,
+    total: inputCost + outputCost,
+  };
+}
+
+export async function breakdownFromSnapshot(
+  snap: ContextSnapshot,
+  fetchInfo: (id: string) => Promise<ModelInfo | null> = fetchModelInfo,
+): Promise<ContextBreakdown> {
+  const modelInfo = await fetchInfo(snap.model);
+  const categories = buildCategories(snap);
+  const estimatedInputTokens = categories.reduce((sum, c) => sum + c.estimatedTokens, 0);
+
+  return {
+    model: snap.model,
+    modelInfo,
+    categories,
+    estimatedInputTokens,
+    lastTurnUsage: snap.lastTurnUsage,
+    turnCount: snap.turnCount,
+    messageCount: snap.messages.length,
+    lastTurnCostUsd: computeCost(modelInfo, snap.lastTurnUsage),
+  };
+}

--- a/src/lib/ai/models-dev.test.ts
+++ b/src/lib/ai/models-dev.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { fetchCatalog, fetchModelInfo, matchModel } from "./models-dev.ts";
+
+const catalog = {
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-sonnet-4-6-20260301": {
+        id: "claude-sonnet-4-6-20260301",
+        release_date: "2026-03-01",
+        last_updated: "2026-03-01",
+        cost: { input: 3, output: 15 },
+        limit: { context: 200_000, output: 64_000 },
+      },
+      "claude-sonnet-4-6-20260115": {
+        id: "claude-sonnet-4-6-20260115",
+        release_date: "2026-01-15",
+        last_updated: "2026-01-15",
+        cost: { input: 3, output: 15 },
+        limit: { context: 200_000, output: 64_000 },
+      },
+      "claude-haiku-4-5-20260101": {
+        id: "claude-haiku-4-5-20260101",
+        release_date: "2026-01-01",
+        cost: { input: 1, output: 5 },
+        limit: { context: 200_000, output: 32_000 },
+      },
+    },
+  },
+  openai: {
+    id: "openai",
+    name: "OpenAI",
+    models: {
+      "gpt-5": {
+        id: "gpt-5",
+        cost: { input: 10, output: 30 },
+        limit: { context: 128_000, output: 32_000 },
+      },
+    },
+  },
+};
+
+describe("matchModel", () => {
+  it("returns null for identifiers without a slash", () => {
+    expect(matchModel(catalog, "claude-sonnet-4.6")).toBeNull();
+  });
+
+  it("returns null when provider is missing", () => {
+    expect(matchModel(catalog, "fakeco/whatever")).toBeNull();
+  });
+
+  it("returns null when no model matches", () => {
+    expect(matchModel(catalog, "anthropic/claude-sonnet-9.9")).toBeNull();
+  });
+
+  it("matches exact model ID after dot-to-dash normalization", () => {
+    const catalogWithExact = {
+      ...catalog,
+      anthropic: {
+        ...catalog.anthropic,
+        models: {
+          "claude-sonnet-4-6": {
+            id: "claude-sonnet-4-6",
+            cost: { input: 3, output: 15 },
+            limit: { context: 200_000, output: 64_000 },
+          },
+        },
+      },
+    };
+    const info = matchModel(catalogWithExact, "anthropic/claude-sonnet-4.6");
+    expect(info).toEqual({
+      id: "claude-sonnet-4-6",
+      provider: "anthropic",
+      cost: { input: 3, output: 15 },
+      limit: { context: 200_000, output: 64_000 },
+    });
+  });
+
+  it("picks the latest dated variant when prefix matches multiple", () => {
+    const info = matchModel(catalog, "anthropic/claude-sonnet-4.6");
+    expect(info?.id).toBe("claude-sonnet-4-6-20260301");
+  });
+
+  it("returns null when the matched entry is missing cost or limit", () => {
+    const bad = {
+      anthropic: {
+        models: {
+          "claude-sonnet-4-6-x": { id: "claude-sonnet-4-6-x" },
+        },
+      },
+    };
+    expect(matchModel(bad, "anthropic/claude-sonnet-4.6")).toBeNull();
+  });
+
+  it("matches haiku prefix for a different gateway id", () => {
+    const info = matchModel(catalog, "anthropic/claude-haiku-4.5");
+    expect(info?.id).toBe("claude-haiku-4-5-20260101");
+  });
+
+  it("handles the openai namespace as a second provider", () => {
+    const info = matchModel(catalog, "openai/gpt-5");
+    expect(info?.provider).toBe("openai");
+    expect(info?.limit.context).toBe(128_000);
+  });
+
+  it("rejects a provider id that ends with a slash", () => {
+    expect(matchModel(catalog, "anthropic/")).toBeNull();
+  });
+
+  it("rejects a bare slash", () => {
+    expect(matchModel(catalog, "/")).toBeNull();
+  });
+});
+
+describe("fetchCatalog", () => {
+  it("returns the parsed body on 200", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => catalog,
+    });
+    const out = await fetchCatalog(fetchImpl as unknown as typeof fetch);
+    expect(out).toEqual(catalog);
+  });
+
+  it("returns null on non-2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    expect(await fetchCatalog(fetchImpl as unknown as typeof fetch)).toBeNull();
+  });
+
+  it("returns null on fetch throw", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    expect(await fetchCatalog(fetchImpl as unknown as typeof fetch)).toBeNull();
+  });
+});
+
+describe("fetchModelInfo", () => {
+  it("returns null when catalog fetch fails", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    expect(
+      await fetchModelInfo("anthropic/claude-sonnet-4.6", fetchImpl as unknown as typeof fetch),
+    ).toBeNull();
+  });
+
+  it("resolves a known model", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => catalog });
+    const info = await fetchModelInfo(
+      "anthropic/claude-sonnet-4.6",
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(info?.id).toBe("claude-sonnet-4-6-20260301");
+  });
+});

--- a/src/lib/ai/models-dev.test.ts
+++ b/src/lib/ai/models-dev.test.ts
@@ -124,6 +124,14 @@ describe("fetchCatalog", () => {
     expect(out).toEqual(catalog);
   });
 
+  it("passes timeout + no-store cache options", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => catalog });
+    await fetchCatalog(fetchImpl as unknown as typeof fetch);
+    const [, opts] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(opts.cache).toBe("no-store");
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it("returns null on non-2xx", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     expect(await fetchCatalog(fetchImpl as unknown as typeof fetch)).toBeNull();
@@ -132,6 +140,16 @@ describe("fetchCatalog", () => {
   it("returns null on fetch throw", async () => {
     const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
     expect(await fetchCatalog(fetchImpl as unknown as typeof fetch)).toBeNull();
+  });
+
+  it("uses the global fetch when no implementation is provided", async () => {
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("no network"));
+    expect(await fetchCatalog()).toBeNull();
+    expect(globalFetch).toHaveBeenCalledWith(
+      "https://models.dev/api.json",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    globalFetch.mockRestore();
   });
 });
 
@@ -150,5 +168,58 @@ describe("fetchModelInfo", () => {
       fetchImpl as unknown as typeof fetch,
     );
     expect(info?.id).toBe("claude-sonnet-4-6-20260301");
+  });
+
+  it("uses the global fetch when no implementation is provided", async () => {
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("no network"));
+    expect(await fetchModelInfo("anthropic/claude-sonnet-4.6")).toBeNull();
+    globalFetch.mockRestore();
+  });
+});
+
+describe("matchModel: pickLatest date fallbacks", () => {
+  it("falls back to release_date when last_updated is missing", () => {
+    const mixedCatalog = {
+      anthropic: {
+        models: {
+          "claude-x-20250101": {
+            id: "claude-x-20250101",
+            release_date: "2025-01-01",
+            cost: { input: 1, output: 2 },
+            limit: { context: 10, output: 20 },
+          },
+          "claude-x-20260301": {
+            id: "claude-x-20260301",
+            release_date: "2026-03-01",
+            cost: { input: 1, output: 2 },
+            limit: { context: 10, output: 20 },
+          },
+        },
+      },
+    };
+    const info = matchModel(mixedCatalog, "anthropic/claude-x");
+    expect(info?.id).toBe("claude-x-20260301");
+  });
+
+  it("handles entries with neither last_updated nor release_date", () => {
+    const dateless = {
+      anthropic: {
+        models: {
+          "claude-y-a": {
+            id: "claude-y-a",
+            cost: { input: 1, output: 2 },
+            limit: { context: 10, output: 20 },
+          },
+          "claude-y-b": {
+            id: "claude-y-b",
+            cost: { input: 1, output: 2 },
+            limit: { context: 10, output: 20 },
+          },
+        },
+      },
+    };
+    const info = matchModel(dateless, "anthropic/claude-y");
+    // With empty strings both compare equal — sort is stable, first one wins.
+    expect(info?.id).toBe("claude-y-a");
   });
 });

--- a/src/lib/ai/models-dev.ts
+++ b/src/lib/ai/models-dev.ts
@@ -1,0 +1,110 @@
+import { log } from "evlog";
+
+import type { ModelInfo } from "./types.ts";
+
+export type { ModelInfo } from "./types.ts";
+
+const CATALOG_URL = "https://models.dev/api.json";
+
+interface RawModelEntry {
+  id: string;
+  name?: string;
+  release_date?: string;
+  last_updated?: string;
+  cost?: { input: number; output: number };
+  limit?: { context: number; output: number };
+}
+
+interface RawProviderEntry {
+  id?: string;
+  name?: string;
+  models?: Record<string, RawModelEntry>;
+}
+
+type RawCatalog = Record<string, RawProviderEntry>;
+
+/**
+ * Split "anthropic/claude-sonnet-4.6" into provider + model key. Returns null
+ * if the identifier doesn't follow `provider/model-name`.
+ */
+function parseGatewayModel(gatewayModelId: string): { provider: string; key: string } | null {
+  const slash = gatewayModelId.indexOf("/");
+  if (slash <= 0 || slash === gatewayModelId.length - 1) return null;
+  return {
+    provider: gatewayModelId.slice(0, slash),
+    key: gatewayModelId.slice(slash + 1),
+  };
+}
+
+/** Normalize dots → dashes so "claude-sonnet-4.6" matches models.dev "claude-sonnet-4-6". */
+function normalize(key: string): string {
+  return key.replaceAll(".", "-");
+}
+
+function pickLatest(candidates: RawModelEntry[]): RawModelEntry | null {
+  if (candidates.length === 0) return null;
+  return [...candidates].sort((a, b) => {
+    const left = a.last_updated ?? a.release_date ?? "";
+    const right = b.last_updated ?? b.release_date ?? "";
+    return right.localeCompare(left);
+  })[0];
+}
+
+/**
+ * Locate the models.dev entry that best matches a gateway model identifier.
+ * Exported for unit testing; prefer `fetchModelInfo` in production paths.
+ */
+export function matchModel(catalog: RawCatalog, gatewayModelId: string): ModelInfo | null {
+  const parsed = parseGatewayModel(gatewayModelId);
+  if (!parsed) return null;
+  const provider = catalog[parsed.provider];
+  if (!provider?.models) return null;
+
+  const normalizedKey = normalize(parsed.key);
+  const entries = Object.values(provider.models);
+
+  // Exact id match first, then prefix match (catches dated variants like
+  // claude-sonnet-4-5 → claude-sonnet-4-5-20250929).
+  const exact = entries.filter((m) => m.id === normalizedKey);
+  const prefix =
+    exact.length > 0
+      ? exact
+      : entries.filter((m) => m.id.startsWith(`${normalizedKey}-`) || m.id === normalizedKey);
+
+  const picked = pickLatest(prefix);
+  if (!picked?.limit || !picked.cost) return null;
+
+  return {
+    id: picked.id,
+    provider: parsed.provider,
+    limit: picked.limit,
+    cost: picked.cost,
+  };
+}
+
+export async function fetchCatalog(fetchImpl: typeof fetch = fetch): Promise<RawCatalog | null> {
+  try {
+    const res = await fetchImpl(CATALOG_URL);
+    if (!res.ok) {
+      log.warn("models-dev", `fetch ${CATALOG_URL} returned ${res.status}`);
+      return null;
+    }
+    return (await res.json()) as RawCatalog;
+  } catch (err) {
+    log.warn("models-dev", `fetch failed: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Look up context window + pricing for a gateway model identifier. Returns
+ * null if the catalog can't be fetched or no matching entry exists.
+ */
+export async function fetchModelInfo(
+  gatewayModelId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ModelInfo | null> {
+  const catalog = await fetchCatalog(fetchImpl);
+  if (!catalog) return null;
+  return matchModel(catalog, gatewayModelId);
+}

--- a/src/lib/ai/models-dev.ts
+++ b/src/lib/ai/models-dev.ts
@@ -82,9 +82,14 @@ export function matchModel(catalog: RawCatalog, gatewayModelId: string): ModelIn
   };
 }
 
+const CATALOG_FETCH_TIMEOUT_MS = 15_000;
+
 export async function fetchCatalog(fetchImpl: typeof fetch = fetch): Promise<RawCatalog | null> {
   try {
-    const res = await fetchImpl(CATALOG_URL);
+    const res = await fetchImpl(CATALOG_URL, {
+      signal: AbortSignal.timeout(CATALOG_FETCH_TIMEOUT_MS),
+      cache: "no-store",
+    });
     if (!res.ok) {
       log.warn("models-dev", `fetch ${CATALOG_URL} returned ${res.status}`);
       return null;

--- a/src/lib/ai/orchestrator.test.ts
+++ b/src/lib/ai/orchestrator.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/test/fixtures";
 
 import { AgentContext } from "./context.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
 
 // --- Boundary mocks: tools that hit external APIs or initialize SDK clients ---
 
@@ -83,7 +84,7 @@ describe("createOrchestrator", () => {
   });
 
   async function drain(ctx: AgentContext) {
-    const agent = createOrchestrator(ctx, { totalTokens: 0, toolCallCount: 0 });
+    const agent = createOrchestrator(ctx, new TurnUsageTracker());
     const result = await agent.stream({ prompt: "say hi" });
     const reader = result.toUIMessageStream().getReader();
     while (!(await reader.read()).done);

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,62 +1,38 @@
 import { ToolLoopAgent, type ToolSet } from "ai";
 
+import type { UserRole } from "./constants.ts";
 import type { SubagentMetrics } from "./types.ts";
 
+import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
 import { AgentContext } from "./context.ts";
 import { buildDelegationTools } from "./delegates.ts";
 import { documentation } from "./tools/docs/index.ts";
 import { scheduleTask, listScheduledTasks, cancelTask } from "./tools/schedule/index.ts";
 import { currentTime } from "./tools/schedule/time.ts";
 
-const SYSTEM_PROMPT = `<identity>
-You are a helpful assistant for Purdue Hackers, embedded in Discord. You speak as "I" and keep responses concise and actionable.
-</identity>
+export { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
 
-<date>
-Today is {{DATE}}.
-</date>
-
-<tools>
-You have direct access to these tools:
-
-- **currentTime** — get the current timestamp.
-- **documentation** — look up Purdue Hackers info (events, projects, history, culture, docs). Prefer this over notion for general informational questions. Relay the tool's answer directly without paraphrasing.
-- **scheduleTask / listScheduledTasks / cancelTask** — schedule one-time or recurring messages and agent prompts. Use action_type "message" for static content, "agent" for dynamic content. Always confirm the schedule with the user before creating it. Default the channel and user to the execution context. Recurring tasks use 5-field cron (minute hour day month weekday).
-- **delegate_linear / delegate_github / delegate_discord / delegate_notion** — forward a task to a focused domain subagent. Forward the user's wording verbatim; the subagent needs the exact phrasing. Wait for the subagent's final result.
-
-Only delegate when the user's request clearly requires a domain-specific action (e.g. creating a channel, filing an issue, querying a database). If the message is casual, ambiguous, or conversational, respond directly — do not delegate.
-
-Plan multi-step requests before starting. For requests that span multiple domains, delegate each in turn.
-</tools>
-
-<tone>
-- Concise and direct. No preamble, no filler.
-- Never open with "Great question!", "Sure!", "Certainly!", or similar. Start with the answer or action.
-- Warm but straightforward. First person: "I found...", "Here's...", "Done."
-- Discord has a 2000-character limit. Keep responses well under it.
-- For simple confirmations: one sentence. For data: clean bullet list.
-</tone>
-
-<formatting>
-- Use Discord-compatible Markdown. Bullet lists use -.
-- Include URLs when referencing entities. Never expose raw UUIDs.
-- Never echo API keys, tokens, or secrets.
-</formatting>`;
-
-export function createOrchestrator(context: AgentContext, metrics: SubagentMetrics) {
-  const instructions = context.buildInstructions(SYSTEM_PROMPT);
-
-  const tools: ToolSet = {
+/**
+ * Build the exact orchestrator tool surface for a given role. Exported so the
+ * context inspector can snapshot the same tool set the orchestrator runs with.
+ */
+export function getOrchestratorTools(role: UserRole, metrics: SubagentMetrics): ToolSet {
+  return {
     currentTime,
     documentation,
     scheduleTask,
     listScheduledTasks,
     cancelTask,
-    ...buildDelegationTools(context.role, metrics),
+    ...buildDelegationTools(role, metrics),
   };
+}
+
+export function createOrchestrator(context: AgentContext, metrics: SubagentMetrics) {
+  const instructions = context.buildInstructions(SYSTEM_PROMPT);
+  const tools = getOrchestratorTools(context.role, metrics);
 
   return new ToolLoopAgent({
-    model: "anthropic/claude-sonnet-4.6",
+    model: ORCHESTRATOR_MODEL,
     instructions,
     tools,
     experimental_telemetry: {

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,7 +1,7 @@
 import { ToolLoopAgent, type ToolSet } from "ai";
 
 import type { UserRole } from "./constants.ts";
-import type { SubagentMetrics } from "./types.ts";
+import type { TurnUsageTracker } from "./turn-usage.ts";
 
 import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
 import { AgentContext } from "./context.ts";
@@ -16,20 +16,20 @@ export { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
  * Build the exact orchestrator tool surface for a given role. Exported so the
  * context inspector can snapshot the same tool set the orchestrator runs with.
  */
-export function getOrchestratorTools(role: UserRole, metrics: SubagentMetrics): ToolSet {
+export function getOrchestratorTools(role: UserRole, tracker: TurnUsageTracker): ToolSet {
   return {
     currentTime,
     documentation,
     scheduleTask,
     listScheduledTasks,
     cancelTask,
-    ...buildDelegationTools(role, metrics),
+    ...buildDelegationTools(role, tracker),
   };
 }
 
-export function createOrchestrator(context: AgentContext, metrics: SubagentMetrics) {
+export function createOrchestrator(context: AgentContext, tracker: TurnUsageTracker) {
   const instructions = context.buildInstructions(SYSTEM_PROMPT);
-  const tools = getOrchestratorTools(context.role, metrics);
+  const tools = getOrchestratorTools(context.role, tracker);
 
   return new ToolLoopAgent({
     model: ORCHESTRATOR_MODEL,

--- a/src/lib/ai/snapshot.test.ts
+++ b/src/lib/ai/snapshot.test.ts
@@ -64,7 +64,7 @@ describe("buildContextSnapshot", () => {
   it("captures the orchestrator model identifier", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [{ role: "user", content: "hi" }],
       totalUsage: usage,
       turnCount: 1,
@@ -75,7 +75,7 @@ describe("buildContextSnapshot", () => {
   it("includes the fully assembled system prompt (with context block)", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [{ role: "user", content: "hi" }],
       totalUsage: usage,
       turnCount: 1,
@@ -89,7 +89,7 @@ describe("buildContextSnapshot", () => {
   it("serializes the orchestrator tool surface", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,
@@ -107,7 +107,7 @@ describe("buildContextSnapshot", () => {
   it("converts zod input schemas to JSON Schema", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,
@@ -128,7 +128,7 @@ describe("buildContextSnapshot", () => {
       { role: "assistant" as const, content: "hello" },
     ];
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: msgs,
       totalUsage: usage,
       turnCount: 7,
@@ -141,7 +141,7 @@ describe("buildContextSnapshot", () => {
   it("stamps updatedAt with an ISO timestamp", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,
@@ -154,7 +154,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
   it("passes through raw JSON-schema tools verbatim (non-Zod)", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,
@@ -169,7 +169,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
   it("uses an empty object when the tool has no inputSchema", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,
@@ -181,7 +181,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
   it("returns an empty object when toJSONSchema rejects a zod-like shape", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"));
     const snap = buildContextSnapshot({
-      agentCtx: ctx,
+      context: ctx.toJSON(),
       messages: [],
       totalUsage: usage,
       turnCount: 1,

--- a/src/lib/ai/snapshot.test.ts
+++ b/src/lib/ai/snapshot.test.ts
@@ -7,6 +7,22 @@ import type { TurnUsage } from "./types.ts";
 import { messagePacket } from "../test/fixtures/index.ts";
 import { AgentContext } from "./context.ts";
 
+const rawJsonSchemaTool = {
+  description: "Raw JSON-schema tool.",
+  inputSchema: { type: "object", properties: { kind: { type: "string" } } },
+};
+
+const toolWithoutSchema = {
+  description: "Opaque provider tool.",
+  inputSchema: undefined,
+};
+
+// A fake Zod-looking schema that toJSONSchema will reject at runtime.
+const malformedZodLike = {
+  description: "Broken zod tool.",
+  inputSchema: { _zod: { notAValidSchema: true } },
+};
+
 vi.mock("./orchestrator", () => ({
   getOrchestratorTools: () => ({
     currentTime: tool({
@@ -26,6 +42,9 @@ vi.mock("./orchestrator", () => ({
       inputSchema: z.object({ when: z.string() }),
       execute: async () => "",
     }),
+    rawJsonSchemaTool,
+    toolWithoutSchema,
+    malformedZodLike,
   }),
 }));
 
@@ -128,5 +147,46 @@ describe("buildContextSnapshot", () => {
       turnCount: 1,
     });
     expect(snap.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("buildContextSnapshot: tool schema serialization", () => {
+  it("passes through raw JSON-schema tools verbatim (non-Zod)", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    const raw = snap.tools.find((t) => t.name === "rawJsonSchemaTool");
+    expect(raw?.inputSchema).toEqual({
+      type: "object",
+      properties: { kind: { type: "string" } },
+    });
+  });
+
+  it("uses an empty object when the tool has no inputSchema", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    const opaque = snap.tools.find((t) => t.name === "toolWithoutSchema");
+    expect(opaque?.inputSchema).toEqual({});
+  });
+
+  it("returns an empty object when toJSONSchema rejects a zod-like shape", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    const malformed = snap.tools.find((t) => t.name === "malformedZodLike");
+    expect(malformed?.inputSchema).toEqual({});
   });
 });

--- a/src/lib/ai/snapshot.test.ts
+++ b/src/lib/ai/snapshot.test.ts
@@ -66,7 +66,7 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [{ role: "user", content: "hi" }],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     expect(snap.model).toMatch(/^anthropic\//);
@@ -77,7 +77,7 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [{ role: "user", content: "hi" }],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     expect(snap.systemPrompt).toContain("<execution_context>");
@@ -91,7 +91,7 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     const names = snap.tools.map((t) => t.name);
@@ -109,7 +109,7 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     const currentTime = snap.tools.find((t) => t.name === "currentTime");
@@ -130,11 +130,11 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: msgs,
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 7,
     });
     expect(snap.messages).toEqual(msgs);
-    expect(snap.lastTurnUsage).toEqual(usage);
+    expect(snap.totalUsage).toEqual(usage);
     expect(snap.turnCount).toBe(7);
   });
 
@@ -143,7 +143,7 @@ describe("buildContextSnapshot", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     expect(snap.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -156,7 +156,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     const raw = snap.tools.find((t) => t.name === "rawJsonSchemaTool");
@@ -171,7 +171,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     const opaque = snap.tools.find((t) => t.name === "toolWithoutSchema");
@@ -183,7 +183,7 @@ describe("buildContextSnapshot: tool schema serialization", () => {
     const snap = buildContextSnapshot({
       agentCtx: ctx,
       messages: [],
-      lastTurnUsage: usage,
+      totalUsage: usage,
       turnCount: 1,
     });
     const malformed = snap.tools.find((t) => t.name === "malformedZodLike");

--- a/src/lib/ai/snapshot.test.ts
+++ b/src/lib/ai/snapshot.test.ts
@@ -1,0 +1,132 @@
+import { tool } from "ai";
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+
+import type { TurnUsage } from "./types.ts";
+
+import { messagePacket } from "../test/fixtures/index.ts";
+import { AgentContext } from "./context.ts";
+
+vi.mock("./orchestrator", () => ({
+  getOrchestratorTools: () => ({
+    currentTime: tool({
+      description: "Get the current time.",
+      inputSchema: z.object({
+        timezone: z.string().optional().describe("IANA timezone."),
+      }),
+      execute: async () => "now",
+    }),
+    documentation: tool({
+      description: "Look up documentation.",
+      inputSchema: z.object({ query: z.string() }),
+      execute: async () => "",
+    }),
+    scheduleTask: tool({
+      description: "Schedule a task.",
+      inputSchema: z.object({ when: z.string() }),
+      execute: async () => "",
+    }),
+  }),
+}));
+
+// Import after vi.mock so the mock is active.
+const { buildContextSnapshot } = await import("./snapshot.ts");
+
+const usage: TurnUsage = {
+  inputTokens: 100,
+  outputTokens: 20,
+  totalTokens: 120,
+  subagentTokens: 0,
+  toolCallCount: 1,
+  stepCount: 1,
+};
+
+describe("buildContextSnapshot", () => {
+  it("captures the orchestrator model identifier", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [{ role: "user", content: "hi" }],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    expect(snap.model).toMatch(/^anthropic\//);
+  });
+
+  it("includes the fully assembled system prompt (with context block)", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [{ role: "user", content: "hi" }],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    expect(snap.systemPrompt).toContain("<execution_context>");
+    expect(snap.systemPrompt).toContain("<identity>");
+    // Date placeholder was substituted
+    expect(snap.systemPrompt).not.toContain("{{DATE}}");
+  });
+
+  it("serializes the orchestrator tool surface", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    const names = snap.tools.map((t) => t.name);
+    expect(names).toContain("currentTime");
+    expect(names).toContain("documentation");
+    expect(names).toContain("scheduleTask");
+    for (const tool of snap.tools) {
+      expect(typeof tool.description).toBe("string");
+      expect(tool.inputSchema).toBeDefined();
+    }
+  });
+
+  it("converts zod input schemas to JSON Schema", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    const currentTime = snap.tools.find((t) => t.name === "currentTime");
+    const schema = currentTime?.inputSchema as {
+      type?: string;
+      properties?: Record<string, unknown>;
+    };
+    expect(schema?.type).toBe("object");
+    expect(schema?.properties).toBeDefined();
+  });
+
+  it("preserves messages and usage verbatim", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const msgs = [
+      { role: "user" as const, content: "hi" },
+      { role: "assistant" as const, content: "hello" },
+    ];
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: msgs,
+      lastTurnUsage: usage,
+      turnCount: 7,
+    });
+    expect(snap.messages).toEqual(msgs);
+    expect(snap.lastTurnUsage).toEqual(usage);
+    expect(snap.turnCount).toBe(7);
+  });
+
+  it("stamps updatedAt with an ISO timestamp", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const snap = buildContextSnapshot({
+      agentCtx: ctx,
+      messages: [],
+      lastTurnUsage: usage,
+      turnCount: 1,
+    });
+    expect(snap.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/src/lib/ai/snapshot.ts
+++ b/src/lib/ai/snapshot.ts
@@ -33,14 +33,17 @@ function describeSchema(schema: unknown): unknown {
  * Build a snapshot of the exact context the orchestrator assembled for this
  * turn. Uses the same code paths the orchestrator runs with (getOrchestratorTools,
  * AgentContext.buildInstructions) so the snapshot is the orchestrator's view.
+ *
+ * `totalUsage` is the conversation-wide cumulative spend; the workflow accumulates
+ * each turn's usage into a running total before calling this.
  */
 export function buildContextSnapshot(args: {
   agentCtx: AgentContext;
   messages: ChatMessage[];
-  lastTurnUsage: TurnUsage;
+  totalUsage: TurnUsage;
   turnCount: number;
 }): ContextSnapshot {
-  const { agentCtx, messages, lastTurnUsage, turnCount } = args;
+  const { agentCtx, messages, totalUsage, turnCount } = args;
 
   // The tracker is write-only here — the snapshot only needs the tool set's
   // shape, not its accumulated counts.
@@ -61,7 +64,7 @@ export function buildContextSnapshot(args: {
     systemPrompt: agentCtx.buildInstructions(SYSTEM_PROMPT),
     tools,
     messages,
-    lastTurnUsage,
+    totalUsage,
     turnCount,
     updatedAt: new Date().toISOString(),
   };

--- a/src/lib/ai/snapshot.ts
+++ b/src/lib/ai/snapshot.ts
@@ -2,10 +2,10 @@ import { toJSONSchema } from "zod";
 
 import type { ContextSnapshot, ToolDefSnapshot } from "@/bot/context-snapshot";
 
-import type { AgentContext } from "./context.ts";
-import type { ChatMessage, TurnUsage } from "./types.ts";
+import type { ChatMessage, SerializedAgentContext, TurnUsage } from "./types.ts";
 
 import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
+import { AgentContext } from "./context.ts";
 import { getOrchestratorTools } from "./orchestrator.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
 
@@ -38,12 +38,13 @@ function describeSchema(schema: unknown): unknown {
  * each turn's usage into a running total before calling this.
  */
 export function buildContextSnapshot(args: {
-  agentCtx: AgentContext;
+  context: SerializedAgentContext;
   messages: ChatMessage[];
   totalUsage: TurnUsage;
   turnCount: number;
 }): ContextSnapshot {
-  const { agentCtx, messages, totalUsage, turnCount } = args;
+  const { context, messages, totalUsage, turnCount } = args;
+  const agentCtx = AgentContext.fromJSON(context);
 
   // The tracker is write-only here — the snapshot only needs the tool set's
   // shape, not its accumulated counts.
@@ -60,7 +61,7 @@ export function buildContextSnapshot(args: {
 
   return {
     model: ORCHESTRATOR_MODEL,
-    context: agentCtx.toJSON(),
+    context,
     systemPrompt: agentCtx.buildInstructions(SYSTEM_PROMPT),
     tools,
     messages,

--- a/src/lib/ai/snapshot.ts
+++ b/src/lib/ai/snapshot.ts
@@ -3,10 +3,11 @@ import { toJSONSchema } from "zod";
 import type { ContextSnapshot, ToolDefSnapshot } from "@/bot/context-snapshot";
 
 import type { AgentContext } from "./context.ts";
-import type { ChatMessage, SubagentMetrics, TurnUsage } from "./types.ts";
+import type { ChatMessage, TurnUsage } from "./types.ts";
 
 import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
 import { getOrchestratorTools } from "./orchestrator.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
 
 interface MinimalTool {
   description?: string;
@@ -41,10 +42,9 @@ export function buildContextSnapshot(args: {
 }): ContextSnapshot {
   const { agentCtx, messages, lastTurnUsage, turnCount } = args;
 
-  // Metrics accumulator is write-only for the orchestrator — a dummy is fine
-  // here since we only need the tool set's shape.
-  const metrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
-  const toolSet = getOrchestratorTools(agentCtx.role, metrics);
+  // The tracker is write-only here — the snapshot only needs the tool set's
+  // shape, not its accumulated counts.
+  const toolSet = getOrchestratorTools(agentCtx.role, new TurnUsageTracker());
 
   const tools: ToolDefSnapshot[] = Object.entries(toolSet).map(([name, tool]) => {
     const t = tool as MinimalTool;

--- a/src/lib/ai/snapshot.ts
+++ b/src/lib/ai/snapshot.ts
@@ -1,0 +1,68 @@
+import { toJSONSchema } from "zod";
+
+import type { ContextSnapshot, ToolDefSnapshot } from "@/bot/context-snapshot";
+
+import type { AgentContext } from "./context.ts";
+import type { ChatMessage, SubagentMetrics, TurnUsage } from "./types.ts";
+
+import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
+import { getOrchestratorTools } from "./orchestrator.ts";
+
+interface MinimalTool {
+  description?: string;
+  inputSchema?: unknown;
+}
+
+function describeSchema(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return {};
+  // Zod v4 schemas carry a _zod marker; use the runtime-safe cast rather than
+  // calling `instanceof ZodType` because the tool may come from any provider.
+  const maybeZod = schema as { _zod?: unknown };
+  if (maybeZod._zod !== undefined) {
+    try {
+      return toJSONSchema(schema as Parameters<typeof toJSONSchema>[0]);
+    } catch {
+      return {};
+    }
+  }
+  return schema;
+}
+
+/**
+ * Build a snapshot of the exact context the orchestrator assembled for this
+ * turn. Uses the same code paths the orchestrator runs with (getOrchestratorTools,
+ * AgentContext.buildInstructions) so the snapshot is the orchestrator's view.
+ */
+export function buildContextSnapshot(args: {
+  agentCtx: AgentContext;
+  messages: ChatMessage[];
+  lastTurnUsage: TurnUsage;
+  turnCount: number;
+}): ContextSnapshot {
+  const { agentCtx, messages, lastTurnUsage, turnCount } = args;
+
+  // Metrics accumulator is write-only for the orchestrator — a dummy is fine
+  // here since we only need the tool set's shape.
+  const metrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
+  const toolSet = getOrchestratorTools(agentCtx.role, metrics);
+
+  const tools: ToolDefSnapshot[] = Object.entries(toolSet).map(([name, tool]) => {
+    const t = tool as MinimalTool;
+    return {
+      name,
+      description: t.description ?? "",
+      inputSchema: describeSchema(t.inputSchema),
+    };
+  });
+
+  return {
+    model: ORCHESTRATOR_MODEL,
+    context: agentCtx.toJSON(),
+    systemPrompt: agentCtx.buildInstructions(SYSTEM_PROMPT),
+    tools,
+    messages,
+    lastTurnUsage,
+    turnCount,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -5,17 +5,12 @@ import { log } from "evlog";
 
 import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
 
-import type {
-  Attachment,
-  ChatMessage,
-  SerializedAgentContext,
-  SubagentMetrics,
-  TurnUsage,
-} from "./types.ts";
+import type { Attachment, ChatMessage, SerializedAgentContext, TurnUsage } from "./types.ts";
 
 import { AgentContext } from "./context.ts";
 import { MessageRenderer } from "./message-renderer.ts";
 import { createOrchestrator } from "./orchestrator.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
 
 export { MessageRenderer } from "./message-renderer.ts";
 
@@ -75,8 +70,8 @@ export async function streamTurn(
   taskId?: string,
 ): Promise<{ text: string; usage: TurnUsage }> {
   const agentCtx = AgentContext.fromJSON(serializedContext);
-  const subagentMetrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
-  const agent = createOrchestrator(agentCtx, subagentMetrics);
+  const tracker = new TurnUsageTracker();
+  const agent = createOrchestrator(agentCtx, tracker);
   const renderer = new MessageRenderer(discord, channelId, { taskId });
 
   await renderer.init();
@@ -112,34 +107,20 @@ export async function streamTurn(
   }
 
   const elapsedMs = Date.now() - startTime;
-  let usage: TurnUsage = {
-    subagentTokens: subagentMetrics.totalTokens,
-    toolCallCount: subagentMetrics.toolCallCount,
-    stepCount: 0,
-  };
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
-    const orchestratorToolCalls = steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
-    const totalTokens = (totalUsage.totalTokens ?? 0) + subagentMetrics.totalTokens;
-    const toolCallCount = orchestratorToolCalls + subagentMetrics.toolCallCount;
-    usage = {
-      inputTokens: totalUsage.inputTokens,
-      outputTokens: totalUsage.outputTokens,
-      totalTokens,
-      subagentTokens: subagentMetrics.totalTokens,
-      toolCallCount,
-      stepCount: steps.length,
-    };
+    tracker.recordOrchestrator({ usage: totalUsage, steps });
+
     await renderer.finalize({
       elapsedMs,
-      totalTokens,
-      toolCallCount,
-      stepCount: steps.length,
+      totalTokens: tracker.totalTokens,
+      toolCallCount: tracker.totalToolCalls,
+      stepCount: tracker.totalSteps,
     });
 
-    recordDistribution("ai.turn.tokens", totalTokens);
-    recordDistribution("ai.turn.tool_calls", toolCallCount);
-    recordDistribution("ai.turn.steps", steps.length);
+    recordDistribution("ai.turn.tokens", tracker.totalTokens);
+    recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls);
+    recordDistribution("ai.turn.steps", tracker.totalSteps);
   } catch (err) {
     log.warn("streaming", `Failed to collect metadata: ${String(err)}`);
     countMetric("ai.turn.metadata_error");
@@ -156,5 +137,5 @@ export async function streamTurn(
 
   log.info("streaming", `Turn complete, ${renderer.content.length} chars, ${elapsedMs}ms`);
 
-  return { text: renderer.content, usage };
+  return { text: renderer.content, usage: tracker.toTurnUsage() };
 }

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -5,7 +5,13 @@ import { log } from "evlog";
 
 import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
 
-import type { Attachment, ChatMessage, SerializedAgentContext, SubagentMetrics } from "./types.ts";
+import type {
+  Attachment,
+  ChatMessage,
+  SerializedAgentContext,
+  SubagentMetrics,
+  TurnUsage,
+} from "./types.ts";
 
 import { AgentContext } from "./context.ts";
 import { MessageRenderer } from "./message-renderer.ts";
@@ -67,7 +73,7 @@ export async function streamTurn(
   messages: ChatMessage[],
   serializedContext: SerializedAgentContext,
   taskId?: string,
-): Promise<{ text: string }> {
+): Promise<{ text: string; usage: TurnUsage }> {
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const subagentMetrics: SubagentMetrics = { totalTokens: 0, toolCallCount: 0 };
   const agent = createOrchestrator(agentCtx, subagentMetrics);
@@ -106,11 +112,24 @@ export async function streamTurn(
   }
 
   const elapsedMs = Date.now() - startTime;
+  let usage: TurnUsage = {
+    subagentTokens: subagentMetrics.totalTokens,
+    toolCallCount: subagentMetrics.toolCallCount,
+    stepCount: 0,
+  };
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
     const orchestratorToolCalls = steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
     const totalTokens = (totalUsage.totalTokens ?? 0) + subagentMetrics.totalTokens;
     const toolCallCount = orchestratorToolCalls + subagentMetrics.toolCallCount;
+    usage = {
+      inputTokens: totalUsage.inputTokens,
+      outputTokens: totalUsage.outputTokens,
+      totalTokens,
+      subagentTokens: subagentMetrics.totalTokens,
+      toolCallCount,
+      stepCount: steps.length,
+    };
     await renderer.finalize({
       elapsedMs,
       totalTokens,
@@ -137,5 +156,5 @@ export async function streamTurn(
 
   log.info("streaming", `Turn complete, ${renderer.content.length} chars, ${elapsedMs}ms`);
 
-  return { text: renderer.content };
+  return { text: renderer.content, usage };
 }

--- a/src/lib/ai/subagent.test.ts
+++ b/src/lib/ai/subagent.test.ts
@@ -14,6 +14,7 @@ import {
 
 import { admin, SkillRegistry } from "./skills/index.ts";
 import { createDelegationTool } from "./subagent.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
 
 const baseSpec = {
   name: "test",
@@ -29,12 +30,12 @@ const baseSpec = {
 
 describe("createDelegationTool — tool shape", () => {
   it("returns a tool with the spec description", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
     expect(t.description).toBe("Test delegation");
   });
 
   it("validates the task input schema", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
     const schema = t.inputSchema as unknown as {
       safeParse: (input: unknown) => { success: boolean };
     };
@@ -57,7 +58,7 @@ describe("createDelegationTool — execute() against MockLanguageModelV3", () =>
   });
 
   async function drain(spec: typeof baseSpec, role: UserRole) {
-    const t = createDelegationTool(spec, role, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(spec, role, new TurnUsageTracker());
     const received: UIMessage[] = [];
     const gen = t.execute!(
       { task: "do the thing" },
@@ -125,7 +126,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   }
 
   it("extracts the last text part from the final UIMessage", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
     const output = uiMessage([
       { type: "text", text: "first" },
       { type: "tool-call" },
@@ -137,7 +138,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back to a completion message when no text parts exist", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
     const output = uiMessage([{ type: "tool-call" }]);
     expect(
       t.toModelOutput!({ output } as Parameters<NonNullable<typeof t.toModelOutput>>[0]),
@@ -145,7 +146,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back when output is undefined", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, { totalTokens: 0, toolCallCount: 0 });
+    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
     expect(
       t.toModelOutput!({ output: undefined } as unknown as Parameters<
         NonNullable<typeof t.toModelOutput>

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 import { countMetric, recordDistribution } from "@/lib/metrics";
 
-import type { SubagentSpec, SubagentMetrics } from "./types.ts";
+import type { SubagentSpec } from "./types.ts";
 
 import { SUBAGENT_MODEL, SUBAGENT_PREAMBLE, UserRole } from "./constants.ts";
 import {
@@ -20,6 +20,7 @@ import {
   computeActiveTools,
   filterAdmin,
 } from "./skills/index.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
 
 export type { SubagentSpec } from "./types.ts";
 
@@ -36,7 +37,11 @@ export type { SubagentSpec } from "./types.ts";
  * message history stays lean (full execution details live in the UI stream,
  * not in the model context).
  */
-export function createDelegationTool(spec: SubagentSpec, role: UserRole, metrics: SubagentMetrics) {
+export function createDelegationTool(
+  spec: SubagentSpec,
+  role: UserRole,
+  tracker: TurnUsageTracker,
+) {
   return tool({
     description: spec.description,
     inputSchema: z.object({
@@ -85,18 +90,13 @@ export function createDelegationTool(spec: SubagentSpec, role: UserRole, metrics
       }
 
       const [usage, steps] = await Promise.all([result.totalUsage, result.steps]);
-      const tokensBefore = metrics.totalTokens;
-      const toolCallsBefore = metrics.toolCallCount;
-      metrics.totalTokens += usage.totalTokens ?? 0;
-      metrics.toolCallCount += steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
+      const tokens = usage.totalTokens ?? 0;
+      const toolCalls = steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
+      tracker.addSubagent({ tokens, toolCalls });
 
       countMetric("ai.subagent.completed", { domain: spec.name });
-      recordDistribution("ai.subagent.tokens", metrics.totalTokens - tokensBefore, {
-        domain: spec.name,
-      });
-      recordDistribution("ai.subagent.tool_calls", metrics.toolCallCount - toolCallsBefore, {
-        domain: spec.name,
-      });
+      recordDistribution("ai.subagent.tokens", tokens, { domain: spec.name });
+      recordDistribution("ai.subagent.tool_calls", toolCalls, { domain: spec.name });
     },
     toModelOutput: ({ output }) => {
       const message = output as UIMessage | undefined;

--- a/src/lib/ai/turn-usage.test.ts
+++ b/src/lib/ai/turn-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { TurnUsageTracker } from "./turn-usage.ts";
+import { TurnUsageTracker, addTurnUsage, emptyTurnUsage } from "./turn-usage.ts";
 
 describe("TurnUsageTracker", () => {
   it("starts empty", () => {
@@ -68,5 +68,91 @@ describe("TurnUsageTracker", () => {
     expect(usage.outputTokens).toBeUndefined();
     expect(usage.toolCallCount).toBe(1);
     expect(usage.stepCount).toBe(0);
+  });
+});
+
+describe("emptyTurnUsage", () => {
+  it("returns a zeroed accumulator", () => {
+    expect(emptyTurnUsage()).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      subagentTokens: 0,
+      toolCallCount: 0,
+      stepCount: 0,
+    });
+  });
+});
+
+describe("addTurnUsage", () => {
+  it("sums every field across two turns", () => {
+    const a = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      subagentTokens: 20,
+      toolCallCount: 2,
+      stepCount: 3,
+    };
+    const b = {
+      inputTokens: 200,
+      outputTokens: 80,
+      totalTokens: 280,
+      subagentTokens: 10,
+      toolCallCount: 1,
+      stepCount: 2,
+    };
+    expect(addTurnUsage(a, b)).toEqual({
+      inputTokens: 300,
+      outputTokens: 130,
+      totalTokens: 430,
+      subagentTokens: 30,
+      toolCallCount: 3,
+      stepCount: 5,
+    });
+  });
+
+  it("treats missing input/output/total tokens as zero", () => {
+    const a = emptyTurnUsage();
+    const b = {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      subagentTokens: 5,
+      toolCallCount: 1,
+      stepCount: 1,
+    };
+    const out = addTurnUsage(a, b);
+    expect(out.inputTokens).toBe(0);
+    expect(out.outputTokens).toBe(0);
+    expect(out.totalTokens).toBe(0);
+    expect(out.subagentTokens).toBe(5);
+  });
+
+  it("treats undefined values on the LHS as zero", () => {
+    const a = {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      subagentTokens: 0,
+      toolCallCount: 0,
+      stepCount: 0,
+    };
+    const b = {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      subagentTokens: 2,
+      toolCallCount: 1,
+      stepCount: 1,
+    };
+    expect(addTurnUsage(a, b)).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      subagentTokens: 2,
+      toolCallCount: 1,
+      stepCount: 1,
+    });
   });
 });

--- a/src/lib/ai/turn-usage.test.ts
+++ b/src/lib/ai/turn-usage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+
+import { TurnUsageTracker } from "./turn-usage.ts";
+
+describe("TurnUsageTracker", () => {
+  it("starts empty", () => {
+    const t = new TurnUsageTracker();
+    expect(t.toTurnUsage()).toEqual({
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: 0,
+      subagentTokens: 0,
+      toolCallCount: 0,
+      stepCount: 0,
+    });
+  });
+
+  it("accumulates subagent contributions across calls", () => {
+    const t = new TurnUsageTracker();
+    t.addSubagent({ tokens: 100, toolCalls: 2 });
+    t.addSubagent({ tokens: 250, toolCalls: 3 });
+    expect(t.toTurnUsage()).toMatchObject({
+      subagentTokens: 350,
+      toolCallCount: 5,
+    });
+  });
+
+  it("merges orchestrator usage with subagent totals", () => {
+    const t = new TurnUsageTracker();
+    t.addSubagent({ tokens: 200, toolCalls: 4 });
+    t.recordOrchestrator({
+      usage: { inputTokens: 800, outputTokens: 150, totalTokens: 950 },
+      steps: [{ toolCalls: [1, 2] }, { toolCalls: [3] }],
+    });
+    const usage = t.toTurnUsage();
+    expect(usage).toEqual({
+      inputTokens: 800,
+      outputTokens: 150,
+      totalTokens: 1150,
+      subagentTokens: 200,
+      toolCallCount: 7,
+      stepCount: 2,
+    });
+  });
+
+  it("exposes convenience accessors after recordOrchestrator", () => {
+    const t = new TurnUsageTracker();
+    t.addSubagent({ tokens: 50, toolCalls: 1 });
+    t.recordOrchestrator({
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      steps: [{ toolCalls: [1, 2, 3] }],
+    });
+    expect(t.totalTokens).toBe(200);
+    expect(t.totalToolCalls).toBe(4);
+    expect(t.totalSteps).toBe(1);
+  });
+
+  it("handles missing orchestrator totalTokens", () => {
+    const t = new TurnUsageTracker();
+    t.addSubagent({ tokens: 50, toolCalls: 1 });
+    t.recordOrchestrator({
+      usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+      steps: [],
+    });
+    const usage = t.toTurnUsage();
+    expect(usage.totalTokens).toBe(50);
+    expect(usage.inputTokens).toBeUndefined();
+    expect(usage.outputTokens).toBeUndefined();
+    expect(usage.toolCallCount).toBe(1);
+    expect(usage.stepCount).toBe(0);
+  });
+});

--- a/src/lib/ai/turn-usage.ts
+++ b/src/lib/ai/turn-usage.ts
@@ -62,3 +62,28 @@ export class TurnUsageTracker {
     };
   }
 }
+
+/** Initial zero-state for a cumulative TurnUsage accumulator. */
+export function emptyTurnUsage(): TurnUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    subagentTokens: 0,
+    toolCallCount: 0,
+    stepCount: 0,
+  };
+}
+
+/** Sum two TurnUsage values into a fresh object — used by the workflow to
+ * accumulate per-turn usage into a conversation-wide running total. */
+export function addTurnUsage(total: TurnUsage, turn: TurnUsage): TurnUsage {
+  return {
+    inputTokens: (total.inputTokens ?? 0) + (turn.inputTokens ?? 0),
+    outputTokens: (total.outputTokens ?? 0) + (turn.outputTokens ?? 0),
+    totalTokens: (total.totalTokens ?? 0) + (turn.totalTokens ?? 0),
+    subagentTokens: total.subagentTokens + turn.subagentTokens,
+    toolCallCount: total.toolCallCount + turn.toolCallCount,
+    stepCount: total.stepCount + turn.stepCount,
+  };
+}

--- a/src/lib/ai/turn-usage.ts
+++ b/src/lib/ai/turn-usage.ts
@@ -1,0 +1,64 @@
+import type { TurnUsage } from "./types.ts";
+
+/**
+ * Mutable accumulator for one orchestrator turn's worth of usage.
+ *
+ * Subagents call `addSubagent` to fold in their per-delegation totals as they
+ * complete; the streaming layer calls `recordOrchestrator` once with the
+ * orchestrator's terminal usage + step trace. `toTurnUsage` produces the
+ * persisted `TurnUsage` shape (subagent totals + orchestrator totals merged).
+ */
+export class TurnUsageTracker {
+  private subagentTokens = 0;
+  private subagentToolCalls = 0;
+  private orchestratorInputTokens: number | undefined;
+  private orchestratorOutputTokens: number | undefined;
+  private orchestratorTotalTokens: number | undefined;
+  private orchestratorToolCalls = 0;
+  private stepCount = 0;
+
+  /** Add a subagent delegation's contribution. */
+  addSubagent(delta: { tokens: number; toolCalls: number }): void {
+    this.subagentTokens += delta.tokens;
+    this.subagentToolCalls += delta.toolCalls;
+  }
+
+  /** Record the orchestrator's terminal usage + step trace for this turn. */
+  recordOrchestrator(args: {
+    usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+    steps: ReadonlyArray<{ toolCalls: ReadonlyArray<unknown> }>;
+  }): void {
+    this.orchestratorInputTokens = args.usage.inputTokens;
+    this.orchestratorOutputTokens = args.usage.outputTokens;
+    this.orchestratorTotalTokens = args.usage.totalTokens;
+    this.orchestratorToolCalls = args.steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
+    this.stepCount = args.steps.length;
+  }
+
+  /** Convenience accessor for the post-stream tool-call total (orchestrator + subagent). */
+  get totalToolCalls(): number {
+    return this.orchestratorToolCalls + this.subagentToolCalls;
+  }
+
+  /** Convenience accessor for the post-stream step count. */
+  get totalSteps(): number {
+    return this.stepCount;
+  }
+
+  /** Convenience accessor for the post-stream merged token total. */
+  get totalTokens(): number {
+    return (this.orchestratorTotalTokens ?? 0) + this.subagentTokens;
+  }
+
+  /** Snapshot in the shape persisted to the context-snapshot store. */
+  toTurnUsage(): TurnUsage {
+    return {
+      inputTokens: this.orchestratorInputTokens,
+      outputTokens: this.orchestratorOutputTokens,
+      totalTokens: this.totalTokens,
+      subagentTokens: this.subagentTokens,
+      toolCallCount: this.totalToolCalls,
+      stepCount: this.stepCount,
+    };
+  }
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -85,6 +85,19 @@ export interface CategoryBreakdown {
   label: string;
   chars: number;
   estimatedTokens: number;
+  /** Optional per-item breakdown (e.g. per-tool token counts within the Tools category). */
+  items?: CategoryItem[];
+}
+
+export interface CategoryItem {
+  name: string;
+  estimatedTokens: number;
+  /**
+   * Loadable subskills nested under this item — populated only for delegate
+   * agents (subskills load on demand inside the subagent via `load_skill`).
+   * Not counted toward the orchestrator's input total.
+   */
+  skills?: CategoryItem[];
 }
 
 export interface ContextBreakdown {
@@ -93,11 +106,12 @@ export interface ContextBreakdown {
   categories: CategoryBreakdown[];
   /** Sum of per-category estimatedTokens (chars/4). */
   estimatedInputTokens: number;
-  lastTurnUsage: TurnUsage;
+  /** Cumulative API usage across every turn this conversation has run. */
+  totalUsage: TurnUsage;
   turnCount: number;
   messageCount: number;
-  /** Dollar cost of the last turn, computed when modelInfo + usage are both present. */
-  lastTurnCostUsd?: { input: number; output: number; total: number };
+  /** Cumulative dollar cost across every turn — modelInfo + usage required. */
+  totalCostUsd?: { input: number; output: number; total: number };
 }
 
 export interface SubagentSpec {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -58,10 +58,52 @@ export interface FooterMeta {
   stepCount: number;
 }
 
+/**
+ * Usage accounting for a single orchestrator turn. Captured from the AI SDK's
+ * `result.totalUsage` plus the subagent metrics accumulator. Stored in the
+ * context snapshot so the /inspect-context command can report real, non-estimated
+ * token numbers for the last completed turn.
+ */
+export interface TurnUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Total including subagent tokens; matches the footer value. */
+  totalTokens?: number;
+  subagentTokens: number;
+  toolCallCount: number;
+  stepCount: number;
+}
+
 /** Mutable accumulator for subagent token/tool-call metrics. */
 export interface SubagentMetrics {
   totalTokens: number;
   toolCallCount: number;
+}
+
+export interface ModelInfo {
+  id: string;
+  provider: string;
+  limit: { context: number; output: number };
+  cost: { input: number; output: number };
+}
+
+export interface CategoryBreakdown {
+  label: string;
+  chars: number;
+  estimatedTokens: number;
+}
+
+export interface ContextBreakdown {
+  model: string;
+  modelInfo: ModelInfo | null;
+  categories: CategoryBreakdown[];
+  /** Sum of per-category estimatedTokens (chars/4). */
+  estimatedInputTokens: number;
+  lastTurnUsage: TurnUsage;
+  turnCount: number;
+  messageCount: number;
+  /** Dollar cost of the last turn, computed when modelInfo + usage are both present. */
+  lastTurnCostUsd?: { input: number; output: number; total: number };
 }
 
 export interface SubagentSpec {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -74,12 +74,6 @@ export interface TurnUsage {
   stepCount: number;
 }
 
-/** Mutable accumulator for subagent token/tool-call metrics. */
-export interface SubagentMetrics {
-  totalTokens: number;
-  toolCallCount: number;
-}
-
 export interface ModelInfo {
   id: string;
   provider: string;

--- a/src/lib/protocol/types.ts
+++ b/src/lib/protocol/types.ts
@@ -39,6 +39,16 @@ export interface InteractionData {
   options?: InteractionOption[];
   custom_id?: string;
   component_type?: number;
+  target_id?: string;
+  resolved?: InteractionResolved;
+}
+
+export interface InteractionResolved {
+  messages?: Record<string, APIMessage>;
+  users?: Record<
+    string,
+    { id: string; username: string; global_name?: string | null; bot?: boolean }
+  >;
 }
 
 export interface InteractionOption {

--- a/src/server/routes/interactions.ts
+++ b/src/server/routes/interactions.ts
@@ -70,6 +70,8 @@ route.post("/interactions", async (c) => {
 
     return c.json({
       type: InteractionResponseType.DeferredChannelMessageWithSource,
+      // Discord MessageFlags.Ephemeral — only the invoker sees the reply.
+      data: command.ephemeral ? { flags: 64 } : undefined,
     });
   }
 

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -3,9 +3,13 @@ import { REST } from "@discordjs/rest";
 import { log } from "evlog";
 import { createHook, getWorkflowMetadata } from "workflow";
 
-import type { ChatMessage, SerializedAgentContext } from "@/lib/ai/types";
+import type { ContextSnapshot } from "@/bot/context-snapshot";
+import type { ChatMessage, SerializedAgentContext, TurnUsage } from "@/lib/ai/types";
 
+import { ContextSnapshotStore } from "@/bot/context-snapshot";
 import { ConversationStore } from "@/bot/store";
+import { AgentContext } from "@/lib/ai/context";
+import { buildContextSnapshot } from "@/lib/ai/snapshot";
 import { streamTurn } from "@/lib/ai/streaming";
 import { countMetric } from "@/lib/metrics";
 
@@ -37,16 +41,41 @@ async function runTurn(
   return streamTurn(discord, channelId, messages, serializedContext);
 }
 
-async function cleanupConversation(channelId: string) {
+async function persistSnapshot(
+  channelId: string,
+  threadId: string | undefined,
+  snapshot: ContextSnapshot,
+) {
   "use step";
-  const store = new ConversationStore();
-  await store.delete(channelId);
+  await new ContextSnapshotStore().set(channelId, threadId, snapshot);
+}
+
+async function cleanupConversation(channelId: string, threadId: string | undefined) {
+  "use step";
+  await Promise.all([
+    new ConversationStore().delete(channelId),
+    new ContextSnapshotStore().delete(channelId, threadId),
+  ]);
+}
+
+function captureSnapshot(
+  serializedContext: SerializedAgentContext,
+  messages: ChatMessage[],
+  usage: TurnUsage,
+  turnCount: number,
+): ContextSnapshot {
+  return buildContextSnapshot({
+    agentCtx: AgentContext.fromJSON(serializedContext),
+    messages,
+    lastTurnUsage: usage,
+    turnCount,
+  });
 }
 
 export async function chatWorkflow(payload: ChatPayload) {
   "use workflow";
 
-  const { channelId, content, context } = payload;
+  const { channelId, threadId, content, context } = payload;
   const { workflowRunId } = getWorkflowMetadata();
 
   log.info("workflow", `Chat started: ${workflowRunId}`);
@@ -63,6 +92,9 @@ export async function chatWorkflow(payload: ChatPayload) {
   const first = await runTurn(channelId, messages, context);
   messages.push({ role: "assistant", content: first.text });
   capHistory(messages);
+  await persistSnapshot(channelId, threadId, captureSnapshot(context, messages, first.usage, 1));
+
+  let turnCount = 1;
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
@@ -90,8 +122,14 @@ export async function chatWorkflow(payload: ChatPayload) {
     const turn = await runTurn(channelId, messages, turnContext);
     messages.push({ role: "assistant", content: turn.text });
     capHistory(messages);
+    turnCount += 1;
+    await persistSnapshot(
+      channelId,
+      threadId,
+      captureSnapshot(turnContext, messages, turn.usage, turnCount),
+    );
   }
 
-  await cleanupConversation(channelId);
+  await cleanupConversation(channelId, threadId);
   log.info("workflow", `Chat cleaned up: ${workflowRunId}`);
 }

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -11,6 +11,7 @@ import { ConversationStore } from "@/bot/store";
 import { AgentContext } from "@/lib/ai/context";
 import { buildContextSnapshot } from "@/lib/ai/snapshot";
 import { streamTurn } from "@/lib/ai/streaming";
+import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
 import { countMetric } from "@/lib/metrics";
 
 import type { ChatHookEvent, ChatPayload } from "./types";
@@ -80,13 +81,13 @@ async function cleanupConversation(channelId: string, threadId: string | undefin
 function captureSnapshot(
   serializedContext: SerializedAgentContext,
   messages: ChatMessage[],
-  usage: TurnUsage,
+  totalUsage: TurnUsage,
   turnCount: number,
 ): ContextSnapshot {
   return buildContextSnapshot({
     agentCtx: AgentContext.fromJSON(serializedContext),
     messages,
-    lastTurnUsage: usage,
+    totalUsage,
     turnCount,
   });
 }
@@ -111,9 +112,10 @@ export async function chatWorkflow(payload: ChatPayload) {
   const first = await runTurn(channelId, messages, context);
   messages.push({ role: "assistant", content: first.text });
   capHistory(messages);
-  await persistSnapshot(channelId, threadId, captureSnapshot(context, messages, first.usage, 1));
 
   let turnCount = 1;
+  let totalUsage = addTurnUsage(emptyTurnUsage(), first.usage);
+  await persistSnapshot(channelId, threadId, captureSnapshot(context, messages, totalUsage, 1));
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
@@ -142,10 +144,11 @@ export async function chatWorkflow(payload: ChatPayload) {
     messages.push({ role: "assistant", content: turn.text });
     capHistory(messages);
     turnCount += 1;
+    totalUsage = addTurnUsage(totalUsage, turn.usage);
     await persistSnapshot(
       channelId,
       threadId,
-      captureSnapshot(turnContext, messages, turn.usage, turnCount),
+      captureSnapshot(turnContext, messages, totalUsage, turnCount),
     );
   }
 

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -4,11 +4,10 @@ import { log } from "evlog";
 import { createHook, getWorkflowMetadata } from "workflow";
 
 import type { ContextSnapshot } from "@/bot/context-snapshot";
-import type { ChatMessage, SerializedAgentContext, TurnUsage } from "@/lib/ai/types";
+import type { ChatMessage, SerializedAgentContext } from "@/lib/ai/types";
 
 import { ContextSnapshotStore } from "@/bot/context-snapshot";
 import { ConversationStore } from "@/bot/store";
-import { AgentContext } from "@/lib/ai/context";
 import { buildContextSnapshot } from "@/lib/ai/snapshot";
 import { streamTurn } from "@/lib/ai/streaming";
 import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
@@ -78,20 +77,6 @@ async function cleanupConversation(channelId: string, threadId: string | undefin
   }
 }
 
-function captureSnapshot(
-  serializedContext: SerializedAgentContext,
-  messages: ChatMessage[],
-  totalUsage: TurnUsage,
-  turnCount: number,
-): ContextSnapshot {
-  return buildContextSnapshot({
-    agentCtx: AgentContext.fromJSON(serializedContext),
-    messages,
-    totalUsage,
-    turnCount,
-  });
-}
-
 export async function chatWorkflow(payload: ChatPayload) {
   "use workflow";
 
@@ -115,7 +100,11 @@ export async function chatWorkflow(payload: ChatPayload) {
 
   let turnCount = 1;
   let totalUsage = addTurnUsage(emptyTurnUsage(), first.usage);
-  await persistSnapshot(channelId, threadId, captureSnapshot(context, messages, totalUsage, 1));
+  await persistSnapshot(
+    channelId,
+    threadId,
+    buildContextSnapshot({ context, messages, totalUsage, turnCount }),
+  );
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
@@ -148,7 +137,7 @@ export async function chatWorkflow(payload: ChatPayload) {
     await persistSnapshot(
       channelId,
       threadId,
-      captureSnapshot(turnContext, messages, totalUsage, turnCount),
+      buildContextSnapshot({ context: turnContext, messages, totalUsage, turnCount }),
     );
   }
 

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -47,15 +47,34 @@ async function persistSnapshot(
   snapshot: ContextSnapshot,
 ) {
   "use step";
-  await new ContextSnapshotStore().set(channelId, threadId, snapshot);
+  // Best-effort: snapshot persistence is diagnostic. A Redis blip should not
+  // abort the chat workflow or hide a successful user-facing turn.
+  try {
+    await new ContextSnapshotStore().set(channelId, threadId, snapshot);
+  } catch (err) {
+    log.warn("workflow", `Snapshot persist failed for ${channelId}: ${String(err)}`);
+    countMetric("workflow.chat.snapshot_error");
+  }
 }
 
 async function cleanupConversation(channelId: string, threadId: string | undefined) {
   "use step";
-  await Promise.all([
+  // Snapshot deletion is best-effort; only the ConversationStore delete is
+  // load-bearing for starting a fresh workflow later.
+  const [conversationResult, snapshotResult] = await Promise.allSettled([
     new ConversationStore().delete(channelId),
     new ContextSnapshotStore().delete(channelId, threadId),
   ]);
+  if (snapshotResult.status === "rejected") {
+    log.warn(
+      "workflow",
+      `Snapshot delete failed for ${channelId}: ${String(snapshotResult.reason)}`,
+    );
+    countMetric("workflow.chat.snapshot_cleanup_error");
+  }
+  if (conversationResult.status === "rejected") {
+    throw conversationResult.reason;
+  }
 }
 
 function captureSnapshot(

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -3,6 +3,8 @@ import type { TaskMeta } from "@/lib/tasks/types";
 
 export interface ChatPayload {
   channelId: string;
+  /** Thread ID when the conversation lives in a thread; used for context-snapshot keying. */
+  threadId?: string;
   content: string;
   context: SerializedAgentContext;
 }


### PR DESCRIPTION
## Summary
- New Discord message context menu command (organizer-only, ephemeral): right-click a message in an active bot thread → Apps → **Inspect Context** to see how the orchestrator's next-turn context window is assembled.
- `chatWorkflow` now mirrors per-turn state (assembled system prompt, tool surface, full messages array, real API `usage`, turn count) to a new Redis-backed `ContextSnapshotStore` so the breakdown reflects stored content verbatim — no reconstruction from Discord.
- Model metadata (context window size + pricing) is looked up live from `https://models.dev/api.json`, which powers the real dollar-cost line (exact last-turn tokens × exact price). Per-category tokens use a `chars/4` estimate and are clearly labeled; last-turn totals and cost are exact from the API response.
- Supporting changes: `streamTurn` returns `{ text, usage }`; `SYSTEM_PROMPT`/`ORCHESTRATOR_MODEL` moved to `constants.ts`; new exported `getOrchestratorTools(role, metrics)` so the snapshot captures the same tool set the orchestrator runs with; `AgentContext.contextBlock()` made public; `ChatPayload` carries `threadId`; `ContextMenuCommandBuilder` joins the command builder union; interactions route honors a new `command.ephemeral` flag.

## Test plan
- [x] `bun format` / `bun lint` / `bun typecheck` / `bun run test` / `bun test:coverage` / `bun knip` all green
- [ ] Register the command (`bun scripts/register-commands.ts`), mention the bot to spawn a thread, right-click a thread message → Apps → Inspect Context, and verify the breakdown renders with real usage + cost
- [ ] Invoke in a channel with no active conversation → "No active conversation…" reply
- [ ] Invoke as a non-organizer → denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)