### PR TITLE
fix: skip Discord command registration on preview builds

### DIFF
--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -4,6 +4,12 @@ import type { SlashCommand } from "../src/bot/commands/types";
 
 import * as commands from "../src/bot/handlers/commands";
 
+const vercelEnv = process.env.VERCEL_ENV;
+if (vercelEnv && vercelEnv !== "production") {
+  console.log(`Skipping command registration on VERCEL_ENV=${vercelEnv}`);
+  process.exit(0);
+}
+
 const token = process.env.DISCORD_BOT_TOKEN;
 const clientId = process.env.DISCORD_CLIENT_ID;
 const guildId = process.env.DISCORD_GUILD_ID;

--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -1,14 +1,13 @@
-import { REST, Routes } from "discord.js";
-
 import type { SlashCommand } from "../src/bot/commands/types";
-
-import * as commands from "../src/bot/handlers/commands";
 
 const vercelEnv = process.env.VERCEL_ENV;
 if (vercelEnv && vercelEnv !== "production") {
   console.log(`Skipping command registration on VERCEL_ENV=${vercelEnv}`);
   process.exit(0);
 }
+
+const { REST, Routes } = await import("discord.js");
+const commands = await import("../src/bot/handlers/commands");
 
 const token = process.env.DISCORD_BOT_TOKEN;
 const clientId = process.env.DISCORD_CLIENT_ID;


### PR DESCRIPTION
## Summary
- Guard `scripts/register-commands.ts` with a `VERCEL_ENV` check so only production deploys re-register Discord slash commands.
- Preview (and any non-production Vercel environment) logs and exits 0 before hitting the Discord API; local manual runs (where `VERCEL_ENV` is unset) are unaffected.

## Test plan
- [ ] Verify preview deploy build logs show the skip message and the build succeeds without Discord credentials.
- [ ] Verify production deploy still registers commands as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)