### PR TITLE
feat: fetch referenced-message context when mentions are replies

### DIFF
--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -8,12 +8,12 @@ import type { RecentMessage } from "@/lib/ai/types";
 import type { MessageCreatePacketType } from "@/lib/protocol/types";
 import type { ChatHookEvent } from "@/workflows/chat";
 
-type MessageData = MessageCreatePacketType["data"];
-
 import { stripBotMention } from "@/bot/mention";
 import { fetchRecentMessages, fetchReferencedMessageContext } from "@/bot/recent-messages";
 import { AgentContext } from "@/lib/ai/context";
 import { chatWorkflow } from "@/workflows/chat";
+
+type MessageData = MessageCreatePacketType["data"];
 
 async function fetchLeadInMessages(
   discord: API,

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -1,14 +1,41 @@
+import type { API } from "@discordjs/core/http-only";
+
 import { log } from "evlog";
 import { start, resumeHook } from "workflow/api";
 
 import type { HandlerContext } from "@/bot/types";
+import type { RecentMessage } from "@/lib/ai/types";
 import type { MessageCreatePacketType } from "@/lib/protocol/types";
 import type { ChatHookEvent } from "@/workflows/chat";
 
+type MessageData = MessageCreatePacketType["data"];
+
 import { stripBotMention } from "@/bot/mention";
-import { fetchRecentMessages } from "@/bot/recent-messages";
+import { fetchRecentMessages, fetchReferencedMessageContext } from "@/bot/recent-messages";
 import { AgentContext } from "@/lib/ai/context";
 import { chatWorkflow } from "@/workflows/chat";
+
+async function fetchLeadInMessages(
+  discord: API,
+  sourceChannelId: string,
+  data: MessageData,
+): Promise<{ recentMessages?: RecentMessage[]; referencedContext?: RecentMessage[] }> {
+  const recentMessages = await fetchRecentMessages(discord, sourceChannelId, data.id);
+
+  const ref = data.reference;
+  if (!ref?.messageId) return { recentMessages };
+
+  const sameChannel = !ref.channelId || ref.channelId === sourceChannelId;
+  const alreadyInRecent = recentMessages?.some((m) => m.id === ref.messageId) ?? false;
+  if (!sameChannel || alreadyInRecent) return { recentMessages };
+
+  const referencedContext = await fetchReferencedMessageContext(
+    discord,
+    sourceChannelId,
+    ref.messageId,
+  );
+  return { recentMessages, referencedContext };
+}
 
 export async function handleMention(
   packet: MessageCreatePacketType,
@@ -72,10 +99,16 @@ export async function handleMention(
     }
   }
 
-  const recentMessages = await fetchRecentMessages(ctx.discord, sourceChannelId, data.id);
+  const { recentMessages, referencedContext } = await fetchLeadInMessages(
+    ctx.discord,
+    sourceChannelId,
+    data,
+  );
+
   const turnContext = AgentContext.fromPacket(packet, {
     threadOverride: createdThread,
     recentMessages,
+    referencedContext,
   }).toJSON();
 
   log.info("mention", `Starting workflow for ${data.author.username} in ${data.channel.name}`);

--- a/src/bot/recent-messages.test.ts
+++ b/src/bot/recent-messages.test.ts
@@ -52,6 +52,17 @@ describe("fetchRecentMessages", () => {
   });
 });
 
