### PR TITLE
feat: add finance (HCB) subagent for Hack Club Bank lookups

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -38,7 +38,7 @@ export const env = createEnv({
     SENTRY_AUTH_TOKEN: z.string(),
     SENTRY_ORG: z.string(),
     SENTRY_DSN: z.string().optional(),
-    HCB_ORG_SLUG: z.string().optional(),
+    HCB_ORG_SLUG: z.string(),
   },
   extends: [vercel()],
   runtimeEnv: process.env,

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,7 +38,7 @@ export const env = createEnv({
     SENTRY_AUTH_TOKEN: z.string(),
     SENTRY_ORG: z.string(),
     SENTRY_DSN: z.string().optional(),
-    HCB_ORG_SLUG: z.string(),
+    HCB_ORG_SLUG: z.string().optional(),
   },
   extends: [vercel()],
   runtimeEnv: process.env,

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,6 +38,7 @@ export const env = createEnv({
     SENTRY_AUTH_TOKEN: z.string(),
     SENTRY_ORG: z.string(),
     SENTRY_DSN: z.string().optional(),
+    HCB_ORG_SLUG: z.string(),
   },
   extends: [vercel()],
   runtimeEnv: process.env,

--- a/src/lib/ai/delegates.test.ts
+++ b/src/lib/ai/delegates.test.ts
@@ -51,6 +51,15 @@ vi.mock("@/lib/ai/skills/generated/manifest", () => ({
       mode: "delegate",
       instructions: "Sentry instructions.",
     },
+    finance: {
+      name: "finance",
+      description: "Finance delegate",
+      criteria: "when asked about finances",
+      toolNames: [],
+      minRole: UserRole.Organizer,
+      mode: "delegate",
+      instructions: "Finance instructions.",
+    },
     // notion is intentionally omitted — buildDelegationTools should tolerate missing domains.
   },
 }));
@@ -62,6 +71,7 @@ vi.mock("@/lib/ai/skills/generated/domains/discord", () => ({ SKILL_MANIFEST: {}
 vi.mock("@/lib/ai/skills/generated/domains/figma", () => ({ SKILL_MANIFEST: {} }));
 vi.mock("@/lib/ai/skills/generated/domains/notion", () => ({ SKILL_MANIFEST: {} }));
 vi.mock("@/lib/ai/skills/generated/domains/sentry", () => ({ SKILL_MANIFEST: {} }));
+vi.mock("@/lib/ai/skills/generated/domains/finance", () => ({ SKILL_MANIFEST: {} }));
 
 // Stub the heavy tool index modules so env-backed SDK clients don't initialize.
 vi.mock("@/lib/ai/tools/linear", () => ({}));
@@ -70,6 +80,7 @@ vi.mock("@/lib/ai/tools/discord", () => ({}));
 vi.mock("@/lib/ai/tools/figma", () => ({}));
 vi.mock("@/lib/ai/tools/notion", () => ({}));
 vi.mock("@/lib/ai/tools/sentry", () => ({}));
+vi.mock("@/lib/ai/tools/finance", () => ({}));
 
 // Stub createDelegationTool so we can see what spec each domain was passed.
 vi.mock("@/lib/ai/subagent", () => ({
@@ -97,6 +108,7 @@ describe("buildDelegationTools", () => {
     const tools = buildDelegationTools(UserRole.Organizer, new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
+      "delegate_finance",
       "delegate_linear",
       "delegate_sentry",
     ]);
@@ -107,6 +119,7 @@ describe("buildDelegationTools", () => {
     const tools = buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
+      "delegate_finance",
       "delegate_github",
       "delegate_linear",
       "delegate_sentry",

--- a/src/lib/ai/delegates.ts
+++ b/src/lib/ai/delegates.ts
@@ -5,6 +5,7 @@ import type { TurnUsageTracker } from "./turn-usage.ts";
 
 import { SKILL_MANIFEST as DISCORD_SUBSKILLS } from "./skills/generated/domains/discord.ts";
 import { SKILL_MANIFEST as FIGMA_SUBSKILLS } from "./skills/generated/domains/figma.ts";
+import { SKILL_MANIFEST as FINANCE_SUBSKILLS } from "./skills/generated/domains/finance.ts";
 import { SKILL_MANIFEST as GITHUB_SUBSKILLS } from "./skills/generated/domains/github.ts";
 import { SKILL_MANIFEST as LINEAR_SUBSKILLS } from "./skills/generated/domains/linear.ts";
 import { SKILL_MANIFEST as NOTION_SUBSKILLS } from "./skills/generated/domains/notion.ts";
@@ -14,6 +15,7 @@ import { SkillRegistry } from "./skills/registry.ts";
 import { createDelegationTool } from "./subagent.ts";
 import * as discordTools from "./tools/discord/index.ts";
 import * as figmaTools from "./tools/figma/index.ts";
+import * as financeTools from "./tools/finance/index.ts";
 import * as githubTools from "./tools/github/index.ts";
 import * as linearTools from "./tools/linear/index.ts";
 import * as notionTools from "./tools/notion/index.ts";
@@ -63,6 +65,11 @@ const DOMAINS = {
     tools: sentryTools as unknown as ToolSet,
     subSkills: SENTRY_SUBSKILLS,
     baseToolNames: ["list_projects", "get_project", "search_issues", "get_issue"],
+  },
+  finance: {
+    tools: financeTools as unknown as ToolSet,
+    subSkills: FINANCE_SUBSKILLS,
+    baseToolNames: ["get_organization", "get_balance", "list_transactions", "get_transaction"],
   },
 } as const satisfies Record<
   string,

--- a/src/lib/ai/skills/finance/SKILL.md
+++ b/src/lib/ai/skills/finance/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: finance
+description: Look up Hack Club Bank balances, transactions, donations, invoices, card charges, and transfers for Purdue Hackers
+criteria: When the user asks about money, budget, balance, donations, sponsor invoices, card spend, microgrant spend, receipts, or finances
+tools: []
+minRole: organizer
+mode: delegate
+---
+
+You are Finance, a read-only Hack Club Bank (HCB) assistant for Purdue Hackers. All operations target the HCB organization identified by the `HCB_ORG_SLUG` env var.
+
+## Sub-skills
+
+When delegated to, you have access to these skill bundles (loaded via `load_skill`):
+
+- transactions: List, inspect, and search transactions by memo / amount / date range
+- donations: List donations and total them over a period — fundraising reporting
+- invoices: List invoices and surface outstanding (unpaid) invoices for sponsor follow-up
+- card-charges: List HCB card charges, optionally filtered by cardholder (microgrant recipient spend tracking)
+- transfers: View inter-org disbursements between HCB organizations
+- receipts: Check whether a transaction has a receipt attached (files themselves are NOT available via API)
+
+## Terminology
+
+Map synonyms silently:
+
+- "balance", "budget", "how much money do we have" -> get_balance
+- "charge", "expense", "purchase" -> card charge or transaction
+- "sponsor payment", "invoice", "bill" -> invoice
+- "sponsor", "donation", "fundraiser" -> donation
+- "grant", "microgrant spend" -> card charges (usually filtered by recipient)
+
+## Key Rules
+
+- **Read-only.** HCB's public API v3 is unauthenticated and exposes no write endpoints. Never claim you can move money, issue a card, or mark a receipt uploaded.
+- **Amounts are in cents.** Negative = outflow, positive = inflow. Always label units (`$123.45` or `12345 cents`).
+- **Pending vs settled.** A `pending: true` charge is not yet cleared. Call this out when it matters (balance reconciliation, month-end totals).
+- **Receipts are a summary only.** The API exposes `receipts: { count, missing }` per transaction — not file URLs or IDs. Direct users to `hcb.hackclub.com/hcb/{id}` for the actual file.
+- **BOSO vs HCB scope.** Purdue Hackers routes most _organization-wide_ reimbursements through **BOSO (Purdue's portal)**, not HCB. Only **microgrant** reimbursements flow through HCB. If the user asks about "reimbursements" without context, ask which system they mean before answering.
+- **Link out.** Transactions link to `hcb.hackclub.com/hcb/{id}`.
+- Only covered orgs (Transparency Mode) are visible. A 404 usually means the slug is wrong or the org is not transparent.

--- a/src/lib/ai/skills/finance/skills/card-charges/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/card-charges/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: card-charges
+description: List Hack Club Bank card charges with optional cardholder filter for microgrant spend tracking.
+criteria: Use when the user asks about card charges, HCB card spend, specific merchant purchases, or per-person grant spend.
+tools: [list_card_charges]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+
+- list_card_charges returns merchant memo, cardholder name, amount_cents (negative = outflow), pending flag, and a receipts summary {count, missing}.
+- The `href` field deep-links to the underlying transaction at `hcb.hackclub.com/hcb/{txn_id}`.
+  </listing>
+
+<user_filter>
+
+- Pass `user` with a substring (case-insensitive) to match cardholder name or email.
+- Primary use case: microgrant spend tracking — "how much has $recipient charged on the HCB card?".
+- User-filtered queries paginate up to 500 charges; unfiltered queries return a single page (default 50).
+  </user_filter>
+
+<receipts>
+
+- A `receipts: { missing: true }` flag means the cardholder hasn't uploaded a receipt yet. Escalate to the Treasurer if needed.
+- Receipt files themselves are not accessible via the API — link to `hcb.hackclub.com/hcb/{txn_id}`.
+  </receipts>

--- a/src/lib/ai/skills/finance/skills/donations/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/donations/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: donations
+description: List Hack Club Bank donations and total them over a date range for fundraising reporting.
+criteria: Use when the user asks about donations, donors, recurring donations, or fundraising totals over a period.
+tools: [list_donations, donation_totals]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+
+- list_donations returns donations with donor name (or "(anonymous)"), amount_cents, status, recurring flag, and any message.
+- Anonymous donations hide the donor name and email.
+  </listing>
+
+<totals>
+
+- donation_totals sums **settled** donations (status in `deposited` / `succeeded` / `in_transit`) within an ISO date range.
+- Returns total_cents, count, recurring_cents, and one_time_cents.
+- Use this to answer "what did we raise this month?" or break down recurring vs one-time support.
+- If a donation is still pending (e.g. `pending` or `failed`), it's excluded from the total.
+  </totals>

--- a/src/lib/ai/skills/finance/skills/invoices/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/invoices/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: invoices
+description: List Hack Club Bank invoices and surface outstanding (unpaid) ones for sponsor follow-ups.
+criteria: Use when the user asks about invoices, sponsor payments, billing status, or outstanding balances.
+tools: [list_invoices, list_open_invoices]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+
+- list_invoices returns all invoices (any status) — sponsor name, amount_cents, status (open/paid/void), due_date, paid_at, memo.
+  </listing>
+
+<open>
+
+- list_open_invoices paginates through all invoices and filters to those that are NOT paid/void — the fundraising team's follow-up list.
+- Surface the sponsor name, amount, and due date so the user can chase them down.
+  </open>

--- a/src/lib/ai/skills/finance/skills/receipts/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/receipts/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: receipts
+description: Check which Hack Club Bank transactions are missing an attached receipt. Files themselves are NOT available via API.
+criteria: Use when the user asks about missing receipts, receipt status for a charge, or wants to chase down receipt uploads.
+tools: [list_missing_receipts, get_receipt_status]
+minRole: organizer
+mode: inline
+---
+
+<scope>
+
+- This covers **HCB card charges and HCB reimbursements only** (which is where Purdue Hackers runs microgrant spend).
+- Organization-wide reimbursements go through **Purdue's BOSO portal**, not HCB. If the user is chasing BOSO receipts, this skill cannot help — redirect them to the `#receipts` Discord channel / BOSO workflow.
+  </scope>
+
+<api_limitation>
+
+- HCB's public API v3 exposes **only a `receipts: { count, missing }` summary** on each transaction. No receipt file URLs, IDs, filenames, or bytes are available.
+- To upload or view the actual receipt image/PDF, the user must go to `hcb.hackclub.com/hcb/{txn_id}`. Always link them there.
+  </api_limitation>
+
+<listing_missing>
+
+- list_missing_receipts paginates through recent transactions and surfaces those with `receipts.missing === true`.
+- Each row includes the transaction id, date, amount_cents, memo, and a direct `href` to the HCB UI for upload.
+  </listing_missing>
+
+<single_status>
+
+- get_receipt_status looks up a single transaction and returns `{ id, count, missing, href }`.
+  </single_status>

--- a/src/lib/ai/skills/finance/skills/transactions/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/transactions/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: transactions
+description: List, inspect, and search Hack Club Bank transactions by memo, amount, or date range.
+criteria: Use when the user asks about recent transactions, a specific charge, or wants to find transactions by memo/amount/date.
+tools: [list_transactions, get_transaction, find_transactions]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+
+- list_transactions returns the most recent transactions (newest first). Page with `per_page` + `page`.
+- Each item: id, date, amount_cents (negative = outflow), memo, type, pending flag, and a receipts summary {count, missing}.
+  </listing>
+
+<details>
+
+- get_transaction returns a single transaction by id, including the receipts summary.
+- Link to the HCB web UI via the `href` field (`hcb.hackclub.com/hcb/{id}`).
+  </details>
+
+<search>
+
+- find_transactions does a client-side filter over up to 500 recent transactions.
+- Filters: memo_contains (case-insensitive substring), min/max_amount_cents (signed), since/until (ISO date), pending ("only" / "exclude" / "any").
+- Useful for "find the $42 charge for badges" or "what did we spend on food last month?" — combine memo_contains with a date range.
+- Amounts are in cents and signed; pass `max_amount_cents: -100` to find outflows ≥ $1.00, for example.
+  </search>

--- a/src/lib/ai/skills/finance/skills/transfers/SKILL.md
+++ b/src/lib/ai/skills/finance/skills/transfers/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: transfers
+description: View Hack Club Bank inter-org transfers (disbursements between HCB organizations).
+criteria: Use when the user asks about transfers, disbursements, or money sent to / received from another HCB org.
+tools: [list_transfers]
+minRole: organizer
+mode: inline
+---
+
+<listing>
+
+- list_transfers shows sender + receiver (org name or slug), amount_cents, status, memo, and created_at.
+- These are specifically **inter-org** HCB transfers — for regular card charges or reimbursements, use `card-charges` or `transactions`.
+  </listing>

--- a/src/lib/ai/tools/finance/base.test.ts
+++ b/src/lib/ai/tools/finance/base.test.ts
@@ -7,7 +7,7 @@ import transactionsFixture from "@/lib/test/fixtures/hcb/transactions.json";
 import { get_balance, get_organization } from "./base.ts";
 import { list_card_charges } from "./card-charges.ts";
 import { donation_totals } from "./donations.ts";
-import { list_missing_receipts } from "./receipts.ts";
+import { get_receipt_status, list_missing_receipts } from "./receipts.ts";
 import { find_transactions, list_transactions } from "./transactions.ts";
 
 const originalFetch = globalThis.fetch;
@@ -162,6 +162,23 @@ describe("list_missing_receipts", () => {
     const parsed = JSON.parse(raw as string);
     expect(parsed.map((t: { id: string }) => t.id).sort()).toEqual(["txn_badge_1", "txn_food_2"]);
     expect(parsed[0].href).toContain("hcb.hackclub.com/hcb/");
+  });
+});
+
+describe("get_receipt_status", () => {
+  it("returns a receipts object consistent with other finance tools", async () => {
+    mockFetch(
+      () =>
+        new Response(JSON.stringify({ id: "txn_food_2", receipts: { count: 0, missing: true } }), {
+          status: 200,
+        }),
+    );
+    const raw = await get_receipt_status.execute!({ id: "txn_food_2" }, toolOpts);
+    expect(JSON.parse(raw as string)).toEqual({
+      id: "txn_food_2",
+      receipts: { count: 0, missing: true },
+      href: "https://hcb.hackclub.com/hcb/txn_food_2",
+    });
   });
 });
 

--- a/src/lib/ai/tools/finance/base.test.ts
+++ b/src/lib/ai/tools/finance/base.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { toolOpts } from "@/lib/test/fixtures";
+import organizationFixture from "@/lib/test/fixtures/hcb/organization.json";
+import transactionsFixture from "@/lib/test/fixtures/hcb/transactions.json";
+
+import { get_balance, get_organization } from "./base.ts";
+import { list_card_charges } from "./card-charges.ts";
+import { donation_totals } from "./donations.ts";
+import { list_missing_receipts } from "./receipts.ts";
+import { find_transactions, list_transactions } from "./transactions.ts";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(impl: (url: URL) => Response) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+    impl(input as URL),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.HCB_ORG_SLUG = "purdue-hackers";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("get_organization", () => {
+  it("returns a compact projection of the org profile", async () => {
+    mockFetch(() => new Response(JSON.stringify(organizationFixture), { status: 200 }));
+    const raw = await get_organization.execute!({}, toolOpts);
+    const parsed = JSON.parse(raw as string);
+    expect(parsed).toMatchObject({
+      id: "org_ph1",
+      name: "Purdue Hackers",
+      slug: "purdue-hackers",
+      transparent: true,
+      balance_cents: 1_234_567,
+      total_raised_cents: 4_321_000,
+    });
+  });
+});
+
+describe("get_balance", () => {
+  it("returns only the balance fields", async () => {
+    mockFetch(() => new Response(JSON.stringify(organizationFixture), { status: 200 }));
+    const raw = await get_balance.execute!({}, toolOpts);
+    expect(JSON.parse(raw as string)).toEqual({
+      balance_cents: 1_234_567,
+      fee_balance_cents: -5000,
+      incoming_balance_cents: 25_000,
+      total_raised_cents: 4_321_000,
+    });
+  });
+});
+
+describe("list_transactions", () => {
+  it("hits the transactions endpoint with default paging", async () => {
+    const seen: URL[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input as URL;
+      seen.push(url);
+      return new Response(JSON.stringify(transactionsFixture), { status: 200 });
+    }) as unknown as typeof fetch;
+    const raw = await list_transactions.execute!(
+      { per_page: undefined, page: undefined },
+      toolOpts,
+    );
+    expect(seen[0].pathname).toBe("/api/v3/organizations/purdue-hackers/transactions");
+    expect(seen[0].searchParams.get("per_page")).toBe("50");
+    const parsed = JSON.parse(raw as string);
+    expect(parsed).toHaveLength(4);
+    expect(parsed[0].href).toBe("https://hcb.hackclub.com/hcb/txn_food_1");
+  });
+});
+
+describe("find_transactions", () => {
+  it("filters by memo substring (case-insensitive)", async () => {
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(transactionsFixture), { status: 200 });
+    });
+    const raw = await find_transactions.execute!({ memo_contains: "HACK NIGHT" }, toolOpts);
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.map((t: { id: string }) => t.id).sort()).toEqual(["txn_food_1", "txn_food_2"]);
+  });
+
+  it("filters by amount and pending status", async () => {
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(transactionsFixture), { status: 200 });
+    });
+    const raw = await find_transactions.execute!(
+      { min_amount_cents: 1, pending: "exclude" },
+      toolOpts,
+    );
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.map((t: { id: string }) => t.id)).toEqual(["txn_donation_1"]);
+  });
+
+  it("filters by ISO date range", async () => {
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(transactionsFixture), { status: 200 });
+    });
+    const raw = await find_transactions.execute!(
+      { since: "2026-04-01", until: "2026-04-30" },
+      toolOpts,
+    );
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.map((t: { id: string }) => t.id).sort()).toEqual([
+      "txn_badge_1",
+      "txn_donation_1",
+    ]);
+  });
+});
+
+describe("donation_totals", () => {
+  it("sums settled donations in the requested window", async () => {
+    const donations = [
+      { amount_cents: 50_000, status: "deposited", created_at: "2026-04-05", recurring: false },
+      { amount_cents: 25_000, status: "deposited", created_at: "2026-04-10", recurring: true },
+      { amount_cents: 100_000, status: "deposited", created_at: "2026-05-01", recurring: false },
+      { amount_cents: 999, status: "pending", created_at: "2026-04-06", recurring: false },
+    ];
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(donations), { status: 200 });
+    });
+    const raw = await donation_totals.execute!(
+      { since: "2026-04-01", until: "2026-04-30" },
+      toolOpts,
+    );
+    expect(JSON.parse(raw as string)).toMatchObject({
+      total_cents: 75_000,
+      count: 2,
+      recurring_cents: 25_000,
+      one_time_cents: 50_000,
+    });
+  });
+});
+
+describe("list_missing_receipts", () => {
+  it("surfaces only transactions flagged missing a receipt", async () => {
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(transactionsFixture), { status: 200 });
+    });
+    const raw = await list_missing_receipts.execute!({ limit: undefined }, toolOpts);
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.map((t: { id: string }) => t.id).sort()).toEqual(["txn_badge_1", "txn_food_2"]);
+    expect(parsed[0].href).toContain("hcb.hackclub.com/hcb/");
+  });
+});
+
+describe("list_card_charges", () => {
+  it("filters by cardholder substring when `user` is provided", async () => {
+    const charges = [
+      { id: "cc_1", user: { name: "Alice Adams", email: "alice@example.com" }, amount_cents: -500 },
+      { id: "cc_2", user: { name: "Bob Baker", email: "bob@example.com" }, amount_cents: -700 },
+    ];
+    mockFetch((url) => {
+      if (Number(url.searchParams.get("page")) > 1) {
+        return new Response("[]", { status: 200 });
+      }
+      return new Response(JSON.stringify(charges), { status: 200 });
+    });
+    const raw = await list_card_charges.execute!({ user: "alice" }, toolOpts);
+    const parsed = JSON.parse(raw as string);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].user).toBe("Alice Adams");
+  });
+});

