### PR TITLE
feat: swap subagent model to openai/gpt-5.4-mini and authorize parallel tool calls

### DIFF
--- a/src/lib/ai/constants.ts
+++ b/src/lib/ai/constants.ts
@@ -33,6 +33,10 @@ export const SUBAGENT_PREAMBLE = `You are a specialized subagent delegated to by
 - Do not stop mid-task, hand back partial work, or wait for confirmation.
 - If one approach fails, try alternatives before giving up.
 
+## CALL INDEPENDENT TOOLS IN PARALLEL
+- When you need data from multiple tools and none of them depend on another's result, emit those tool calls in a SINGLE turn — they will run concurrently.
+- Only serialize when a later call requires data returned by an earlier one.
+
 ## ONLY TAKE REQUESTED ACTIONS
 - Only perform actions (create, modify, delete resources) that the user explicitly asked for.
 - Never infer, guess, or assume the user wants a resource created, modified, or deleted unless they specifically said so.
@@ -45,7 +49,7 @@ Your final message MUST contain exactly two sections:
 2. **Answer**: The direct answer to the task, formatted for Discord (markdown links required for any entities you reference).
 `;
 
-export const SUBAGENT_MODEL = "anthropic/claude-haiku-4.5";
+export const SUBAGENT_MODEL = "openai/gpt-5.4-mini";
 
 export const ORCHESTRATOR_MODEL = "anthropic/claude-sonnet-4.6";
 
@@ -67,7 +71,7 @@ You have direct access to these tools:
 
 Only delegate when the user's request clearly requires a domain-specific action (e.g. creating a channel, filing an issue, querying a database). If the message is casual, ambiguous, or conversational, respond directly — do not delegate.
 
-Plan multi-step requests before starting. For requests that span multiple domains, delegate each in turn.
+Plan multi-step requests before starting. When sub-tasks are independent (no call needs another's result), emit the tool calls in a SINGLE turn — they will run in parallel. Serialize only when a later call depends on an earlier result.
 </tools>
 
 <tone>

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -71,6 +71,11 @@ export function createDelegationTool(
           const active = computeActiveTools({ steps, registry, role, baseToolNames });
           return active ? { activeTools: active as ToolKey[] } : undefined;
         },
+        providerOptions: {
+          openai: {
+            parallelToolCalls: true,
+          },
+        },
         experimental_telemetry: {
           isEnabled: true,
           functionId: `subagent.${spec.name}`,


### PR DESCRIPTION
## Summary
- Swap `SUBAGENT_MODEL` from `anthropic/claude-haiku-4.5` to `openai/gpt-5.4-mini` and set `providerOptions.openai.parallelToolCalls = true` on the nested `ToolLoopAgent` so the new provider honors parallel tool use explicitly.
- Replace the orchestrator `SYSTEM_PROMPT` "delegate each in turn" rule with explicit authorization to emit independent tool calls in a single turn; add a matching `CALL INDEPENDENT TOOLS IN PARALLEL` section to `SUBAGENT_PREAMBLE`.
- No new tools, no provider option on the orchestrator (Anthropic already parallelizes by default) — behavior change is pure prompt + model-string + one SDK provider option.

## Test plan
- [x] `bun format && bun lint && bun typecheck && bun run test && bun test:coverage && bun knip` — all green (316 tests passing; 1 preexisting unrelated lint warning in `sentry/client.ts`).
- [ ] Smoke: send an independent multi-domain request (e.g. "list open Linear issues for team Eng AND list members of #announcements") and confirm `/Inspect Context` shows a single orchestrator step with two `delegate_*` tool calls.
- [ ] Smoke: send a Linear task that fans out inside the subagent and confirm the subagent step trace shows parallel tool calls.
- [ ] Spot-check GPT-5.4-mini output against each domain's `SKILL.md` (prompts were written for Haiku 4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)