+function rawMsg(id: string, username: string, content: string, time: string): unknown {
+  return { id, author: { username }, content, timestamp: time };
+}
+
+function mockWithAnchor(anchor: unknown, priors: unknown[]) {
+  const mock = createMockAPI();
+  mock.channels.getMessage = async () => anchor as never;
+  mock.channels.getMessages = async () => priors as never;
+  return mock;
+}
+
 describe("fetchReferencedMessageContext", () => {
   it("returns undefined when anchor fetch fails", async () => {
     const mock = createMockAPI();
@@ -65,12 +76,7 @@ describe("fetchReferencedMessageContext", () => {
   it("returns undefined when priors fetch fails", async () => {
     const mock = createMockAPI();
     mock.channels.getMessage = async () =>
-      ({
-        id: "anchor",
-        author: { username: "a" },
-        content: "hi",
-        timestamp: "2024-01-01T13:05:00Z",
-      }) as never;
+      rawMsg("anchor", "a", "hi", "2024-01-01T13:05:00Z") as never;
     mock.channels.getMessages = async () => {
       throw new Error("rate limited");
     };
@@ -79,30 +85,10 @@ describe("fetchReferencedMessageContext", () => {
   });
 
   it("puts the anchor last and reverses priors into chronological order", async () => {
-    const mock = createMockAPI();
-    mock.channels.getMessage = async () =>
-      ({
-        id: "anchor",
-        author: { username: "c" },
-        content: "anchor msg",
-        timestamp: "2024-01-01T13:05:00Z",
-      }) as never;
-    mock.channels.getMessages = async () =>
-      [
-        {
-          id: "p-newer",
-          author: { username: "b" },
-          content: "second",
-          timestamp: "2024-01-01T13:02:00Z",
-        },
-        {
-          id: "p-older",
-          author: { username: "a" },
-          content: "first",
-          timestamp: "2024-01-01T13:01:00Z",
-        },
-      ] as never;
-
+    const mock = mockWithAnchor(rawMsg("anchor", "c", "anchor msg", "2024-01-01T13:05:00Z"), [
+      rawMsg("p-newer", "b", "second", "2024-01-01T13:02:00Z"),
+      rawMsg("p-older", "a", "first", "2024-01-01T13:01:00Z"),
+    ]);
     const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
     expect(result).toEqual([
       { id: "p-older", author: "a", content: "first", timestamp: expect.any(String) },
@@ -111,28 +97,24 @@ describe("fetchReferencedMessageContext", () => {
     ]);
   });
 
-  it("filters empty-content messages but keeps the anchor when it has content", async () => {
-    const mock = createMockAPI();
-    mock.channels.getMessage = async () =>
-      ({
-        id: "anchor",
-        author: { username: "c" },
-        content: "anchor msg",
-        timestamp: "2024-01-01T13:05:00Z",
-      }) as never;
-    mock.channels.getMessages = async () =>
-      [
-        {
-          id: "p-empty",
-          author: { username: "b" },
-          content: "   ",
-          timestamp: "2024-01-01T13:02:00Z",
-        },
-      ] as never;
-
+  it("filters empty-content priors but keeps the anchor when it has content", async () => {
+    const mock = mockWithAnchor(rawMsg("anchor", "c", "anchor msg", "2024-01-01T13:05:00Z"), [
+      rawMsg("p-empty", "b", "   ", "2024-01-01T13:02:00Z"),
+    ]);
     const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
     expect(result).toEqual([
       { id: "anchor", author: "c", content: "anchor msg", timestamp: expect.any(String) },
+    ]);
+  });
+
+  it("keeps an attachment-only anchor with a placeholder so it stays last", async () => {
+    const mock = mockWithAnchor(rawMsg("anchor", "c", "", "2024-01-01T13:05:00Z"), [
+      rawMsg("p-older", "a", "first", "2024-01-01T13:01:00Z"),
+    ]);
+    const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
+    expect(result).toEqual([
+      { id: "p-older", author: "a", content: "first", timestamp: expect.any(String) },
+      { id: "anchor", author: "c", content: "(no text content)", timestamp: expect.any(String) },
     ]);
   });
 });

--- a/src/bot/recent-messages.test.ts
+++ b/src/bot/recent-messages.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import { asAPI, createMockAPI } from "@/lib/test/fixtures";
 
-import { fetchRecentMessages } from "./recent-messages";
+import { fetchRecentMessages, fetchReferencedMessageContext } from "./recent-messages";
 
 function mockWithMessages(messages: unknown[]) {
   const mock = createMockAPI();
@@ -22,8 +22,8 @@ describe("fetchRecentMessages", () => {
 
   it("returns undefined when no messages have content", async () => {
     const mock = mockWithMessages([
-      { author: { username: "a" }, content: "", timestamp: "2024-01-01T00:00:00Z" },
-      { author: { username: "b" }, content: "   ", timestamp: "2024-01-01T00:01:00Z" },
+      { id: "m1", author: { username: "a" }, content: "", timestamp: "2024-01-01T00:00:00Z" },
+      { id: "m2", author: { username: "b" }, content: "   ", timestamp: "2024-01-01T00:01:00Z" },
     ]);
     const result = await fetchRecentMessages(asAPI(mock), "ch-1", "msg-0");
     expect(result).toBeUndefined();
@@ -32,16 +32,107 @@ describe("fetchRecentMessages", () => {
   it("reverses to chronological order and prefers global_name", async () => {
     const mock = mockWithMessages([
       {
+        id: "m2",
         author: { username: "b", global_name: "Bob" },
         content: "world",
         timestamp: "2024-01-01T13:02:00Z",
       },
-      { author: { username: "a" }, content: "hello", timestamp: "2024-01-01T13:01:00Z" },
+      {
+        id: "m1",
+        author: { username: "a" },
+        content: "hello",
+        timestamp: "2024-01-01T13:01:00Z",
+      },
     ]);
     const result = await fetchRecentMessages(asAPI(mock), "ch-1", "msg-0");
     expect(result).toEqual([
-      { author: "a", content: "hello", timestamp: expect.any(String) },
-      { author: "Bob", content: "world", timestamp: expect.any(String) },
+      { id: "m1", author: "a", content: "hello", timestamp: expect.any(String) },
+      { id: "m2", author: "Bob", content: "world", timestamp: expect.any(String) },
+    ]);
+  });
+});
+
+describe("fetchReferencedMessageContext", () => {
+  it("returns undefined when anchor fetch fails", async () => {
+    const mock = createMockAPI();
+    mock.channels.getMessage = async () => {
+      throw new Error("not found");
+    };
+    const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when priors fetch fails", async () => {
+    const mock = createMockAPI();
+    mock.channels.getMessage = async () =>
+      ({
+        id: "anchor",
+        author: { username: "a" },
+        content: "hi",
+        timestamp: "2024-01-01T13:05:00Z",
+      }) as never;
+    mock.channels.getMessages = async () => {
+      throw new Error("rate limited");
+    };
+    const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
+    expect(result).toBeUndefined();
+  });
+
+  it("puts the anchor last and reverses priors into chronological order", async () => {
+    const mock = createMockAPI();
+    mock.channels.getMessage = async () =>
+      ({
+        id: "anchor",
+        author: { username: "c" },
+        content: "anchor msg",
+        timestamp: "2024-01-01T13:05:00Z",
+      }) as never;
+    mock.channels.getMessages = async () =>
+      [
+        {
+          id: "p-newer",
+          author: { username: "b" },
+          content: "second",
+          timestamp: "2024-01-01T13:02:00Z",
+        },
+        {
+          id: "p-older",
+          author: { username: "a" },
+          content: "first",
+          timestamp: "2024-01-01T13:01:00Z",
+        },
+      ] as never;
+
+    const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
+    expect(result).toEqual([
+      { id: "p-older", author: "a", content: "first", timestamp: expect.any(String) },
+      { id: "p-newer", author: "b", content: "second", timestamp: expect.any(String) },
+      { id: "anchor", author: "c", content: "anchor msg", timestamp: expect.any(String) },
+    ]);
+  });
+
+  it("filters empty-content messages but keeps the anchor when it has content", async () => {
+    const mock = createMockAPI();
+    mock.channels.getMessage = async () =>
+      ({
+        id: "anchor",
+        author: { username: "c" },
+        content: "anchor msg",
+        timestamp: "2024-01-01T13:05:00Z",
+      }) as never;
+    mock.channels.getMessages = async () =>
+      [
+        {
+          id: "p-empty",
+          author: { username: "b" },
+          content: "   ",
+          timestamp: "2024-01-01T13:02:00Z",
+        },
+      ] as never;
+
+    const result = await fetchReferencedMessageContext(asAPI(mock), "ch-1", "anchor");
+    expect(result).toEqual([
+      { id: "anchor", author: "c", content: "anchor msg", timestamp: expect.any(String) },
     ]);
   });
 });

--- a/src/bot/recent-messages.ts
+++ b/src/bot/recent-messages.ts
@@ -5,6 +5,21 @@ import { log } from "evlog";
 import type { RecentMessage } from "@/lib/ai/types";
 
 const MAX_RECENT_MESSAGES = 15;
+const REFERENCED_CONTEXT_SIZE = 15;
+
+type RawMessage = Awaited<ReturnType<API["channels"]["getMessage"]>>;
+
+function toRecentMessage(m: RawMessage): RecentMessage {
+  return {
+    id: m.id,
+    author: (m.author as { global_name?: string }).global_name ?? m.author.username,
+    content: m.content,
+    timestamp: new Date(m.timestamp).toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+  };
+}
 
 export async function fetchRecentMessages(
   discord: API,
@@ -18,21 +33,47 @@ export async function fetchRecentMessages(
     });
 
     // Discord returns newest-first; keep chronological order
-    const messages: RecentMessage[] = raw
+    const messages = raw
       .filter((m) => m.content?.trim())
       .reverse()
-      .map((m) => ({
-        author: (m.author as { global_name?: string }).global_name ?? m.author.username,
-        content: m.content,
-        timestamp: new Date(m.timestamp).toLocaleTimeString("en-US", {
-          hour: "numeric",
-          minute: "2-digit",
-        }),
-      }));
+      .map(toRecentMessage);
 
     return messages.length > 0 ? messages : undefined;
   } catch (err) {
     log.warn("recent-messages", `Failed to fetch: ${String(err)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Fetch the referenced message plus the 14 messages that immediately preceded
+ * it, in chronological order. Used when a mention arrives as a reply to older
+ * chatter that isn't in the recent-messages tail — gives the model the anchor
+ * plus context leading up to it.
+ */
+export async function fetchReferencedMessageContext(
+  discord: API,
+  channelId: string,
+  referencedMessageId: string,
+): Promise<RecentMessage[] | undefined> {
+  try {
+    const [anchor, priors] = await Promise.all([
+      discord.channels.getMessage(channelId, referencedMessageId),
+      discord.channels.getMessages(channelId, {
+        before: referencedMessageId,
+        limit: REFERENCED_CONTEXT_SIZE - 1,
+      }),
+    ]);
+
+    // priors is newest-first; chronological = reverse(priors) then anchor
+    const chronological: RawMessage[] = [...priors].reverse();
+    chronological.push(anchor);
+
+    const messages = chronological.filter((m) => m.content?.trim()).map(toRecentMessage);
+
+    return messages.length > 0 ? messages : undefined;
+  } catch (err) {
+    log.warn("recent-messages", `Failed to fetch referenced context: ${String(err)}`);
     return undefined;
   }
 }

--- a/src/bot/recent-messages.ts
+++ b/src/bot/recent-messages.ts
@@ -65,11 +65,10 @@ export async function fetchReferencedMessageContext(
       }),
     ]);
 
-    // priors is newest-first; chronological = reverse(priors) then anchor
-    const chronological: RawMessage[] = [...priors].reverse();
-    chronological.push(anchor);
-
-    const messages = chronological.filter((m) => m.content?.trim()).map(toRecentMessage);
+    // Discord returns priors newest-first; chronological = reverse(priors) then anchor.
+    const messages = [...priors.toReversed(), anchor]
+      .filter((m) => m.content?.trim())
+      .map(toRecentMessage);
 
     return messages.length > 0 ? messages : undefined;
   } catch (err) {

--- a/src/bot/recent-messages.ts
+++ b/src/bot/recent-messages.ts
@@ -13,7 +13,11 @@ function toRecentMessage(m: RawMessage): RecentMessage {
   return {
     id: m.id,
     author: (m.author as { global_name?: string }).global_name ?? m.author.username,
-    content: m.content,
+    // Attachment-only / sticker messages arrive with empty content. Render a
+    // placeholder so callers that include such messages (e.g. the anchor of a
+    // reply-context fetch) produce a line the model can see, rather than a
+    // dangling `author:` with nothing after it.
+    content: m.content?.trim() ? m.content : "(no text content)",
     timestamp: new Date(m.timestamp).toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",
@@ -65,12 +69,12 @@ export async function fetchReferencedMessageContext(
       }),
     ]);
 
-    // Discord returns priors newest-first; chronological = reverse(priors) then anchor.
-    const messages = [...priors.toReversed(), anchor]
-      .filter((m) => m.content?.trim())
-      .map(toRecentMessage);
-
-    return messages.length > 0 ? messages : undefined;
+    // Priors come newest-first; reverse for chronological order and drop
+    // empty-content entries. The anchor is always kept as the last element —
+    // even if it's attachment-only — so "last item = reply target" holds
+    // and the model can see what was being replied to.
+    const chronologicalPriors = priors.toReversed().filter((m) => m.content?.trim());
+    return [...chronologicalPriors, anchor].map(toRecentMessage);
   } catch (err) {
     log.warn("recent-messages", `Failed to fetch referenced context: ${String(err)}`);
     return undefined;

--- a/src/lib/ai/context.test.ts
+++ b/src/lib/ai/context.test.ts
@@ -89,9 +89,15 @@ describe("AgentContext.fromPacket", () => {
   });
 
   it("attaches recentMessages when provided", () => {
-    const messages = [{ author: "bob", content: "hi", timestamp: "1:00 PM" }];
+    const messages = [{ id: "m-bob", author: "bob", content: "hi", timestamp: "1:00 PM" }];
     const ctx = AgentContext.fromPacket(messagePacket("hello"), { recentMessages: messages });
     expect(ctx.recentMessages).toEqual(messages);
+  });
+
+  it("attaches referencedContext when provided", () => {
+    const ref = [{ id: "anchor", author: "carol", content: "original", timestamp: "12:55 PM" }];
+    const ctx = AgentContext.fromPacket(messagePacket("hello"), { referencedContext: ref });
+    expect(ctx.referencedContext).toEqual(ref);
   });
 });
 
@@ -192,7 +198,7 @@ describe("AgentContext.buildInstructions", () => {
   it("uses recent_thread_messages tag when lead-in came from the thread", () => {
     const ctx = AgentContext.fromPacket(
       messagePacket("hello", { thread: { parentId: "p1", parentName: "parent" } }),
-      { recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }] },
+      { recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }] },
     );
     const result = ctx.buildInstructions("Base.");
     expect(result).toContain("<recent_thread_messages>");
@@ -201,7 +207,7 @@ describe("AgentContext.buildInstructions", () => {
 
   it("uses recent_channel_messages tag when not in a thread", () => {
     const ctx = AgentContext.fromPacket(messagePacket("hello"), {
-      recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }],
+      recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }],
     });
     const result = ctx.buildInstructions("Base.");
     expect(result).toContain("<recent_channel_messages>");
@@ -213,11 +219,30 @@ describe("AgentContext.buildInstructions", () => {
     // came from the parent channel, not the newly-created thread.
     const ctx = AgentContext.fromPacket(messagePacket("hello"), {
       threadOverride: { id: "thread-99", name: "new" },
-      recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }],
+      recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }],
     });
     const result = ctx.buildInstructions("Base.");
     expect(result).toContain("<recent_channel_messages>");
     expect(result).not.toContain("<recent_thread_messages>");
+  });
+
+  it("renders <referenced_message_context> when referencedContext is set", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"), {
+      recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }],
+      referencedContext: [
+        { id: "anchor", author: "carol", content: "original", timestamp: "12:55 PM" },
+      ],
+    });
+    const result = ctx.buildInstructions("Base.");
+    expect(result).toContain("<referenced_message_context>");
+    expect(result).toContain("carol: original");
+  });
+
+  it("omits <referenced_message_context> when referencedContext is empty", () => {
+    const ctx = AgentContext.fromPacket(messagePacket("hello"), {
+      recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }],
+    });
+    expect(ctx.buildInstructions("Base.")).not.toContain("<referenced_message_context>");
   });
 
   it("falls back to thread presence when recentMessagesFromThread is absent", () => {
@@ -229,7 +254,7 @@ describe("AgentContext.buildInstructions", () => {
       channel: { id: "t", name: "t" },
       thread: { id: "t", name: "t", parentChannel: { id: "p", name: "p" } },
       date: "today",
-      recentMessages: [{ author: "bob", content: "hey", timestamp: "1:00 PM" }],
+      recentMessages: [{ id: "m-bob", author: "bob", content: "hey", timestamp: "1:00 PM" }],
     });
     const result = ctx.buildInstructions("Base.");
     expect(result).toContain("<recent_thread_messages>");

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -34,6 +34,7 @@ export class AgentContext {
   readonly memberRoles?: string[];
   readonly recentMessages?: RecentMessage[];
   readonly recentMessagesFromThread?: boolean;
+  readonly referencedContext?: RecentMessage[];
 
   private constructor(data: SerializedAgentContext) {
     this.userId = data.userId;
@@ -46,6 +47,7 @@ export class AgentContext {
     this.memberRoles = data.memberRoles;
     this.recentMessages = data.recentMessages;
     this.recentMessagesFromThread = data.recentMessagesFromThread;
+    this.referencedContext = data.referencedContext;
   }
 
   /** Resolve Discord role IDs to an application-level access tier. */
@@ -63,16 +65,20 @@ export class AgentContext {
    *   The packet still describes the parent channel; pass the new thread and
    *   the context's `channel`/`thread` fields will reflect the thread instead.
    * - `recentMessages`: attach the recent-messages block fetched separately.
+   * - `referencedContext`: attach a second lead-in block built from the
+   *   referenced message (when the mention was a reply) plus messages
+   *   preceding it.
    */
   static fromPacket(
     packet: MessageCreatePacketType,
     options?: {
       threadOverride?: { id: string; name: string };
       recentMessages?: RecentMessage[];
+      referencedContext?: RecentMessage[];
     },
   ): AgentContext {
     const { data } = packet;
-    const { threadOverride, recentMessages } = options ?? {};
+    const { threadOverride, recentMessages, referencedContext } = options ?? {};
 
     let channel: ChannelInfo;
     let thread: ThreadInfo | undefined;
@@ -126,6 +132,7 @@ export class AgentContext {
       memberRoles: data.memberRoles ?? undefined,
       recentMessages,
       recentMessagesFromThread,
+      referencedContext,
     });
   }
 
@@ -145,6 +152,7 @@ export class AgentContext {
       memberRoles: this.memberRoles,
       recentMessages: this.recentMessages,
       recentMessagesFromThread: this.recentMessagesFromThread,
+      referencedContext: this.referencedContext,
     };
   }
 
@@ -174,6 +182,12 @@ export class AgentContext {
           .join("\n")}\n</${msgTag}>`
       : "";
 
+    const refMsgs = this.referencedContext?.length
+      ? `\n\n<referenced_message_context>\nThe user's mention was a reply to a message in this channel. Below is that message (last) plus the messages that immediately preceded it, in chronological order.\n${this.referencedContext
+          .map((m) => `[${m.timestamp}] ${m.author}: ${m.content}`)
+          .join("\n")}\n</referenced_message_context>`
+      : "";
+
     return `<execution_context>
 \`\`\`yaml
 user:
@@ -185,6 +199,6 @@ channel:
   id: "${this.channel.id}"${thread}
 date: "${this.date}"
 \`\`\`
-</execution_context>${recentMsgs}`;
+</execution_context>${recentMsgs}${refMsgs}`;
   }
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -20,6 +20,8 @@ export interface Attachment {
 }
 
 export interface RecentMessage {
+  /** Discord message ID — used to dedupe against other context batches. Not rendered. */
+  id: string;
   author: string;
   content: string;
   timestamp: string;
@@ -49,6 +51,13 @@ export interface SerializedAgentContext {
    * lead-in is actually channel chatter.
    */
   recentMessagesFromThread?: boolean;
+  /**
+   * Extra lead-in fetched when the triggering mention was a reply to another
+   * message: the referenced message plus up to 14 messages immediately
+   * preceding it, in chronological order. Only set when the reply target is
+   * not already included in `recentMessages`.
+   */
+  referencedContext?: RecentMessage[];
 }
 
 export interface FooterMeta {

--- a/src/lib/protocol/packets.ts
+++ b/src/lib/protocol/packets.ts
@@ -49,6 +49,12 @@ const MessageData = z.object({
   flags: z.number().optional(),
   categoryId: z.string().optional(),
   forwardedSnapshots: z.array(MessageSnapshot).optional(),
+  reference: z
+    .object({
+      messageId: z.string(),
+      channelId: z.string().optional(),
+    })
+    .optional(),
 });
 
 const ReactionDataEmoji = z.object({

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -213,6 +213,12 @@ function bindMessageHandlers(client: Client, publish: Publish): void {
             height: a.height ?? undefined,
           })),
         })),
+        reference: message.reference?.messageId
+          ? {
+              messageId: message.reference.messageId,
+              channelId: message.reference.channelId ?? undefined,
+            }
+          : undefined,
       },
     });
   });

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -99,6 +99,7 @@ export async function chatWorkflow(payload: ChatPayload) {
   const stableChannel = context.channel;
   const stableThread = context.thread;
   const stableRecentMessages = context.recentMessages;
+  const stableReferencedContext = context.referencedContext;
 
   const messages: ChatMessage[] = [{ role: "user", content }];
   const first = await runTurn(channelId, messages, context);
@@ -129,6 +130,7 @@ export async function chatWorkflow(payload: ChatPayload) {
       channel: stableChannel,
       thread: stableThread,
       recentMessages: stableRecentMessages,
+      referencedContext: stableReferencedContext,
     };
 
     messages.push({ role: "user", content: event.content });


### PR DESCRIPTION
## Summary
- When the bot is @-mentioned in a **reply**, fetch the referenced message plus the 14 messages immediately preceding it (chronological) and include them as a new `<referenced_message_context>` block alongside the existing 15-message channel tail.
- Same-channel only; deduped against the recent-15 tail so no redundant API calls when the reply target is already visible.
- `RecentMessage` gains an (unrendered) `id` field to support dedupe; new context is pinned across follow-up turns in `chatWorkflow`.

## Test plan
- [x] `bun format` / `bun lint` / `bun typecheck` green (1 pre-existing sentry warning, unrelated)
- [x] `bun run test` — 323/323 passing, with new unit tests for `fetchReferencedMessageContext` and the new context block
- [ ] Manual: reply-mention with target outside recent-15 → snapshot contains both blocks; reply-mention with target inside recent-15 → no extra fetch; cross-channel reply → skipped; follow-up turn pins referenced context

🤖 Generated with [Claude Code](https://claude.com/claude-code)