--- a/src/lib/ai/tools/finance/base.ts
+++ b/src/lib/ai/tools/finance/base.ts
@@ -1,0 +1,60 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug } from "./client.ts";
+
+interface HcbOrganization {
+  id?: string;
+  name?: string;
+  slug?: string;
+  category?: string;
+  transparent?: boolean;
+  website?: string;
+  description?: string;
+  balances?: {
+    balance_cents?: number;
+    fee_balance_cents?: number;
+    incoming_balance_cents?: number;
+    total_raised?: number;
+  };
+}
+
+/** Get the Purdue Hackers HCB organization profile. */
+export const get_organization = tool({
+  description:
+    "Get the Hack Club Bank organization profile — name, slug, website, description, and whether Transparency Mode is enabled. Amounts are in cents.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    const data = await hcbGet<HcbOrganization>(`/organizations/${hcbOrgSlug()}`);
+    return JSON.stringify({
+      id: data.id,
+      name: data.name,
+      slug: data.slug,
+      category: data.category,
+      transparent: data.transparent,
+      website: data.website,
+      description: data.description,
+      balance_cents: data.balances?.balance_cents,
+      fee_balance_cents: data.balances?.fee_balance_cents,
+      incoming_balance_cents: data.balances?.incoming_balance_cents,
+      total_raised_cents: data.balances?.total_raised,
+    });
+  },
+});
+
+/** Get the current HCB account balance summary. */
+export const get_balance = tool({
+  description:
+    "Get the current Hack Club Bank balance summary for Purdue Hackers — cleared balance, incoming (pending) balance, fee balance, and total raised. All amounts in cents (negative = outflow).",
+  inputSchema: z.object({}),
+  execute: async () => {
+    const data = await hcbGet<HcbOrganization>(`/organizations/${hcbOrgSlug()}`);
+    const b = data.balances ?? {};
+    return JSON.stringify({
+      balance_cents: b.balance_cents,
+      fee_balance_cents: b.fee_balance_cents,
+      incoming_balance_cents: b.incoming_balance_cents,
+      total_raised_cents: b.total_raised,
+    });
+  },
+});

