### PR TITLE
feat: trigger mention handler on thread replies to the bot

### DIFF
--- a/src/bot/mention.test.ts
+++ b/src/bot/mention.test.ts
@@ -1,43 +1,98 @@
 import { describe, it, expect } from "vitest";
 
-import { isBotMention, stripBotMention } from "./mention";
+import type { MessageCreatePacketType } from "@/lib/protocol/types";
+
+import { messagePacket } from "@/lib/test/fixtures";
+
+import { isBotMention, isReplyToBot, stripBotMention } from "./mention";
 
 const BOT = "bot-123";
 
+function data(
+  content: string,
+  overrides: Record<string, unknown> = {},
+): MessageCreatePacketType["data"] {
+  return messagePacket(content, overrides).data;
+}
+
 describe("isBotMention", () => {
-  it("matches the standard mention form", () => {
-    expect(isBotMention("<@bot-123> hi", BOT)).toBe(true);
+  it("matches the standard mention form when the bot is in mentions", () => {
+    expect(isBotMention(data(`<@${BOT}> hi`, { mentions: [BOT] }), BOT)).toBe(true);
   });
 
-  it("matches the nickname mention form", () => {
-    expect(isBotMention("<@!bot-123> hi", BOT)).toBe(true);
+  it("matches the nickname mention form when the bot is in mentions", () => {
+    expect(isBotMention(data(`<@!${BOT}> hi`, { mentions: [BOT] }), BOT)).toBe(true);
+  });
+
+  it("rejects leading `<@id>` text when the bot is not in the native mentions array", () => {
+    // e.g. pasted as literal text or inside a code fence — Discord's gateway
+    // does not include the bot in `mentions` in this case.
+    expect(isBotMention(data(`<@${BOT}> hi`, { mentions: [] }), BOT)).toBe(false);
   });
 
   it("ignores mentions of other users", () => {
-    expect(isBotMention("<@other> hi", BOT)).toBe(false);
-    expect(isBotMention("<@!other> hi", BOT)).toBe(false);
+    expect(isBotMention(data("<@other> hi", { mentions: ["other"] }), BOT)).toBe(false);
   });
 
   it("ignores non-mentions", () => {
-    expect(isBotMention("hello there", BOT)).toBe(false);
+    expect(isBotMention(data("hello there"), BOT)).toBe(false);
   });
 
   it("requires the mention at the start", () => {
-    expect(isBotMention("oh <@bot-123> hi", BOT)).toBe(false);
+    expect(isBotMention(data(`oh <@${BOT}> hi`, { mentions: [BOT] }), BOT)).toBe(false);
+  });
+
+  it("returns false on empty content", () => {
+    expect(isBotMention(data("", { mentions: [BOT] }), BOT)).toBe(false);
+  });
+});
+
+describe("isReplyToBot", () => {
+  const thread = { parentId: "ch-parent", parentName: "parent" };
+
+  it("is true for a thread reply to the bot", () => {
+    expect(
+      isReplyToBot(data("hi", { thread, reference: { messageId: "msg-0", authorId: BOT } }), BOT),
+    ).toBe(true);
+  });
+
+  it("is false for a thread reply to someone else", () => {
+    expect(
+      isReplyToBot(
+        data("hi", { thread, reference: { messageId: "msg-0", authorId: "other" } }),
+        BOT,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for a reply to the bot outside a thread", () => {
+    expect(
+      isReplyToBot(data("hi", { reference: { messageId: "msg-0", authorId: BOT } }), BOT),
+    ).toBe(false);
+  });
+
+  it("is false in a thread with no reference", () => {
+    expect(isReplyToBot(data("hi", { thread }), BOT)).toBe(false);
+  });
+
+  it("is false when the referenced author is unknown", () => {
+    expect(isReplyToBot(data("hi", { thread, reference: { messageId: "msg-0" } }), BOT)).toBe(
+      false,
+    );
   });
 });
 
 describe("stripBotMention", () => {
   it("strips the standard form", () => {
-    expect(stripBotMention("<@bot-123> hello world", BOT)).toBe("hello world");
+    expect(stripBotMention(`<@${BOT}> hello world`, BOT)).toBe("hello world");
   });
 
   it("strips the nickname form", () => {
-    expect(stripBotMention("<@!bot-123> hello world", BOT)).toBe("hello world");
+    expect(stripBotMention(`<@!${BOT}> hello world`, BOT)).toBe("hello world");
   });
 
   it("trims whitespace after the mention", () => {
-    expect(stripBotMention("<@bot-123>   hi   ", BOT)).toBe("hi");
+    expect(stripBotMention(`<@${BOT}>   hi   `, BOT)).toBe("hi");
   });
 
   it("returns the content unchanged when no mention present", () => {
@@ -45,6 +100,6 @@ describe("stripBotMention", () => {
   });
 
   it("does not strip mid-message mentions", () => {
-    expect(stripBotMention("hi <@bot-123>", BOT)).toBe("hi <@bot-123>");
+    expect(stripBotMention(`hi <@${BOT}>`, BOT)).toBe(`hi <@${BOT}>`);
   });
 });

--- a/src/bot/mention.ts
+++ b/src/bot/mention.ts
@@ -1,15 +1,28 @@
-/**
- * Discord emits user mentions in two forms:
- *   - `<@id>`  — standard mention
- *   - `<@!id>` — nickname mention (older clients, still seen in historical
- *                messages and some gateway payloads)
- *
- * The bot's at-mention detection has to handle both, otherwise `<@!id>` pings
- * get missed or have the prefix left in the content after "stripping".
- */
+import type { MessageCreatePacketType } from "@/lib/protocol/types";
 
-export function isBotMention(content: string, botUserId: string): boolean {
-  return content.startsWith(`<@${botUserId}>`) || content.startsWith(`<@!${botUserId}>`);
+type MessageData = MessageCreatePacketType["data"];
+
+/**
+ * True when the bot is @-mentioned at the start of the message. Combines two
+ * signals: Discord's native `mentions` array (filters out literal `<@id>` text
+ * that isn't actually pinging anyone) and a content-position check (preserves
+ * the "only trigger when the mention leads the message" rule).
+ *
+ * Discord emits mentions as `<@id>` or `<@!id>` (nickname form, older clients).
+ */
+export function isBotMention(data: MessageData, botUserId: string): boolean {
+  if (!data.mentions.includes(botUserId)) return false;
+  return data.content.startsWith(`<@${botUserId}>`) || data.content.startsWith(`<@!${botUserId}>`);
+}
+
+/**
+ * True when a thread message is a reply to a bot-authored message. Replies
+ * outside threads don't count — the thread scope is what distinguishes
+ * "continuing a conversation with the bot" from "quoting the bot at someone
+ * else in a busy channel".
+ */
+export function isReplyToBot(data: MessageData, botUserId: string): boolean {
+  return Boolean(data.thread && data.reference?.authorId === botUserId);
 }
 
 export function stripBotMention(content: string, botUserId: string): string {

--- a/src/bot/router.test.ts
+++ b/src/bot/router.test.ts
@@ -18,7 +18,10 @@ describe("EventRouter - message routing", () => {
     const router = new EventRouter();
     const handler = vi.fn();
     router.onMention(handler);
-    await router.dispatch(messagePacket("<@bot-123> hello"), handlerCtx());
+    await router.dispatch(
+      messagePacket("<@bot-123> hello", { mentions: ["bot-123"] }),
+      handlerCtx(),
+    );
     expect(handler).toHaveBeenCalledOnce();
   });
 
@@ -35,7 +38,10 @@ describe("EventRouter - message routing", () => {
     const mention = vi.fn();
     const message = vi.fn();
     router.onMention(mention).onMessage(message);
-    await router.dispatch(messagePacket("<@bot-123> hello"), handlerCtx());
+    await router.dispatch(
+      messagePacket("<@bot-123> hello", { mentions: ["bot-123"] }),
+      handlerCtx(),
+    );
     expect(mention).toHaveBeenCalledOnce();
     expect(message).toHaveBeenCalledOnce();
   });
@@ -62,6 +68,68 @@ describe("EventRouter - message routing", () => {
     router.onMessageDelete(handler);
     await router.dispatch(deletePacket(), handlerCtx());
     expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("EventRouter - mention edge cases", () => {
+  it("does not route mid-sentence mentions of the bot", async () => {
+    const router = new EventRouter();
+    const handler = vi.fn();
+    router.onMention(handler);
+    await router.dispatch(
+      messagePacket("hey <@bot-123> fyi", { mentions: ["bot-123"] }),
+      handlerCtx(),
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not route leading `<@id>` when the bot is not in the native mentions array", async () => {
+    const router = new EventRouter();
+    const handler = vi.fn();
+    router.onMention(handler);
+    await router.dispatch(messagePacket("<@bot-123> hi", { mentions: [] }), handlerCtx());
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("routes thread replies to the bot as mentions", async () => {
+    const router = new EventRouter();
+    const handler = vi.fn();
+    router.onMention(handler);
+    await router.dispatch(
+      messagePacket("following up", {
+        thread: { parentId: "ch-parent", parentName: "parent" },
+        reference: { messageId: "msg-0", authorId: "bot-123" },
+      }),
+      handlerCtx(),
+    );
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not route replies to the bot outside a thread", async () => {
+    const router = new EventRouter();
+    const handler = vi.fn();
+    router.onMention(handler);
+    await router.dispatch(
+      messagePacket("following up", {
+        reference: { messageId: "msg-0", authorId: "bot-123" },
+      }),
+      handlerCtx(),
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not route thread replies to non-bot authors", async () => {
+    const router = new EventRouter();
+    const handler = vi.fn();
+    router.onMention(handler);
+    await router.dispatch(
+      messagePacket("following up", {
+        thread: { parentId: "ch-parent", parentName: "parent" },
+        reference: { messageId: "msg-0", authorId: "someone-else" },
+      }),
+      handlerCtx(),
+    );
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 

--- a/src/bot/router.ts
+++ b/src/bot/router.ts
@@ -13,7 +13,7 @@ import { PacketCodec } from "@/lib/protocol/packets";
 
 import type { HandlerContext } from "./types";
 
-import { isBotMention } from "./mention";
+import { isBotMention, isReplyToBot } from "./mention";
 
 export type { HandlerContext } from "./types";
 
@@ -73,7 +73,7 @@ export class EventRouter {
 
     switch (packet.type) {
       case "GATEWAY_MESSAGE_CREATE": {
-        if (isBotMention(packet.data.content, ctx.botUserId)) {
+        if (isBotMention(packet.data, ctx.botUserId) || isReplyToBot(packet.data, ctx.botUserId)) {
           await run(this.handlers.mention, packet);
         }
         await run(this.handlers.message, packet);

--- a/src/lib/protocol/packets.test.ts
+++ b/src/lib/protocol/packets.test.ts
@@ -96,7 +96,7 @@ describe("PacketCodec", () => {
 });
 
 describe("PacketCodec - mentions defaulting", () => {
-  it("defaults mentions to an empty array when omitted on the wire", () => {
+  it("defaults mentions to an empty array on MESSAGE_CREATE when omitted on the wire", () => {
     const raw = JSON.stringify({
       type: "GATEWAY_MESSAGE_CREATE",
       timestamp: new Date("2024-01-01"),
@@ -113,6 +113,17 @@ describe("PacketCodec - mentions defaulting", () => {
     const decoded = PacketCodec.decode(raw);
     if (decoded.type !== "GATEWAY_MESSAGE_CREATE") throw new Error("wrong type");
     expect(decoded.data.mentions).toEqual([]);
+  });
+
+  it("leaves mentions undefined on MESSAGE_UPDATE when omitted (no default leak)", () => {
+    const raw = JSON.stringify({
+      type: "GATEWAY_MESSAGE_UPDATE",
+      timestamp: new Date("2024-01-01"),
+      data: { id: "msg-1", channelId: "ch-1", guildId: "guild-1" },
+    });
+    const decoded = PacketCodec.decode(raw);
+    if (decoded.type !== "GATEWAY_MESSAGE_UPDATE") throw new Error("wrong type");
+    expect(decoded.data.mentions).toBeUndefined();
   });
 });
 

--- a/src/lib/protocol/packets.test.ts
+++ b/src/lib/protocol/packets.test.ts
@@ -62,6 +62,12 @@ describe("PacketCodec", () => {
               size: 1024,
             },
           ],
+          mentions: ["bot-123", "user-2"],
+          reference: {
+            messageId: "msg-0",
+            channelId: "ch-1",
+            authorId: "bot-123",
+          },
         }),
       ),
     );
@@ -71,6 +77,12 @@ describe("PacketCodec", () => {
     expect(decoded.data.memberRoles).toEqual(["role-1", "role-2"]);
     expect(decoded.data.author.nickname).toBe("Ali");
     expect(decoded.data.attachments).toHaveLength(1);
+    expect(decoded.data.mentions).toEqual(["bot-123", "user-2"]);
+    expect(decoded.data.reference).toEqual({
+      messageId: "msg-0",
+      channelId: "ch-1",
+      authorId: "bot-123",
+    });
   });
 
   it("handles voice state with null channelId", () => {
@@ -80,6 +92,27 @@ describe("PacketCodec", () => {
 
   it("rejects invalid JSON", () => {
     expect(() => PacketCodec.decode("not json")).toThrow();
+  });
+});
+
+describe("PacketCodec - mentions defaulting", () => {
+  it("defaults mentions to an empty array when omitted on the wire", () => {
+    const raw = JSON.stringify({
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: new Date("2024-01-01"),
+      data: {
+        id: "msg-1",
+        attachments: [],
+        author: { id: "user-1", username: "alice" },
+        channel: { id: "ch-1", name: "general" },
+        guildId: "guild-1",
+        content: "hi",
+        timestamp: "2024-01-01T00:00:00.000+00:00",
+      },
+    });
+    const decoded = PacketCodec.decode(raw);
+    if (decoded.type !== "GATEWAY_MESSAGE_CREATE") throw new Error("wrong type");
+    expect(decoded.data.mentions).toEqual([]);
   });
 });
 

--- a/src/lib/protocol/packets.ts
+++ b/src/lib/protocol/packets.ts
@@ -49,10 +49,12 @@ const MessageData = z.object({
   flags: z.number().optional(),
   categoryId: z.string().optional(),
   forwardedSnapshots: z.array(MessageSnapshot).optional(),
+  mentions: z.array(z.string()).default([]),
   reference: z
     .object({
       messageId: z.string(),
       channelId: z.string().optional(),
+      authorId: z.string().optional(),
     })
     .optional(),
 });

--- a/src/lib/protocol/packets.ts
+++ b/src/lib/protocol/packets.ts
@@ -36,6 +36,11 @@ const MessageSnapshot = z.object({
   attachments: z.array(MessageDataAttachment).optional(),
 });
 
+// Base shape shared by MESSAGE_CREATE and MESSAGE_UPDATE. `mentions` stays
+// optional here so `MessageData.partial()` on the update packet doesn't
+// silently default an omitted field to `[]` (which would be
+// indistinguishable from "the update explicitly had zero mentions").
+// MessageCreate re-tightens `mentions` to a defaulted array below.
 const MessageData = z.object({
   id: z.string(),
   attachments: z.array(MessageDataAttachment),
@@ -49,7 +54,7 @@ const MessageData = z.object({
   flags: z.number().optional(),
   categoryId: z.string().optional(),
   forwardedSnapshots: z.array(MessageSnapshot).optional(),
-  mentions: z.array(z.string()).default([]),
+  mentions: z.array(z.string()).optional(),
   reference: z
     .object({
       messageId: z.string(),
@@ -57,6 +62,10 @@ const MessageData = z.object({
       authorId: z.string().optional(),
     })
     .optional(),
+});
+
+const MessageCreateData = MessageData.extend({
+  mentions: z.array(z.string()).default([]),
 });
 
 const ReactionDataEmoji = z.object({
@@ -90,7 +99,7 @@ const MessageDeleteData = z.object({
 export const MessageCreatePacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_CREATE"),
   timestamp: PacketTimestamp,
-  data: MessageData,
+  data: MessageCreateData,
 });
 
 export const MessageReactionAddPacket = z.object({

--- a/src/lib/test/fixtures/packets.ts
+++ b/src/lib/test/fixtures/packets.ts
@@ -20,6 +20,7 @@ export function messagePacket(
       guildId: "guild-1",
       content,
       timestamp: "2024-01-01T00:00:00.000+00:00",
+      mentions: [],
       ...overrides,
     },
   };

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -213,10 +213,12 @@ function bindMessageHandlers(client: Client, publish: Publish): void {
             height: a.height ?? undefined,
           })),
         })),
+        mentions: [...message.mentions.users.keys()],
         reference: message.reference?.messageId
           ? {
               messageId: message.reference.messageId,
               channelId: message.reference.channelId ?? undefined,
+              authorId: message.mentions.repliedUser?.id,
             }
           : undefined,
       },

--- a/src/server/routes/handlers.ts
+++ b/src/server/routes/handlers.ts
@@ -18,7 +18,7 @@ router.onMessage(async (packet, ctx) => {
   // Mentions are already handled by `handleMention`, which calls `resumeHook`
   // with the mention prefix stripped. Forwarding again here would duplicate
   // the turn and push the un-stripped content into the conversation.
-  if (isBotMention(packet.data.content, ctx.botUserId)) return;
+  if (isBotMention(packet.data, ctx.botUserId)) return;
   if (packet.data.thread) return;
 
   const channelId = packet.data.channel.id;


### PR DESCRIPTION
## Summary

- Thread replies to a bot-authored message now route through the mention handler, since Discord's Reply UX doesn't inject `<@bot>` into content.
- Mention detection now uses Discord's native `mentions` array as a reliability gate, stacked with the existing leading-position check, so literal `<@id>` text in code fences or plain text no longer falsely triggers the bot.
- Added `mentions: string[]` and `reference.authorId?` to `MessageData`; populated in the gateway from `message.mentions.users` / `message.mentions.repliedUser?.id`; added `isReplyToBot(data, botUserId)` helper.

## Test plan

- [x] `bun format && bun lint && bun typecheck && bun run test && bun test:coverage && bun knip` all green
- [ ] Manual: `@wack hacker hi` at start → responds
- [ ] Manual: `yo @wack hacker fyi` mid-sentence → silent (unchanged rule)
- [ ] Manual: literal `<@BOT_ID>` pasted without a real ping (e.g. code fence) → silent (new gate)
- [ ] Manual: reply to a bot message inside a thread without `@` → responds (new)
- [ ] Manual: reply to a bot message in a top-level channel without `@` → silent
- [ ] Manual: reply to a non-bot message in a thread → silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)