### PR TITLE
fix: await discord.js ClientReady before /api/discord/gateway responds

### DIFF
--- a/docs/discord/gateway.md
+++ b/docs/discord/gateway.md
@@ -22,7 +22,7 @@ const HANDOFF_WAIT_MS = 8_000;
 
 `vercel.ts` schedules `*/9 * * * *` → `GET /api/discord/gateway`. The 9-minute cadence deliberately overlaps with the 10-minute hold so there's always a listener trying to claim the lease. If an instance dies mid-hold, the next cron invocation picks up within a minute.
 
-The route uses `waitUntil(runGatewayListener(client))` to keep the async lifecycle alive past the HTTP response, so the cron's `GET` returns `{ message: "ok" }` immediately while the listener runs to completion in the background.
+The route awaits the discord.js `ClientReady` event before responding, then uses `waitUntil` to keep the remaining lifecycle alive past the HTTP response. The cron's `GET` returns `{ message: "ok" }` only after the bot successfully logs in; if login or readiness fails, the route responds `500`. The hold continues running in the background for the rest of the 10 minutes.
 
 ## What the client publishes
 

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -32,80 +32,110 @@ async function relay(packet: Packet, oidcToken: string): Promise<void> {
 
 type Publish = (packet: Packet) => Promise<void>;
 
-async function runGatewayListener(client: Client): Promise<void> {
+type GatewayListener = {
+  ready: Promise<void>;
+  done: Promise<void>;
+};
+
+function runGatewayListener(client: Client): GatewayListener {
   const redis = Redis.fromEnv();
   const listenerId = `gw_${ulid()}`;
   const abort = new AbortController();
 
-  log.info("gateway", `listener ${listenerId} starting`);
+  let resolveReady!: () => void;
+  let rejectReady!: (err: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  let readySettled = false;
+  const markReady = () => {
+    if (readySettled) return;
+    readySettled = true;
+    resolveReady();
+  };
+  const failReady = (err: unknown) => {
+    if (readySettled) return;
+    readySettled = true;
+    rejectReady(err);
+  };
+  client.once(Events.ClientReady, markReady);
 
-  const existing = await redis.get<string>(LEADER_KEY).catch(() => null);
-  await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
+  const done = (async () => {
+    log.info("gateway", `listener ${listenerId} starting`);
 
-  if (existing && existing !== listenerId) {
-    log.info(
-      "gateway",
-      `prior leader ${existing} detected, waiting ${HANDOFF_WAIT_MS}ms for handoff`,
-    );
-    await new Promise((r) => setTimeout(r, HANDOFF_WAIT_MS));
-  }
+    const existing = await redis.get<string>(LEADER_KEY).catch(() => null);
+    await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
 
-  const poll = setInterval(async () => {
-    if (abort.signal.aborted) return;
-    try {
-      const current = await redis.get<string>(LEADER_KEY);
-      if (current !== listenerId) {
-        log.info(
-          "gateway",
-          `leadership lost (current=${current ?? "null"}), aborting ${listenerId}`,
-        );
-        abort.abort();
-        return;
-      }
-      await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
-    } catch (err) {
-      log.error("gateway", `lease poll failed: ${String(err)}`);
-    }
-  }, POLL_INTERVAL_MS);
-
-  try {
-    await client.login(env.DISCORD_BOT_TOKEN);
-    log.info("gateway", `login() resolved for ${listenerId}`);
-
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        log.info("gateway", `hold elapsed for ${listenerId}`);
-        resolve();
-      }, HOLD_MS);
-      abort.signal.addEventListener(
-        "abort",
-        () => {
-          clearTimeout(timer);
-          resolve();
-        },
-        { once: true },
+    if (existing && existing !== listenerId) {
+      log.info(
+        "gateway",
+        `prior leader ${existing} detected, waiting ${HANDOFF_WAIT_MS}ms for handoff`,
       );
-    });
-  } catch (err) {
-    log.error("gateway", `login/hold failed: ${String(err)}`);
-  } finally {
-    clearInterval(poll);
-    log.info("gateway", `destroying client ${listenerId}`);
-    try {
-      await client.destroy();
-    } catch (err) {
-      log.error("gateway", `destroy failed: ${String(err)}`);
+      await new Promise((r) => setTimeout(r, HANDOFF_WAIT_MS));
     }
-    try {
-      const current = await redis.get<string>(LEADER_KEY);
-      if (current === listenerId) {
-        await redis.del(LEADER_KEY);
-        log.info("gateway", `released lease for ${listenerId}`);
+
+    const poll = setInterval(async () => {
+      if (abort.signal.aborted) return;
+      try {
+        const current = await redis.get<string>(LEADER_KEY);
+        if (current !== listenerId) {
+          log.info(
+            "gateway",
+            `leadership lost (current=${current ?? "null"}), aborting ${listenerId}`,
+          );
+          abort.abort();
+          return;
+        }
+        await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
+      } catch (err) {
+        log.error("gateway", `lease poll failed: ${String(err)}`);
       }
+    }, POLL_INTERVAL_MS);
+
+    try {
+      await client.login(env.DISCORD_BOT_TOKEN);
+      log.info("gateway", `login() resolved for ${listenerId}`);
+
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          log.info("gateway", `hold elapsed for ${listenerId}`);
+          resolve();
+        }, HOLD_MS);
+        abort.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true },
+        );
+      });
     } catch (err) {
-      log.error("gateway", `lease release failed: ${String(err)}`);
+      log.error("gateway", `login/hold failed: ${String(err)}`);
+      failReady(err);
+    } finally {
+      failReady(new Error(`gateway ${listenerId} ended before ready`));
+      clearInterval(poll);
+      log.info("gateway", `destroying client ${listenerId}`);
+      try {
+        await client.destroy();
+      } catch (err) {
+        log.error("gateway", `destroy failed: ${String(err)}`);
+      }
+      try {
+        const current = await redis.get<string>(LEADER_KEY);
+        if (current === listenerId) {
+          await redis.del(LEADER_KEY);
+          log.info("gateway", `released lease for ${listenerId}`);
+        }
+      } catch (err) {
+        log.error("gateway", `lease release failed: ${String(err)}`);
+      }
     }
-  }
+  })();
+
+  return { ready, done };
 }
 
 const route = new Hono();