--- a/src/lib/ai/tools/finance/card-charges.ts
+++ b/src/lib/ai/tools/finance/card-charges.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl, paginationQuery } from "./client.ts";
+import { paginationInputShape } from "./constants.ts";
 
 interface HcbCardCharge {
   id?: string;
@@ -41,28 +42,29 @@ export const list_card_charges = tool({
       .string()
       .optional()
       .describe("Substring match (case-insensitive) against cardholder name or email"),
-    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
-    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+    ...paginationInputShape,
   }),
-  execute: async ({ user, per_page, page }) => {
+  execute: async ({ user, ...pagination }) => {
+    const path = `/organizations/${hcbOrgSlug()}/card_charges`;
     if (user) {
       const all = await hcbPaginate<HcbCardCharge>(
-        `/organizations/${hcbOrgSlug()}/card_charges`,
+        path,
         {},
-        { maxItems: 500, maxPages: 10, perPage: 100 },
+        {
+          maxItems: 500,
+          maxPages: 10,
+          perPage: 100,
+        },
       );
       const needle = user.toLowerCase();
-      const filtered = all.filter(
+      const matches = all.filter(
         (c) =>
           (c.user?.name ?? "").toLowerCase().includes(needle) ||
           (c.user?.email ?? "").toLowerCase().includes(needle),
       );
-      return JSON.stringify(filtered.map(projectCharge));
+      return JSON.stringify(matches.map(projectCharge));
     }
-    const data = await hcbGet<HcbCardCharge[]>(`/organizations/${hcbOrgSlug()}/card_charges`, {
-      per_page: per_page ?? 50,
-      page: page ?? 1,
-    });
+    const data = await hcbGet<HcbCardCharge[]>(path, paginationQuery(pagination));
     return JSON.stringify(data.map(projectCharge));
   },
 });

--- a/src/lib/ai/tools/finance/card-charges.ts
+++ b/src/lib/ai/tools/finance/card-charges.ts
@@ -1,0 +1,68 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+
+interface HcbCardCharge {
+  id?: string;
+  amount_cents?: number;
+  memo?: string;
+  spent_at?: string;
+  pending?: boolean;
+  user?: { id?: string; name?: string; email?: string };
+  card?: { id?: string; name?: string; last4?: string };
+  merchant?: { name?: string };
+  receipts?: { count?: number; missing?: boolean };
+  transaction_id?: string;
+}
+
+function projectCharge(c: HcbCardCharge) {
+  return {
+    id: c.id,
+    amount_cents: c.amount_cents,
+    memo: c.memo,
+    spent_at: c.spent_at,
+    pending: c.pending,
+    user: c.user?.name,
+    user_email: c.user?.email,
+    card_last4: c.card?.last4,
+    merchant: c.merchant?.name,
+    receipts: c.receipts,
+    href: c.transaction_id ? hcbTxnUrl(c.transaction_id) : undefined,
+  };
+}
+
+/** List HCB card charges, optionally filtered by user. */
+export const list_card_charges = tool({
+  description:
+    "List HCB card charges — merchant, user, amount_cents, and receipts summary {count, missing}. Supports an optional user filter (substring match on cardholder name or email) for microgrant recipient spend tracking.",
+  inputSchema: z.object({
+    user: z
+      .string()
+      .optional()
+      .describe("Substring match (case-insensitive) against cardholder name or email"),
+    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+  }),
+  execute: async ({ user, per_page, page }) => {
+    if (user) {
+      const all = await hcbPaginate<HcbCardCharge>(
+        `/organizations/${hcbOrgSlug()}/card_charges`,
+        {},
+        { maxItems: 500, maxPages: 10, perPage: 100 },
+      );
+      const needle = user.toLowerCase();
+      const filtered = all.filter(
+        (c) =>
+          (c.user?.name ?? "").toLowerCase().includes(needle) ||
+          (c.user?.email ?? "").toLowerCase().includes(needle),
+      );
+      return JSON.stringify(filtered.map(projectCharge));
+    }
+    const data = await hcbGet<HcbCardCharge[]>(`/organizations/${hcbOrgSlug()}/card_charges`, {
+      per_page: per_page ?? 50,
+      page: page ?? 1,
+    });
+    return JSON.stringify(data.map(projectCharge));
+  },
+});

--- a/src/lib/ai/tools/finance/client.test.ts
+++ b/src/lib/ai/tools/finance/client.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(impl: (url: URL) => Response | Promise<Response>) {
+  const fn = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input as URL;
+    return impl(url);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+beforeEach(() => {
+  process.env.HCB_ORG_SLUG = "purdue-hackers";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("hcbOrgSlug", () => {
+  it("returns the configured slug", () => {
+    expect(hcbOrgSlug()).toBe("purdue-hackers");
+  });
+});
+
+describe("hcbTxnUrl", () => {
+  it("builds the HCB web UI link for a transaction id", () => {
+    expect(hcbTxnUrl("txn_abc")).toBe("https://hcb.hackclub.com/hcb/txn_abc");
+  });
+});
+
+describe("hcbGet", () => {
+  it("hits the v3 base URL and returns parsed JSON", async () => {
+    const fetchMock = mockFetch((url) => {
+      expect(url.origin).toBe("https://hcb.hackclub.com");
+      expect(url.pathname).toBe("/api/v3/organizations/purdue-hackers");
+      return new Response(JSON.stringify({ name: "Purdue Hackers" }), { status: 200 });
+    });
+    const data = await hcbGet<{ name: string }>("/organizations/purdue-hackers");
+    expect(data.name).toBe("Purdue Hackers");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("serializes query params, skipping null/undefined", async () => {
+    mockFetch((url) => {
+      expect(url.searchParams.get("page")).toBe("2");
+      expect(url.searchParams.get("per_page")).toBe("100");
+      expect(url.searchParams.has("skip")).toBe(false);
+      return new Response("[]", { status: 200 });
+    });
+    await hcbGet("/organizations/purdue-hackers/transactions", {
+      page: 2,
+      per_page: 100,
+      skip: undefined,
+      other: null,
+    });
+  });
+
+  it("appends array query params as repeated keys", async () => {
+    mockFetch((url) => {
+      expect(url.searchParams.getAll("status")).toEqual(["open", "paid"]);
+      return new Response("[]", { status: 200 });
+    });
+    await hcbGet("/anything", { status: ["open", "paid"] });
+  });
+
+  it("throws a helpful 404 error", async () => {
+    mockFetch(() => new Response("not found", { status: 404 }));
+    await expect(hcbGet("/organizations/missing")).rejects.toThrow(/404/);
+  });
+
+  it("throws a specific message on 429", async () => {
+    mockFetch(() => new Response("rate limited", { status: 429 }));
+    await expect(hcbGet("/x")).rejects.toThrow(/rate limited/i);
+  });
+
+  it("throws with status + body for unexpected errors", async () => {
+    mockFetch(() => new Response("server exploded", { status: 500 }));
+    await expect(hcbGet("/x")).rejects.toThrow(/500/);
+  });
+});
+
+describe("hcbPaginate", () => {
+  it("stops when a page returns an empty array", async () => {
+    const pages: Record<string, unknown[]> = {
+      "1": [{ id: "a" }, { id: "b" }],
+      "2": [],
+    };
+    mockFetch((url) => {
+      const page = url.searchParams.get("page") ?? "1";
+      return new Response(JSON.stringify(pages[page]), { status: 200 });
+    });
+    const rows = await hcbPaginate<{ id: string }>("/transactions", {}, { perPage: 2 });
+    expect(rows.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("stops when a partial page is returned (signals last page)", async () => {
+    const calls: string[] = [];
+    mockFetch((url) => {
+      const page = url.searchParams.get("page") ?? "1";
+      calls.push(page);
+      return new Response(JSON.stringify([{ id: `p${page}` }]), { status: 200 });
+    });
+    const rows = await hcbPaginate<{ id: string }>("/x", {}, { perPage: 50 });
+    expect(calls).toEqual(["1"]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("respects the maxItems cap", async () => {
+    mockFetch((url) => {
+      const page = Number(url.searchParams.get("page") ?? "1");
+      const rows = Array.from({ length: 3 }, (_, i) => ({ id: `${page}-${i}` }));
+      return new Response(JSON.stringify(rows), { status: 200 });
+    });
+    const rows = await hcbPaginate<{ id: string }>(
+      "/x",
+      {},
+      {
+        perPage: 3,
+        maxItems: 4,
+        maxPages: 10,
+      },
+    );
+    expect(rows).toHaveLength(4);
+  });
+
+  it("respects the maxPages cap", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url.searchParams.get("page") ?? "?");
+      return new Response(JSON.stringify([{ id: "x" }, { id: "y" }]), { status: 200 });
+    });
+    await hcbPaginate<{ id: string }>("/x", {}, { perPage: 2, maxPages: 2, maxItems: 1000 });
+    expect(seen).toEqual(["1", "2"]);
+  });
+});

--- a/src/lib/ai/tools/finance/client.test.ts
+++ b/src/lib/ai/tools/finance/client.test.ts
@@ -26,6 +26,16 @@ describe("hcbOrgSlug", () => {
   it("returns the configured slug", () => {
     expect(hcbOrgSlug()).toBe("purdue-hackers");
   });
+
+  it("throws a helpful error when the slug is not configured", () => {
+    const original = process.env.HCB_ORG_SLUG;
+    delete process.env.HCB_ORG_SLUG;
+    try {
+      expect(() => hcbOrgSlug()).toThrow(/HCB_ORG_SLUG/);
+    } finally {
+      if (original !== undefined) process.env.HCB_ORG_SLUG = original;
+    }
+  });
 });
 
 describe("hcbTxnUrl", () => {

--- a/src/lib/ai/tools/finance/client.test.ts
+++ b/src/lib/ai/tools/finance/client.test.ts
@@ -26,16 +26,6 @@ describe("hcbOrgSlug", () => {
   it("returns the configured slug", () => {
     expect(hcbOrgSlug()).toBe("purdue-hackers");
   });
-
-  it("throws a helpful error when the slug is not configured", () => {
-    const original = process.env.HCB_ORG_SLUG;
-    delete process.env.HCB_ORG_SLUG;
-    try {
-      expect(() => hcbOrgSlug()).toThrow(/HCB_ORG_SLUG/);
-    } finally {
-      if (original !== undefined) process.env.HCB_ORG_SLUG = original;
-    }
-  });
 });
 
 describe("hcbTxnUrl", () => {

--- a/src/lib/ai/tools/finance/client.ts
+++ b/src/lib/ai/tools/finance/client.ts
@@ -12,13 +12,7 @@ export function paginationQuery(input: { per_page?: number; page?: number }): {
 }
 
 export function hcbOrgSlug(): string {
-  const slug = env.HCB_ORG_SLUG;
-  if (!slug) {
-    throw new Error(
-      "Finance tools require HCB_ORG_SLUG to be set (Purdue Hackers' Hack Club Bank slug).",
-    );
-  }
-  return slug;
+  return env.HCB_ORG_SLUG;
 }
 
 /** Build a link to the HCB web UI for a transaction id. */

--- a/src/lib/ai/tools/finance/client.ts
+++ b/src/lib/ai/tools/finance/client.ts
@@ -3,6 +3,14 @@ import { env } from "../../../../env.ts";
 const BASE_URL = "https://hcb.hackclub.com/api/v3";
 const REQUEST_TIMEOUT_MS = 15_000;
 
+/** Resolve pagination input to a query-string object with defaults. */
+export function paginationQuery(input: { per_page?: number; page?: number }): {
+  per_page: number;
+  page: number;
+} {
+  return { per_page: input.per_page ?? 50, page: input.page ?? 1 };
+}
+
 export function hcbOrgSlug(): string {
   return env.HCB_ORG_SLUG;
 }

--- a/src/lib/ai/tools/finance/client.ts
+++ b/src/lib/ai/tools/finance/client.ts
@@ -12,7 +12,13 @@ export function paginationQuery(input: { per_page?: number; page?: number }): {
 }
 
 export function hcbOrgSlug(): string {
-  return env.HCB_ORG_SLUG;
+  const slug = env.HCB_ORG_SLUG;
+  if (!slug) {
+    throw new Error(
+      "Finance tools require HCB_ORG_SLUG to be set (Purdue Hackers' Hack Club Bank slug).",
+    );
+  }
+  return slug;
 }
 
 /** Build a link to the HCB web UI for a transaction id. */

--- a/src/lib/ai/tools/finance/client.ts
+++ b/src/lib/ai/tools/finance/client.ts
@@ -1,0 +1,71 @@
+import { env } from "../../../../env.ts";
+
+const BASE_URL = "https://hcb.hackclub.com/api/v3";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export function hcbOrgSlug(): string {
+  return env.HCB_ORG_SLUG;
+}
+
+/** Build a link to the HCB web UI for a transaction id. */
+export function hcbTxnUrl(id: string): string {
+  return `https://hcb.hackclub.com/hcb/${id}`;
+}
+
+/** GET against the HCB v3 public API. Read-only; no auth required (Transparency Mode). */
+export async function hcbGet<T = unknown>(
+  path: string,
+  query?: Record<string, unknown>,
+): Promise<T> {
+  const url = new URL(path.startsWith("http") ? path : `${BASE_URL}${path}`);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const v of value) url.searchParams.append(key, String(v));
+      } else {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`HCB API 404: ${url.pathname} — check the org slug or resource id.`);
+    }
+    if (response.status === 429) {
+      throw new Error("HCB API rate limited. Try again in a moment.");
+    }
+    const body = await response.text().catch(() => "");
+    throw new Error(`HCB API ${response.status}: ${body.slice(0, 200)}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+/** Paginate through a list endpoint until an empty page or the cap is reached. */
+export async function hcbPaginate<T>(
+  path: string,
+  query: Record<string, unknown> = {},
+  {
+    maxItems = 500,
+    maxPages = 10,
+    perPage = 100,
+  }: {
+    maxItems?: number;
+    maxPages?: number;
+    perPage?: number;
+  } = {},
+): Promise<T[]> {
+  const results: T[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const batch = await hcbGet<T[]>(path, { ...query, page, per_page: perPage });
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    results.push(...batch);
+    if (results.length >= maxItems) return results.slice(0, maxItems);
+    if (batch.length < perPage) break;
+  }
+  return results;
+}

--- a/src/lib/ai/tools/finance/constants.ts
+++ b/src/lib/ai/tools/finance/constants.ts
@@ -5,3 +5,11 @@ export const paginationInputShape = {
   per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
   page: z.number().int().min(1).optional().describe("Page number (default 1)"),
 };
+
+/** Validate an ISO date (YYYY-MM-DD) so `Date.parse` never silently yields NaN downstream. */
+export const isoDate = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}(?:T[\d:.]+(?:Z|[+-]\d{2}:?\d{2})?)?$/,
+    "Expected ISO date (YYYY-MM-DD)",
+  );

--- a/src/lib/ai/tools/finance/constants.ts
+++ b/src/lib/ai/tools/finance/constants.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+/** Shared per_page/page input fields — spread into a tool's `z.object({...})`. */
+export const paginationInputShape = {
+  per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+  page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+};

--- a/src/lib/ai/tools/finance/donations.ts
+++ b/src/lib/ai/tools/finance/donations.ts
@@ -1,7 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { hcbGet, hcbOrgSlug, hcbPaginate } from "./client.ts";
+import { hcbGet, hcbOrgSlug, hcbPaginate, paginationQuery } from "./client.ts";
+import { paginationInputShape } from "./constants.ts";
+
+const SETTLED_DONATION_STATUSES = new Set(["deposited", "succeeded", "in_transit"]);
 
 interface HcbDonation {
   id?: string;
@@ -32,15 +35,12 @@ function projectDonation(d: HcbDonation) {
 export const list_donations = tool({
   description:
     "List donations to the Hack Club Bank org — donor name (or '(anonymous)'), amount_cents, status, recurring flag, and message.",
-  inputSchema: z.object({
-    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
-    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
-  }),
-  execute: async ({ per_page, page }) => {
-    const data = await hcbGet<HcbDonation[]>(`/organizations/${hcbOrgSlug()}/donations`, {
-      per_page: per_page ?? 50,
-      page: page ?? 1,
-    });
+  inputSchema: z.object(paginationInputShape),
+  execute: async (input) => {
+    const data = await hcbGet<HcbDonation[]>(
+      `/organizations/${hcbOrgSlug()}/donations`,
+      paginationQuery(input),
+    );
     return JSON.stringify(data.map(projectDonation));
   },
 });
@@ -66,13 +66,7 @@ export const donation_totals = tool({
     let oneTime = 0;
     let count = 0;
     for (const d of all) {
-      if (
-        d.status &&
-        d.status !== "deposited" &&
-        d.status !== "succeeded" &&
-        d.status !== "in_transit"
-      )
-        continue;
+      if (d.status && !SETTLED_DONATION_STATUSES.has(d.status)) continue;
       if (sinceTs !== undefined && d.created_at && Date.parse(d.created_at) < sinceTs) continue;
       if (untilTs !== undefined && d.created_at && Date.parse(d.created_at) > untilTs) continue;
       total += d.amount_cents ?? 0;

--- a/src/lib/ai/tools/finance/donations.ts
+++ b/src/lib/ai/tools/finance/donations.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { hcbGet, hcbOrgSlug, hcbPaginate, paginationQuery } from "./client.ts";
-import { paginationInputShape } from "./constants.ts";
+import { isoDate, paginationInputShape } from "./constants.ts";
 
 const SETTLED_DONATION_STATUSES = new Set(["deposited", "succeeded", "in_transit"]);
 
@@ -50,8 +50,8 @@ export const donation_totals = tool({
   description:
     "Sum successful donations within an ISO date range. Returns total_cents, count, and a breakdown of recurring vs one-time. Useful for fundraising team asks ('what did we raise this month?').",
   inputSchema: z.object({
-    since: z.string().optional().describe("ISO date — include donations on/after this date"),
-    until: z.string().optional().describe("ISO date — include donations on/before this date"),
+    since: isoDate.optional().describe("ISO date (YYYY-MM-DD) — on/after this date"),
+    until: isoDate.optional().describe("ISO date (YYYY-MM-DD) — on/before this date"),
   }),
   execute: async ({ since, until }) => {
     const all = await hcbPaginate<HcbDonation>(
@@ -66,7 +66,8 @@ export const donation_totals = tool({
     let oneTime = 0;
     let count = 0;
     for (const d of all) {
-      if (d.status && !SETTLED_DONATION_STATUSES.has(d.status)) continue;
+      const normalizedStatus = d.status?.toLowerCase();
+      if (!normalizedStatus || !SETTLED_DONATION_STATUSES.has(normalizedStatus)) continue;
       if (sinceTs !== undefined && d.created_at && Date.parse(d.created_at) < sinceTs) continue;
       if (untilTs !== undefined && d.created_at && Date.parse(d.created_at) > untilTs) continue;
       total += d.amount_cents ?? 0;

--- a/src/lib/ai/tools/finance/donations.ts
+++ b/src/lib/ai/tools/finance/donations.ts
@@ -1,0 +1,92 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate } from "./client.ts";
+
+interface HcbDonation {
+  id?: string;
+  amount_cents?: number;
+  name?: string;
+  email?: string;
+  status?: string;
+  recurring?: boolean;
+  anonymous?: boolean;
+  created_at?: string;
+  message?: string;
+}
+
+function projectDonation(d: HcbDonation) {
+  return {
+    id: d.id,
+    amount_cents: d.amount_cents,
+    donor: d.anonymous ? "(anonymous)" : d.name,
+    email: d.anonymous ? undefined : d.email,
+    status: d.status,
+    recurring: d.recurring,
+    created_at: d.created_at,
+    message: d.message,
+  };
+}
+
+/** List donations to the org. */
+export const list_donations = tool({
+  description:
+    "List donations to the Hack Club Bank org — donor name (or '(anonymous)'), amount_cents, status, recurring flag, and message.",
+  inputSchema: z.object({
+    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+  }),
+  execute: async ({ per_page, page }) => {
+    const data = await hcbGet<HcbDonation[]>(`/organizations/${hcbOrgSlug()}/donations`, {
+      per_page: per_page ?? 50,
+      page: page ?? 1,
+    });
+    return JSON.stringify(data.map(projectDonation));
+  },
+});
+
+/** Sum donations in a date window. */
+export const donation_totals = tool({
+  description:
+    "Sum successful donations within an ISO date range. Returns total_cents, count, and a breakdown of recurring vs one-time. Useful for fundraising team asks ('what did we raise this month?').",
+  inputSchema: z.object({
+    since: z.string().optional().describe("ISO date — include donations on/after this date"),
+    until: z.string().optional().describe("ISO date — include donations on/before this date"),
+  }),
+  execute: async ({ since, until }) => {
+    const all = await hcbPaginate<HcbDonation>(
+      `/organizations/${hcbOrgSlug()}/donations`,
+      {},
+      { maxItems: 1000, maxPages: 20, perPage: 100 },
+    );
+    const sinceTs = since ? Date.parse(since) : undefined;
+    const untilTs = until ? Date.parse(until) : undefined;
+    let total = 0;
+    let recurring = 0;
+    let oneTime = 0;
+    let count = 0;
+    for (const d of all) {
+      if (
+        d.status &&
+        d.status !== "deposited" &&
+        d.status !== "succeeded" &&
+        d.status !== "in_transit"
+      )
+        continue;
+      if (sinceTs !== undefined && d.created_at && Date.parse(d.created_at) < sinceTs) continue;
+      if (untilTs !== undefined && d.created_at && Date.parse(d.created_at) > untilTs) continue;
+      total += d.amount_cents ?? 0;
+      count += 1;
+      if (d.recurring) recurring += d.amount_cents ?? 0;
+      else oneTime += d.amount_cents ?? 0;
+    }
+    return JSON.stringify({
+      since,
+      until,
+      total_cents: total,
+      count,
+      recurring_cents: recurring,
+      one_time_cents: oneTime,
+    });
+  },
+});

--- a/src/lib/ai/tools/finance/index.ts
+++ b/src/lib/ai/tools/finance/index.ts
@@ -1,0 +1,7 @@
+export * from "./base.ts";
+export * from "./transactions.ts";
+export * from "./donations.ts";
+export * from "./invoices.ts";
+export * from "./card-charges.ts";
+export * from "./transfers.ts";
+export * from "./receipts.ts";

--- a/src/lib/ai/tools/finance/invoices.ts
+++ b/src/lib/ai/tools/finance/invoices.ts
@@ -1,7 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { hcbGet, hcbOrgSlug, hcbPaginate } from "./client.ts";
+import { hcbGet, hcbOrgSlug, hcbPaginate, paginationQuery } from "./client.ts";
+import { paginationInputShape } from "./constants.ts";
+
+const CLOSED_INVOICE_STATUSES = new Set(["paid", "void", "voided", "deposited"]);
 
 interface HcbInvoice {
   id?: string;
@@ -32,15 +35,12 @@ function projectInvoice(i: HcbInvoice) {
 export const list_invoices = tool({
   description:
     "List invoices sent by the org — sponsor name, amount_cents, status (open/paid/void), due/paid dates, and memo.",
-  inputSchema: z.object({
-    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
-    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
-  }),
-  execute: async ({ per_page, page }) => {
-    const data = await hcbGet<HcbInvoice[]>(`/organizations/${hcbOrgSlug()}/invoices`, {
-      per_page: per_page ?? 50,
-      page: page ?? 1,
-    });
+  inputSchema: z.object(paginationInputShape),
+  execute: async (input) => {
+    const data = await hcbGet<HcbInvoice[]>(
+      `/organizations/${hcbOrgSlug()}/invoices`,
+      paginationQuery(input),
+    );
     return JSON.stringify(data.map(projectInvoice));
   },
 });
@@ -56,10 +56,7 @@ export const list_open_invoices = tool({
       {},
       { maxItems: 500, maxPages: 10, perPage: 100 },
     );
-    const open = all.filter((i) => {
-      const s = (i.status ?? "").toLowerCase();
-      return s !== "paid" && s !== "void" && s !== "voided" && s !== "deposited";
-    });
+    const open = all.filter((i) => !CLOSED_INVOICE_STATUSES.has((i.status ?? "").toLowerCase()));
     return JSON.stringify(open.map(projectInvoice));
   },
 });

--- a/src/lib/ai/tools/finance/invoices.ts
+++ b/src/lib/ai/tools/finance/invoices.ts
@@ -1,0 +1,65 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate } from "./client.ts";
+
+interface HcbInvoice {
+  id?: string;
+  amount_cents?: number;
+  sponsor?: { id?: string; name?: string; email?: string };
+  status?: string;
+  due_date?: string;
+  memo?: string;
+  created_at?: string;
+  paid_at?: string;
+}
+
+function projectInvoice(i: HcbInvoice) {
+  return {
+    id: i.id,
+    amount_cents: i.amount_cents,
+    sponsor: i.sponsor?.name,
+    sponsor_email: i.sponsor?.email,
+    status: i.status,
+    due_date: i.due_date,
+    paid_at: i.paid_at,
+    memo: i.memo,
+    created_at: i.created_at,
+  };
+}
+
+/** List all invoices. */
+export const list_invoices = tool({
+  description:
+    "List invoices sent by the org — sponsor name, amount_cents, status (open/paid/void), due/paid dates, and memo.",
+  inputSchema: z.object({
+    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+  }),
+  execute: async ({ per_page, page }) => {
+    const data = await hcbGet<HcbInvoice[]>(`/organizations/${hcbOrgSlug()}/invoices`, {
+      per_page: per_page ?? 50,
+      page: page ?? 1,
+    });
+    return JSON.stringify(data.map(projectInvoice));
+  },
+});
+
+/** List outstanding (unpaid) invoices. */
+export const list_open_invoices = tool({
+  description:
+    "List outstanding (unpaid) invoices only — drives fundraising follow-ups with sponsors. Paginates through all invoices and filters to statuses that aren't paid/void.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    const all = await hcbPaginate<HcbInvoice>(
+      `/organizations/${hcbOrgSlug()}/invoices`,
+      {},
+      { maxItems: 500, maxPages: 10, perPage: 100 },
+    );
+    const open = all.filter((i) => {
+      const s = (i.status ?? "").toLowerCase();
+      return s !== "paid" && s !== "void" && s !== "voided" && s !== "deposited";
+    });
+    return JSON.stringify(open.map(projectInvoice));
+  },
+});

--- a/src/lib/ai/tools/finance/receipts.ts
+++ b/src/lib/ai/tools/finance/receipts.ts
@@ -52,7 +52,7 @@ export const list_missing_receipts = tool({
 /** Report whether a given transaction has a receipt attached. */
 export const get_receipt_status = tool({
   description:
-    "Report whether a given HCB transaction has a receipt attached — returns {count, missing}. The HCB API does not expose the receipt file itself; to upload or view the actual image/PDF, visit hcb.hackclub.com/hcb/{id}.",
+    "Report whether a given HCB transaction has a receipt attached — returns { id, receipts: { count, missing }, href }. The HCB API does not expose the receipt file itself; to upload or view the actual image/PDF, visit hcb.hackclub.com/hcb/{id}.",
   inputSchema: z.object({
     id: z.string().describe("HCB transaction id"),
   }),
@@ -60,8 +60,10 @@ export const get_receipt_status = tool({
     const data = await hcbGet<HcbTransaction>(`/transactions/${id}`);
     return JSON.stringify({
       id,
-      count: data.receipts?.count ?? 0,
-      missing: data.receipts?.missing ?? false,
+      receipts: {
+        count: data.receipts?.count ?? 0,
+        missing: data.receipts?.missing ?? false,
+      },
       href: hcbTxnUrl(id),
     });
   },

--- a/src/lib/ai/tools/finance/receipts.ts
+++ b/src/lib/ai/tools/finance/receipts.ts
@@ -1,0 +1,68 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+
+interface HcbTransaction {
+  id?: string;
+  date?: string;
+  amount_cents?: number;
+  memo?: string;
+  type?: string;
+  pending?: boolean;
+  receipts?: { count?: number; missing?: boolean };
+}
+
+/**
+ * List transactions flagged as missing a receipt.
+ *
+ * IMPORTANT: the HCB public API v3 does not expose receipt files/URLs. This
+ * tool can only report whether a receipt is attached (via the
+ * `receipts: { count, missing }` summary on each transaction). Uploading or
+ * viewing actual receipt files still requires the HCB web UI.
+ */
+export const list_missing_receipts = tool({
+  description:
+    "List HCB transactions flagged as missing a receipt. Note: only HCB card charges and HCB reimbursements are tracked here — org-wide reimbursements through Purdue's BOSO portal are NOT in HCB. The HCB API does not expose receipt files themselves — only whether one is attached. Link users to hcb.hackclub.com/hcb/{id} to upload/view files.",
+  inputSchema: z.object({
+    limit: z.number().int().min(1).max(200).optional().describe("Max results (default 50)"),
+  }),
+  execute: async ({ limit }) => {
+    const all = await hcbPaginate<HcbTransaction>(
+      `/organizations/${hcbOrgSlug()}/transactions`,
+      {},
+      { maxItems: 500, maxPages: 10, perPage: 100 },
+    );
+    const missing = all.filter((t) => Boolean(t.receipts?.missing));
+    return JSON.stringify(
+      missing.slice(0, limit ?? 50).map((t) => ({
+        id: t.id,
+        date: t.date,
+        amount_cents: t.amount_cents,
+        memo: t.memo,
+        type: t.type,
+        pending: t.pending,
+        receipts: t.receipts,
+        href: t.id ? hcbTxnUrl(t.id) : undefined,
+      })),
+    );
+  },
+});
+
+/** Report whether a given transaction has a receipt attached. */
+export const get_receipt_status = tool({
+  description:
+    "Report whether a given HCB transaction has a receipt attached — returns {count, missing}. The HCB API does not expose the receipt file itself; to upload or view the actual image/PDF, visit hcb.hackclub.com/hcb/{id}.",
+  inputSchema: z.object({
+    id: z.string().describe("HCB transaction id"),
+  }),
+  execute: async ({ id }) => {
+    const data = await hcbGet<HcbTransaction>(`/transactions/${id}`);
+    return JSON.stringify({
+      id,
+      count: data.receipts?.count ?? 0,
+      missing: data.receipts?.missing ?? false,
+      href: hcbTxnUrl(id),
+    });
+  },
+});

--- a/src/lib/ai/tools/finance/transactions.ts
+++ b/src/lib/ai/tools/finance/transactions.ts
@@ -1,0 +1,136 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+
+interface HcbReceiptsSummary {
+  count?: number;
+  missing?: boolean;
+}
+
+interface HcbTransaction {
+  id?: string;
+  date?: string;
+  amount_cents?: number;
+  memo?: string;
+  type?: string;
+  pending?: boolean;
+  receipts?: HcbReceiptsSummary;
+}
+
+function projectTransaction(t: HcbTransaction) {
+  return {
+    id: t.id,
+    date: t.date,
+    amount_cents: t.amount_cents,
+    memo: t.memo,
+    type: t.type,
+    pending: t.pending,
+    receipts: t.receipts,
+    href: t.id ? hcbTxnUrl(t.id) : undefined,
+  };
+}
+
+/** List the most recent transactions. */
+export const list_transactions = tool({
+  description:
+    "List recent HCB transactions for Purdue Hackers — newest first. Each transaction includes id, date, amount_cents (negative = outflow), memo, type, pending flag, and a receipts summary {count, missing}. Receipt files themselves are NOT available via HCB's API; only whether a receipt is attached.",
+  inputSchema: z.object({
+    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+  }),
+  execute: async ({ per_page, page }) => {
+    const data = await hcbGet<HcbTransaction[]>(`/organizations/${hcbOrgSlug()}/transactions`, {
+      per_page: per_page ?? 50,
+      page: page ?? 1,
+    });
+    return JSON.stringify(data.map(projectTransaction));
+  },
+});
+
+/** Get a single transaction by id. */
+export const get_transaction = tool({
+  description:
+    "Get full details for a single HCB transaction by id. Includes receipts summary {count, missing} — note: the actual receipt files are only available in the HCB web UI at hcb.hackclub.com/hcb/{id}, not via this API.",
+  inputSchema: z.object({
+    id: z.string().describe("HCB transaction id (e.g. 'txn_abc123')"),
+  }),
+  execute: async ({ id }) => {
+    const data = await hcbGet<HcbTransaction>(`/transactions/${id}`);
+    return JSON.stringify({ ...projectTransaction(data), href: hcbTxnUrl(id) });
+  },
+});
+
+/** Search transactions by memo substring, amount range, and/or date range. */
+export const find_transactions = tool({
+  description:
+    "Search HCB transactions by memo substring, amount range (in cents), and/or ISO date range. Client-side filter over paginated results (capped). Useful for answering 'find the $42 charge for badges' or 'what did we spend on food last month?'.",
+  inputSchema: z.object({
+    memo_contains: z
+      .string()
+      .optional()
+      .describe("Case-insensitive substring match on the memo field"),
+    min_amount_cents: z
+      .number()
+      .int()
+      .optional()
+      .describe("Inclusive lower bound on amount_cents (signed — negatives are outflows)"),
+    max_amount_cents: z.number().int().optional().describe("Inclusive upper bound on amount_cents"),
+    since: z
+      .string()
+      .optional()
+      .describe("ISO date — only include transactions on/after this date"),
+    until: z
+      .string()
+      .optional()
+      .describe("ISO date — only include transactions on/before this date"),
+    pending: z
+      .enum(["any", "only", "exclude"])
+      .optional()
+      .describe("Filter by pending status (default 'any')"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Max results to return (default 50)"),
+  }),
+  execute: async (input) => {
+    const all = await hcbPaginate<HcbTransaction>(
+      `/organizations/${hcbOrgSlug()}/transactions`,
+      {},
+      { maxItems: 500, maxPages: 10, perPage: 100 },
+    );
+    const predicate = buildTransactionFilter(input);
+    const filtered = all.filter(predicate);
+    return JSON.stringify(filtered.slice(0, input.limit ?? 50).map(projectTransaction));
+  },
+});
+
+interface FindFilter {
+  memo_contains?: string;
+  min_amount_cents?: number;
+  max_amount_cents?: number;
+  since?: string;
+  until?: string;
+  pending?: "any" | "only" | "exclude";
+}
+
+function buildTransactionFilter(f: FindFilter): (t: HcbTransaction) => boolean {
+  const needle = f.memo_contains?.toLowerCase();
+  const sinceTs = f.since ? Date.parse(f.since) : undefined;
+  const untilTs = f.until ? Date.parse(f.until) : undefined;
+  return (t) => {
+    if (needle && !(t.memo ?? "").toLowerCase().includes(needle)) return false;
+    if (f.min_amount_cents !== undefined && (t.amount_cents ?? 0) < f.min_amount_cents)
+      return false;
+    if (f.max_amount_cents !== undefined && (t.amount_cents ?? 0) > f.max_amount_cents)
+      return false;
+    if (sinceTs !== undefined && t.date && Date.parse(t.date) < sinceTs) return false;
+    if (untilTs !== undefined && t.date && Date.parse(t.date) > untilTs) return false;
+    if (f.pending === "only" && !t.pending) return false;
+    if (f.pending === "exclude" && t.pending) return false;
+    return true;
+  };
+}

--- a/src/lib/ai/tools/finance/transactions.ts
+++ b/src/lib/ai/tools/finance/transactions.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl, paginationQuery } from "./client.ts";
-import { paginationInputShape } from "./constants.ts";
+import { isoDate, paginationInputShape } from "./constants.ts";
 
 interface HcbReceiptsSummary {
   count?: number;
@@ -49,7 +49,7 @@ export const list_transactions = tool({
 /** Get a single transaction by id. */
 export const get_transaction = tool({
   description:
-    "Get full details for a single HCB transaction by id. Includes receipts summary {count, missing} — note: the actual receipt files are only available in the HCB web UI at hcb.hackclub.com/hcb/{id}, not via this API.",
+    "Get a single HCB transaction by id. Returns a compact summary with id, date, amount_cents (negative = outflow), memo, type, pending flag, receipts summary {count, missing}, and href. Receipt files themselves are NOT available via HCB's API; only whether a receipt is attached — visit hcb.hackclub.com/hcb/{id} for the actual file.",
   inputSchema: z.object({
     id: z.string().describe("HCB transaction id (e.g. 'txn_abc123')"),
   }),
@@ -74,14 +74,8 @@ export const find_transactions = tool({
       .optional()
       .describe("Inclusive lower bound on amount_cents (signed — negatives are outflows)"),
     max_amount_cents: z.number().int().optional().describe("Inclusive upper bound on amount_cents"),
-    since: z
-      .string()
-      .optional()
-      .describe("ISO date — only include transactions on/after this date"),
-    until: z
-      .string()
-      .optional()
-      .describe("ISO date — only include transactions on/before this date"),
+    since: isoDate.optional().describe("ISO date (YYYY-MM-DD) — on/after this date"),
+    until: isoDate.optional().describe("ISO date (YYYY-MM-DD) — on/before this date"),
     pending: z
       .enum(["any", "only", "exclude"])
       .optional()

--- a/src/lib/ai/tools/finance/transactions.ts
+++ b/src/lib/ai/tools/finance/transactions.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl } from "./client.ts";
+import { hcbGet, hcbOrgSlug, hcbPaginate, hcbTxnUrl, paginationQuery } from "./client.ts";
+import { paginationInputShape } from "./constants.ts";
 
 interface HcbReceiptsSummary {
   count?: number;
@@ -35,15 +36,12 @@ function projectTransaction(t: HcbTransaction) {
 export const list_transactions = tool({
   description:
     "List recent HCB transactions for Purdue Hackers — newest first. Each transaction includes id, date, amount_cents (negative = outflow), memo, type, pending flag, and a receipts summary {count, missing}. Receipt files themselves are NOT available via HCB's API; only whether a receipt is attached.",
-  inputSchema: z.object({
-    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
-    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
-  }),
-  execute: async ({ per_page, page }) => {
-    const data = await hcbGet<HcbTransaction[]>(`/organizations/${hcbOrgSlug()}/transactions`, {
-      per_page: per_page ?? 50,
-      page: page ?? 1,
-    });
+  inputSchema: z.object(paginationInputShape),
+  execute: async (input) => {
+    const data = await hcbGet<HcbTransaction[]>(
+      `/organizations/${hcbOrgSlug()}/transactions`,
+      paginationQuery(input),
+    );
     return JSON.stringify(data.map(projectTransaction));
   },
 });

--- a/src/lib/ai/tools/finance/transfers.ts
+++ b/src/lib/ai/tools/finance/transfers.ts
@@ -1,0 +1,41 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { hcbGet, hcbOrgSlug } from "./client.ts";
+
+interface HcbTransfer {
+  id?: string;
+  amount_cents?: number;
+  memo?: string;
+  status?: string;
+  created_at?: string;
+  sender?: { id?: string; name?: string; slug?: string };
+  receiver?: { id?: string; name?: string; slug?: string };
+}
+
+/** List inter-org transfers (disbursements between HCB orgs). */
+export const list_transfers = tool({
+  description:
+    "List HCB inter-org transfers (disbursements) involving Purdue Hackers — sender, receiver, amount_cents, status, and memo.",
+  inputSchema: z.object({
+    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
+    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
+  }),
+  execute: async ({ per_page, page }) => {
+    const data = await hcbGet<HcbTransfer[]>(`/organizations/${hcbOrgSlug()}/transfers`, {
+      per_page: per_page ?? 50,
+      page: page ?? 1,
+    });
+    return JSON.stringify(
+      data.map((t) => ({
+        id: t.id,
+        amount_cents: t.amount_cents,
+        memo: t.memo,
+        status: t.status,
+        created_at: t.created_at,
+        sender: t.sender?.name ?? t.sender?.slug,
+        receiver: t.receiver?.name ?? t.receiver?.slug,
+      })),
+    );
+  },
+});

--- a/src/lib/ai/tools/finance/transfers.ts
+++ b/src/lib/ai/tools/finance/transfers.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { hcbGet, hcbOrgSlug } from "./client.ts";
+import { hcbGet, hcbOrgSlug, paginationQuery } from "./client.ts";
+import { paginationInputShape } from "./constants.ts";
 
 interface HcbTransfer {
   id?: string;
@@ -17,15 +18,12 @@ interface HcbTransfer {
 export const list_transfers = tool({
   description:
     "List HCB inter-org transfers (disbursements) involving Purdue Hackers — sender, receiver, amount_cents, status, and memo.",
-  inputSchema: z.object({
-    per_page: z.number().int().min(1).max(100).optional().describe("Page size (default 50)"),
-    page: z.number().int().min(1).optional().describe("Page number (default 1)"),
-  }),
-  execute: async ({ per_page, page }) => {
-    const data = await hcbGet<HcbTransfer[]>(`/organizations/${hcbOrgSlug()}/transfers`, {
-      per_page: per_page ?? 50,
-      page: page ?? 1,
-    });
+  inputSchema: z.object(paginationInputShape),
+  execute: async (input) => {
+    const data = await hcbGet<HcbTransfer[]>(
+      `/organizations/${hcbOrgSlug()}/transfers`,
+      paginationQuery(input),
+    );
     return JSON.stringify(
       data.map((t) => ({
         id: t.id,

--- a/src/lib/test/fixtures/hcb/organization.json
+++ b/src/lib/test/fixtures/hcb/organization.json
@@ -1,0 +1,15 @@
+{
+  "id": "org_ph1",
+  "name": "Purdue Hackers",
+  "slug": "purdue-hackers",
+  "category": "hackathon",
+  "transparent": true,
+  "website": "https://purduehackers.com",
+  "description": "Community of student hackers at Purdue University.",
+  "balances": {
+    "balance_cents": 1234567,
+    "fee_balance_cents": -5000,
+    "incoming_balance_cents": 25000,
+    "total_raised": 4321000
+  }
+}

--- a/src/lib/test/fixtures/hcb/transactions.json
+++ b/src/lib/test/fixtures/hcb/transactions.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "txn_food_1",
+    "date": "2026-03-15",
+    "amount_cents": -4200,
+    "memo": "Pizza for Hack Night",
+    "type": "card_charge",
+    "pending": false,
+    "receipts": { "count": 1, "missing": false }
+  },
+  {
+    "id": "txn_food_2",
+    "date": "2026-03-20",
+    "amount_cents": -7800,
+    "memo": "Snacks and drinks for Hack Night",
+    "type": "card_charge",
+    "pending": false,
+    "receipts": { "count": 0, "missing": true }
+  },
+  {
+    "id": "txn_donation_1",
+    "date": "2026-04-01",
+    "amount_cents": 100000,
+    "memo": "Vercel sponsorship",
+    "type": "donation",
+    "pending": false,
+    "receipts": { "count": 0, "missing": false }
+  },
+  {
+    "id": "txn_badge_1",
+    "date": "2026-04-10",
+    "amount_cents": -4200,
+    "memo": "Badge printing supplies",
+    "type": "card_charge",
+    "pending": true,
+    "receipts": { "count": 0, "missing": true }
+  }
+]


### PR DESCRIPTION
## Summary

- Adds a new `finance` delegate subagent wrapping Hack Club Bank's read-only v3 public API so organizers can ask about balance, transactions, donations, invoices, card charges, transfers, and receipt status from Discord.
- Ships tools (`get_organization`, `get_balance`, `list/get/find_transactions`, `list_donations` + `donation_totals`, `list_invoices` + `list_open_invoices`, `list_card_charges` with cardholder filter, `list_transfers`, `list_missing_receipts`, `get_receipt_status`), a top-level + six sub-skill `SKILL.md` tree, registers the domain in `delegates.ts`, and adds `HCB_ORG_SLUG` to `src/env.ts`.
- Scope is fenced to HCB only — BOSO reimbursements are explicitly out of scope in the skill prompts. Receipt files aren't exposed by HCB's API, so the subagent reports `{count, missing}` and links to `hcb.hackclub.com/hcb/{id}`.

## Test plan

- [x] `bun format` / `bun lint` (0 errors) / `bun typecheck`
- [x] `bun run test` — 337/337 passing, including new `client.test.ts` (fetch + pagination edge cases) and `base.test.ts` (tool output shapes against fixtures)
- [x] `bun test:coverage` — thresholds met (99.22% stmts / 96.37% branches)
- [x] `bun knip` clean
- [ ] Manual smoke via `/inspect-context` / local Discord message once `HCB_ORG_SLUG` is set in Vercel env

🤖 Generated with [Claude Code](https://claude.com/claude-code)