@@ -264,7 +294,7 @@ function bindGuildHandlers(client: Client, publish: Publish): void {
   });
 }
 
-route.get("/gateway", (c) => {
+route.get("/gateway", async (c) => {
   let oidcToken: string;
   try {
     oidcToken = getVercelOidcTokenSync();
@@ -320,9 +350,15 @@ route.get("/gateway", (c) => {
   bindMessageHandlers(client, publish);
   bindGuildHandlers(client, publish);
 
-  const loginAndHold = runGatewayListener(client);
+  const listener = runGatewayListener(client);
+  waitUntil(listener.done);
 
-  waitUntil(loginAndHold);
+  try {
+    await listener.ready;
+  } catch (err) {
+    log.error("gateway", `ready wait failed: ${String(err)}`);
+    return c.json({ error: "gateway failed to become ready" }, 500);
+  }
 
   return c.json({ message: "ok" });
 });

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -95,7 +95,9 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
   }, POLL_INTERVAL_MS);
 
   try {
-    const ready = once(client, Events.ClientReady);
+    // Pass abort.signal so the ready wait rejects if the lease poll detects
+    // we lost leadership during login/handshake.
+    const ready = once(client, Events.ClientReady, { signal: abort.signal });
     await client.login(env.DISCORD_BOT_TOKEN);
     await ready;
     log.info("gateway", `ready for ${listenerId}`);
@@ -109,6 +111,13 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
 
   const hold = (async () => {
     try {
+      // Fast-path: abort fired between ready and hold-executor running.
+      // AbortSignal listeners added post-abort never fire, so teardown
+      // would otherwise wait out the full HOLD_MS.
+      if (abort.signal.aborted) {
+        log.info("gateway", `hold skipped, already aborted for ${listenerId}`);
+        return;
+      }
       await new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
           log.info("gateway", `hold elapsed for ${listenerId}`);

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -4,6 +4,7 @@ import { getVercelOidcTokenSync } from "@vercel/functions/oidc";
 import { ActivityType, Client, Events, GatewayIntentBits, Partials } from "discord.js";
 import { log } from "evlog";
 import { Hono } from "hono";
+import { once } from "node:events";
 import { monotonicFactory } from "ulid";
 
 import type { Packet } from "@/lib/protocol/types";
@@ -32,71 +33,82 @@ async function relay(packet: Packet, oidcToken: string): Promise<void> {
 
 type Publish = (packet: Packet) => Promise<void>;
 
-type GatewayListener = {
-  ready: Promise<void>;
-  done: Promise<void>;
-};
+async function releaseLease(redis: Redis, listenerId: string): Promise<void> {
+  try {
+    const current = await redis.get<string>(LEADER_KEY);
+    if (current === listenerId) {
+      await redis.del(LEADER_KEY);
+      log.info("gateway", `released lease for ${listenerId}`);
+    }
+  } catch (err) {
+    log.error("gateway", `lease release failed: ${String(err)}`);
+  }
+}
 
-function runGatewayListener(client: Client): GatewayListener {
+async function destroyClient(client: Client, listenerId: string): Promise<void> {
+  log.info("gateway", `destroying client ${listenerId}`);
+  try {
+    await client.destroy();
+  } catch (err) {
+    log.error("gateway", `destroy failed: ${String(err)}`);
+  }
+}
+
+// Acquires the leader lease and logs the client in. Resolves once Discord
+// emits ClientReady; returns a `hold` promise that runs the 10-minute lease
+// renewal loop and tears everything down when it completes or loses leadership.
+// Throws (and cleans up) if login or the ready handshake fails.
+async function startGatewayListener(client: Client): Promise<{ hold: Promise<void> }> {
   const redis = Redis.fromEnv();
   const listenerId = `gw_${ulid()}`;
   const abort = new AbortController();
 
-  let resolveReady!: () => void;
-  let rejectReady!: (err: unknown) => void;
-  const ready = new Promise<void>((resolve, reject) => {
-    resolveReady = resolve;
-    rejectReady = reject;
-  });
-  let readySettled = false;
-  const markReady = () => {
-    if (readySettled) return;
-    readySettled = true;
-    resolveReady();
-  };
-  const failReady = (err: unknown) => {
-    if (readySettled) return;
-    readySettled = true;
-    rejectReady(err);
-  };
-  client.once(Events.ClientReady, markReady);
+  log.info("gateway", `listener ${listenerId} starting`);
 
-  const done = (async () => {
-    log.info("gateway", `listener ${listenerId} starting`);
+  const existing = await redis.get<string>(LEADER_KEY).catch(() => null);
+  await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
 
-    const existing = await redis.get<string>(LEADER_KEY).catch(() => null);
-    await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
+  if (existing && existing !== listenerId) {
+    log.info(
+      "gateway",
+      `prior leader ${existing} detected, waiting ${HANDOFF_WAIT_MS}ms for handoff`,
+    );
+    await new Promise((r) => setTimeout(r, HANDOFF_WAIT_MS));
+  }
 
-    if (existing && existing !== listenerId) {
-      log.info(
-        "gateway",
-        `prior leader ${existing} detected, waiting ${HANDOFF_WAIT_MS}ms for handoff`,
-      );
-      await new Promise((r) => setTimeout(r, HANDOFF_WAIT_MS));
-    }
-
-    const poll = setInterval(async () => {
-      if (abort.signal.aborted) return;
-      try {
-        const current = await redis.get<string>(LEADER_KEY);
-        if (current !== listenerId) {
-          log.info(
-            "gateway",
-            `leadership lost (current=${current ?? "null"}), aborting ${listenerId}`,
-          );
-          abort.abort();
-          return;
-        }
-        await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
-      } catch (err) {
-        log.error("gateway", `lease poll failed: ${String(err)}`);
-      }
-    }, POLL_INTERVAL_MS);
-
+  const poll = setInterval(async () => {
+    if (abort.signal.aborted) return;
     try {
-      await client.login(env.DISCORD_BOT_TOKEN);
-      log.info("gateway", `login() resolved for ${listenerId}`);
+      const current = await redis.get<string>(LEADER_KEY);
+      if (current !== listenerId) {
+        log.info(
+          "gateway",
+          `leadership lost (current=${current ?? "null"}), aborting ${listenerId}`,
+        );
+        abort.abort();
+        return;
+      }
+      await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
+    } catch (err) {
+      log.error("gateway", `lease poll failed: ${String(err)}`);
+    }
+  }, POLL_INTERVAL_MS);
 
+  try {
+    const ready = once(client, Events.ClientReady);
+    await client.login(env.DISCORD_BOT_TOKEN);
+    await ready;
+    log.info("gateway", `ready for ${listenerId}`);
+  } catch (err) {
+    log.error("gateway", `login/ready failed: ${String(err)}`);
+    clearInterval(poll);
+    await destroyClient(client, listenerId);
+    await releaseLease(redis, listenerId);
+    throw err;
+  }
+
+  const hold = (async () => {
+    try {
       await new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
           log.info("gateway", `hold elapsed for ${listenerId}`);
@@ -111,31 +123,14 @@ function runGatewayListener(client: Client): GatewayListener {
           { once: true },
         );
       });
-    } catch (err) {
-      log.error("gateway", `login/hold failed: ${String(err)}`);
-      failReady(err);
     } finally {
-      failReady(new Error(`gateway ${listenerId} ended before ready`));
       clearInterval(poll);
-      log.info("gateway", `destroying client ${listenerId}`);
-      try {
-        await client.destroy();
-      } catch (err) {
-        log.error("gateway", `destroy failed: ${String(err)}`);
-      }
-      try {
-        const current = await redis.get<string>(LEADER_KEY);
-        if (current === listenerId) {
-          await redis.del(LEADER_KEY);
-          log.info("gateway", `released lease for ${listenerId}`);
-        }
-      } catch (err) {
-        log.error("gateway", `lease release failed: ${String(err)}`);
-      }
+      await destroyClient(client, listenerId);
+      await releaseLease(redis, listenerId);
     }
   })();
 
-  return { ready, done };
+  return { hold };
 }
 
 const route = new Hono();
@@ -350,16 +345,14 @@ route.get("/gateway", async (c) => {
   bindMessageHandlers(client, publish);
   bindGuildHandlers(client, publish);
 
-  const listener = runGatewayListener(client);
-  waitUntil(listener.done);
-
+  let hold: Promise<void>;
   try {
-    await listener.ready;
-  } catch (err) {
-    log.error("gateway", `ready wait failed: ${String(err)}`);
+    ({ hold } = await startGatewayListener(client));
+  } catch {
     return c.json({ error: "gateway failed to become ready" }, 500);
   }
 
+  waitUntil(hold);
   return c.json({ message: "ok" });
 });
 


### PR DESCRIPTION
## Summary
- `/api/discord/gateway` previously returned `200 { message: "ok" }` as soon as `waitUntil` was attached, so post-deploy smoke checks (and the cron's curl) passed even when the bot never finished logging in.
- `startGatewayListener(client)` now runs a linear `acquire lease → register once(ClientReady) → login → await ready` sequence. It throws (after cleaning up the client + lease) if login or the ready handshake fails, and otherwise returns `{ hold }` — a promise wrapping the 10-minute lease-renewal loop and teardown.
- The route does `try { ({ hold } = await startGatewayListener(client)) } catch { return 500 }`, then `waitUntil(hold)` and returns `200`. Post-review follow-ups: `once()` is passed `abort.signal` so abort-during-login rejects ready, and the hold executor has an `abort.signal.aborted` fast-path so teardown is immediate if leadership was already lost.
- Updated `docs/discord/gateway.md` to describe the new response semantics.

## Test plan
- [x] `bun format`
- [x] `bun lint` (1 pre-existing warning in `src/lib/ai/tools/sentry/client.ts`, unrelated)
- [x] `bun typecheck`
- [x] `bun run test` (317/317)
- [x] `bun test:coverage` (317/317)
- [x] `bun knip`
- [ ] Manual: hit `GET /api/discord/gateway` against a preview and confirm it only returns `200` once the bot appears online in Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)