### PR TITLE
chore: namespace Discord bot env vars under DISCORD_BOT_* and move guild ID to constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 # Discord
 DISCORD_BOT_TOKEN=
-DISCORD_CLIENT_ID=
-DISCORD_PUBLIC_KEY=
-DISCORD_GUILD_ID=
+DISCORD_BOT_CLIENT_ID=
+DISCORD_BOT_PUBLIC_KEY=
 
 # Internal auth
 # Vercel cron invocations send `Authorization: Bearer ${CRON_SECRET}`; must match this.

--- a/docs/deployment/build.md
+++ b/docs/deployment/build.md
@@ -24,7 +24,7 @@ The output is committed to the repo. Type-checking and tests rely on having the 
 
 ## register-commands.ts
 
-Requires Discord credentials (`DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`) at build time:
+Requires Discord credentials (`DISCORD_BOT_TOKEN`, `DISCORD_BOT_CLIENT_ID`) at build time:
 
 - In CI, those come from Vercel project env.
 - Locally, they come from `.env.local`.

--- a/docs/discord/inbound.md
+++ b/docs/discord/inbound.md
@@ -20,7 +20,7 @@ The actual dispatch logic. For each packet it:
 1. **Dedupes** using `ConversationStore.dedup(key)` — atomic `SET NX` against Redis, 5-minute window by default. Dedup keys are packet-type-specific (see below). If the key already exists, the packet is dropped silently (`log.debug "Dedup hit"`).
 2. **Locks per channel** for `MESSAGE_CREATE` only via `ConversationStore.acquireLock(channelId)` — 30-second TTL, token-matched release (Lua script). Other packet types skip locking.
 3. **If the lock can't be acquired**, the packet is **dropped** with a warning log — it does not wait. Vercel Queues will retry the delivery later, by which point the lock has likely expired.
-4. **Dispatches** to `router.dispatch(packet, ctx)` with a freshly-constructed `ctx` containing a Discord API client (`new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN))`), the `ConversationStore`, and `env.DISCORD_CLIENT_ID` as the bot user ID.
+4. **Dispatches** to `router.dispatch(packet, ctx)` with a freshly-constructed `ctx` containing a Discord API client (`new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN))`), the `ConversationStore`, and `env.DISCORD_BOT_CLIENT_ID` as the bot user ID.
 5. **Releases** the lock in a `finally`.
 
 ### Dedup keys

--- a/docs/discord/protocol.md
+++ b/docs/discord/protocol.md
@@ -43,7 +43,7 @@ It extracts `X-Signature-Ed25519` and `X-Signature-Timestamp`, reads the raw bod
 The interactions route calls this **before** parsing or dispatching, so an unsigned request can never reach a handler:
 
 ```ts
-const result = await verifyInteraction(c.req.raw, env.DISCORD_PUBLIC_KEY);
+const result = await verifyInteraction(c.req.raw, env.DISCORD_BOT_PUBLIC_KEY);
 if (!result.valid) return c.json({ error: "Invalid signature" }, 401);
 ```
 

--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -1,5 +1,7 @@
 import type { SlashCommand } from "../src/bot/commands/types";
 
+import { DISCORD_GUILD_ID } from "../src/lib/protocol/constants";
+
 const vercelEnv = process.env.VERCEL_ENV;
 if (vercelEnv && vercelEnv !== "production") {
   console.log(`Skipping command registration on VERCEL_ENV=${vercelEnv}`);
@@ -10,11 +12,10 @@ const { REST, Routes } = await import("discord.js");
 const commands = await import("../src/bot/handlers/commands");
 
 const token = process.env.DISCORD_BOT_TOKEN;
-const clientId = process.env.DISCORD_CLIENT_ID;
-const guildId = process.env.DISCORD_GUILD_ID;
+const clientId = process.env.DISCORD_BOT_CLIENT_ID;
 
 if (!token || !clientId) {
-  console.error("DISCORD_BOT_TOKEN and DISCORD_CLIENT_ID are required");
+  console.error("DISCORD_BOT_TOKEN and DISCORD_BOT_CLIENT_ID are required");
   process.exit(1);
 }
 
@@ -24,12 +25,8 @@ const payload = Object.values(commands)
   .filter((v): v is SlashCommand => !!v && typeof v === "object" && "builder" in v)
   .map((c) => c.builder.toJSON());
 
-const route = guildId
-  ? Routes.applicationGuildCommands(clientId, guildId)
-  : Routes.applicationCommands(clientId);
+const route = Routes.applicationGuildCommands(clientId, DISCORD_GUILD_ID);
 
 await rest.put(route, { body: payload });
 
-console.log(
-  `Registered ${payload.length} commands${guildId ? ` to guild ${guildId}` : " globally"}`,
-);
+console.log(`Registered ${payload.length} commands to guild ${DISCORD_GUILD_ID}`);

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,9 +5,8 @@ import { z } from "zod";
 export const env = createEnv({
   server: {
     DISCORD_BOT_TOKEN: z.string(),
-    DISCORD_CLIENT_ID: z.string(),
-    DISCORD_PUBLIC_KEY: z.string(),
-    DISCORD_GUILD_ID: z.string(),
+    DISCORD_BOT_CLIENT_ID: z.string(),
+    DISCORD_BOT_PUBLIC_KEY: z.string(),
     CRON_SECRET: z.string(),
     LINEAR_API_KEY: z.string(),
     NOTION_TOKEN: z.string(),

--- a/src/lib/ai/tools/discord/base.ts
+++ b/src/lib/ai/tools/discord/base.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -45,7 +45,7 @@ export const get_server_info = tool({
     "Get Discord server overview: name, member count, channel count, role count, and basic settings. Use this to understand the server at a high level.",
   inputSchema: z.object({}),
   execute: async () => {
-    const guild = (await discord.get(Routes.guild(env.DISCORD_GUILD_ID), {
+    const guild = (await discord.get(Routes.guild(DISCORD_GUILD_ID), {
       query: new URLSearchParams({ with_counts: "true" }),
     })) as any;
     return JSON.stringify({
@@ -72,7 +72,7 @@ export const list_channels = tool({
     "List all channels in the Discord server, organized by category. Returns channel IDs, names, types, topics, and positions. Use this to find the right channel before sending messages or performing channel operations.",
   inputSchema: z.object({}),
   execute: async () => {
-    const channels = (await discord.get(Routes.guildChannels(env.DISCORD_GUILD_ID))) as any[];
+    const channels = (await discord.get(Routes.guildChannels(DISCORD_GUILD_ID))) as any[];
 
     const nonThread = channels.filter((ch) => ![10, 11, 12].includes(ch.type));
 
@@ -109,7 +109,7 @@ export const list_roles = tool({
     "List all roles in the Discord server with their colors, positions, and whether they are hoisted or mentionable. Use this to find role IDs before assigning or managing roles.",
   inputSchema: z.object({}),
   execute: async () => {
-    const roles = (await discord.get(Routes.guildRoles(env.DISCORD_GUILD_ID))) as any[];
+    const roles = (await discord.get(Routes.guildRoles(DISCORD_GUILD_ID))) as any[];
     const sorted = roles.sort((a, b) => b.position - a.position);
     return JSON.stringify(
       sorted.map((r) => ({
@@ -120,7 +120,7 @@ export const list_roles = tool({
         mentionable: r.mentionable,
         hoist: r.hoist,
         managed: r.managed,
-        isEveryone: r.id === env.DISCORD_GUILD_ID,
+        isEveryone: r.id === DISCORD_GUILD_ID,
       })),
     );
   },
@@ -139,13 +139,13 @@ export const search_members = tool({
     // If the query looks like a Discord user ID, fetch directly
     if (/^\d{17,20}$/.test(query)) {
       try {
-        const found = (await discord.get(Routes.guildMember(env.DISCORD_GUILD_ID, query))) as any;
+        const found = (await discord.get(Routes.guildMember(DISCORD_GUILD_ID, query))) as any;
         return JSON.stringify([summarizeMember(found)]);
       } catch {
         return JSON.stringify([]);
       }
     }
-    const matches = (await discord.get(Routes.guildMembersSearch(env.DISCORD_GUILD_ID), {
+    const matches = (await discord.get(Routes.guildMembersSearch(DISCORD_GUILD_ID), {
       query: new URLSearchParams({ query, limit: String(limit) }),
     })) as any[];
     return JSON.stringify(matches.map(summarizeMember));

--- a/src/lib/ai/tools/discord/channels.ts
+++ b/src/lib/ai/tools/discord/channels.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ export const create_channel = tool({
     if (default_thread_slowmode !== undefined)
       body.default_thread_rate_limit_per_user = default_thread_slowmode;
 
-    const channel = (await discord.post(Routes.guildChannels(env.DISCORD_GUILD_ID), {
+    const channel = (await discord.post(Routes.guildChannels(DISCORD_GUILD_ID), {
       body,
     })) as any;
     return JSON.stringify(summarizeChannel(channel));

--- a/src/lib/ai/tools/discord/emojis.ts
+++ b/src/lib/ai/tools/discord/emojis.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ export const list_emojis = tool({
     "List all custom emojis in the server. Returns emoji IDs, names, animation status, image URLs, and role restrictions.",
   inputSchema: z.object({}),
   execute: async () => {
-    const emojis = (await discord.get(Routes.guildEmojis(env.DISCORD_GUILD_ID))) as any[];
+    const emojis = (await discord.get(Routes.guildEmojis(DISCORD_GUILD_ID))) as any[];
     return JSON.stringify(emojis.map(summarizeEmoji));
   },
 });
@@ -56,7 +56,7 @@ export const create_emoji = tool({
     const body: Record<string, any> = { name, image: dataUri };
     if (roles) body.roles = roles;
 
-    const emoji = (await discord.post(Routes.guildEmojis(env.DISCORD_GUILD_ID), {
+    const emoji = (await discord.post(Routes.guildEmojis(DISCORD_GUILD_ID), {
       body,
     })) as any;
 
@@ -85,7 +85,7 @@ export const edit_emoji = tool({
     if (name) body.name = name;
     if (roles) body.roles = roles;
 
-    const edited = (await discord.patch(Routes.guildEmoji(env.DISCORD_GUILD_ID, emoji_id), {
+    const edited = (await discord.patch(Routes.guildEmoji(DISCORD_GUILD_ID, emoji_id), {
       body,
     })) as any;
 
@@ -107,8 +107,8 @@ export const delete_emoji = tool({
   }),
   execute: async ({ emoji_id }) => {
     // Fetch emoji first to get its name
-    const emoji = (await discord.get(Routes.guildEmoji(env.DISCORD_GUILD_ID, emoji_id))) as any;
-    await discord.delete(Routes.guildEmoji(env.DISCORD_GUILD_ID, emoji_id));
+    const emoji = (await discord.get(Routes.guildEmoji(DISCORD_GUILD_ID, emoji_id))) as any;
+    await discord.delete(Routes.guildEmoji(DISCORD_GUILD_ID, emoji_id));
     return JSON.stringify({ success: true, deleted: emoji.name });
   },
 });

--- a/src/lib/ai/tools/discord/events.ts
+++ b/src/lib/ai/tools/discord/events.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -50,7 +50,7 @@ export const list_events = tool({
     "List all scheduled events in the server. Returns event details including name, description, times, type, location, and attendee count.",
   inputSchema: z.object({}),
   execute: async () => {
-    const events = (await discord.get(Routes.guildScheduledEvents(env.DISCORD_GUILD_ID), {
+    const events = (await discord.get(Routes.guildScheduledEvents(DISCORD_GUILD_ID), {
       query: new URLSearchParams({ with_user_count: "true" }),
     })) as any[];
     return JSON.stringify(events.map(summarizeEvent));
@@ -100,7 +100,7 @@ export const create_event = tool({
     if (location) body.entity_metadata = { location };
     if (image) body.image = image;
 
-    const event = (await discord.post(Routes.guildScheduledEvents(env.DISCORD_GUILD_ID), {
+    const event = (await discord.post(Routes.guildScheduledEvents(DISCORD_GUILD_ID), {
       body,
     })) as any;
 
@@ -156,12 +156,9 @@ export const edit_event = tool({
     if (status) body.status = STATUS_MAP[status];
     if (channel_id !== undefined) body.channel_id = channel_id;
 
-    const edited = (await discord.patch(
-      Routes.guildScheduledEvent(env.DISCORD_GUILD_ID, event_id),
-      {
-        body,
-      },
-    )) as any;
+    const edited = (await discord.patch(Routes.guildScheduledEvent(DISCORD_GUILD_ID, event_id), {
+      body,
+    })) as any;
 
     return JSON.stringify({
       id: edited.id,
@@ -182,9 +179,9 @@ export const delete_event = tool({
   execute: async ({ event_id }) => {
     // Fetch event first to get its name
     const event = (await discord.get(
-      Routes.guildScheduledEvent(env.DISCORD_GUILD_ID, event_id),
+      Routes.guildScheduledEvent(DISCORD_GUILD_ID, event_id),
     )) as any;
-    await discord.delete(Routes.guildScheduledEvent(env.DISCORD_GUILD_ID, event_id));
+    await discord.delete(Routes.guildScheduledEvent(DISCORD_GUILD_ID, event_id));
     return JSON.stringify({ success: true, deleted: event.name });
   },
 });

--- a/src/lib/ai/tools/discord/invites.ts
+++ b/src/lib/ai/tools/discord/invites.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { admin } from "../../skills/index.ts";
 import { discord } from "./client.ts";
 
@@ -16,7 +16,7 @@ export const list_invites = admin(
       "List all active server invites with their codes, channels, creators, usage counts, and expiry dates.",
     inputSchema: z.object({}),
     execute: async () => {
-      const invites = (await discord.get(Routes.guildInvites(env.DISCORD_GUILD_ID))) as any[];
+      const invites = (await discord.get(Routes.guildInvites(DISCORD_GUILD_ID))) as any[];
       return JSON.stringify(
         invites.map((inv) => ({
           code: inv.code,

--- a/src/lib/ai/tools/discord/members.ts
+++ b/src/lib/ai/tools/discord/members.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -17,9 +17,7 @@ export const get_member = tool({
   }),
   execute: async ({ member_id }) => {
     try {
-      const member = (await discord.get(
-        Routes.guildMember(env.DISCORD_GUILD_ID, member_id),
-      )) as any;
+      const member = (await discord.get(Routes.guildMember(DISCORD_GUILD_ID, member_id))) as any;
       return JSON.stringify({
         id: member.user.id,
         username: member.user.username,
@@ -30,7 +28,7 @@ export const get_member = tool({
         isBot: member.user.bot ?? false,
         premiumSince: member.premium_since ?? null,
         avatar: member.avatar
-          ? `https://cdn.discordapp.com/guilds/${env.DISCORD_GUILD_ID}/users/${member.user.id}/avatars/${member.avatar}.png`
+          ? `https://cdn.discordapp.com/guilds/${DISCORD_GUILD_ID}/users/${member.user.id}/avatars/${member.avatar}.png`
           : member.user.avatar
             ? `https://cdn.discordapp.com/avatars/${member.user.id}/${member.user.avatar}.png`
             : null,
@@ -49,7 +47,7 @@ export const set_nickname = tool({
     nickname: z.string().nullable().describe("New nickname (null to clear)"),
   }),
   execute: async ({ member_id, nickname }) => {
-    await discord.patch(Routes.guildMember(env.DISCORD_GUILD_ID, member_id), {
+    await discord.patch(Routes.guildMember(DISCORD_GUILD_ID, member_id), {
       body: { nick: nickname },
     });
     return JSON.stringify({

--- a/src/lib/ai/tools/discord/roles.ts
+++ b/src/lib/ai/tools/discord/roles.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -35,13 +35,13 @@ export const create_role = tool({
     if (icon) body.icon = icon;
     if (unicode_emoji) body.unicode_emoji = unicode_emoji;
 
-    const role = (await discord.post(Routes.guildRoles(env.DISCORD_GUILD_ID), {
+    const role = (await discord.post(Routes.guildRoles(DISCORD_GUILD_ID), {
       body,
     })) as any;
 
     // If position was requested, modify it separately
     if (position !== undefined) {
-      await discord.patch(Routes.guildRoles(env.DISCORD_GUILD_ID), {
+      await discord.patch(Routes.guildRoles(DISCORD_GUILD_ID), {
         body: [{ id: role.id, position }],
       });
     }
@@ -85,12 +85,12 @@ export const edit_role = tool({
     if (icon !== undefined) body.icon = icon;
     if (unicode_emoji !== undefined) body.unicode_emoji = unicode_emoji;
 
-    const edited = (await discord.patch(Routes.guildRole(env.DISCORD_GUILD_ID, role_id), {
+    const edited = (await discord.patch(Routes.guildRole(DISCORD_GUILD_ID, role_id), {
       body,
     })) as any;
 
     if (position !== undefined) {
-      await discord.patch(Routes.guildRoles(env.DISCORD_GUILD_ID), {
+      await discord.patch(Routes.guildRoles(DISCORD_GUILD_ID), {
         body: [{ id: role_id, position }],
       });
     }
@@ -112,10 +112,10 @@ export const delete_role = tool({
   }),
   execute: async ({ role_id }) => {
     // Fetch the role first to get its name
-    const allRoles = (await discord.get(Routes.guildRoles(env.DISCORD_GUILD_ID))) as any[];
+    const allRoles = (await discord.get(Routes.guildRoles(DISCORD_GUILD_ID))) as any[];
     const target = allRoles.find((r) => r.id === role_id);
     if (!target) return JSON.stringify({ error: "Role not found" });
-    await discord.delete(Routes.guildRole(env.DISCORD_GUILD_ID, role_id));
+    await discord.delete(Routes.guildRole(DISCORD_GUILD_ID, role_id));
     return JSON.stringify({ success: true, deleted: target.name });
   },
 });
@@ -128,7 +128,7 @@ export const assign_role = tool({
     role_id: z.string().describe("Role ID to assign"),
   }),
   execute: async ({ member_id, role_id }) => {
-    await discord.put(Routes.guildMemberRole(env.DISCORD_GUILD_ID, member_id, role_id));
+    await discord.put(Routes.guildMemberRole(DISCORD_GUILD_ID, member_id, role_id));
     return JSON.stringify({ success: true, member: member_id, role: role_id });
   },
 });
@@ -141,7 +141,7 @@ export const remove_role = tool({
     role_id: z.string().describe("Role ID to remove"),
   }),
   execute: async ({ member_id, role_id }) => {
-    await discord.delete(Routes.guildMemberRole(env.DISCORD_GUILD_ID, member_id, role_id));
+    await discord.delete(Routes.guildMemberRole(DISCORD_GUILD_ID, member_id, role_id));
     return JSON.stringify({ success: true, member: member_id, role: role_id });
   },
 });

--- a/src/lib/ai/tools/discord/threads.ts
+++ b/src/lib/ai/tools/discord/threads.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -50,7 +50,7 @@ export const list_threads = tool({
   execute: async ({ channel_id, include_archived }) => {
     if (channel_id) {
       // Get active threads for the guild, then filter by channel
-      const active = (await discord.get(Routes.guildActiveThreads(env.DISCORD_GUILD_ID))) as any;
+      const active = (await discord.get(Routes.guildActiveThreads(DISCORD_GUILD_ID))) as any;
       const channelThreads = (active.threads ?? []).filter((t: any) => t.parent_id === channel_id);
       const threads = channelThreads.map(summarizeThread);
 
@@ -67,7 +67,7 @@ export const list_threads = tool({
     }
 
     // All active threads in the guild
-    const active = (await discord.get(Routes.guildActiveThreads(env.DISCORD_GUILD_ID))) as any;
+    const active = (await discord.get(Routes.guildActiveThreads(DISCORD_GUILD_ID))) as any;
     return JSON.stringify((active.threads ?? []).map(summarizeThread));
   },
 });

--- a/src/lib/ai/tools/discord/webhooks.ts
+++ b/src/lib/ai/tools/discord/webhooks.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { z } from "zod";
 
-import { env } from "../../../../env.ts";
+import { DISCORD_GUILD_ID } from "../../../protocol/constants.ts";
 import { discord } from "./client.ts";
 
 // ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ export const list_webhooks = tool({
   execute: async ({ channel_id }) => {
     const webhooks = channel_id
       ? ((await discord.get(Routes.channelWebhooks(channel_id))) as any[])
-      : ((await discord.get(Routes.guildWebhooks(env.DISCORD_GUILD_ID))) as any[]);
+      : ((await discord.get(Routes.guildWebhooks(DISCORD_GUILD_ID))) as any[]);
 
     return JSON.stringify(webhooks.map(summarizeWebhook));
   },

--- a/src/lib/protocol/constants.ts
+++ b/src/lib/protocol/constants.ts
@@ -1,3 +1,5 @@
+export const DISCORD_GUILD_ID = "772576325897945119";
+
 export const DISCORD_IDS = {
   roles: {
     ADMIN: "1344066433172373656",

--- a/src/server/process-event.ts
+++ b/src/server/process-event.ts
@@ -44,7 +44,7 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
   const ctx = {
     discord: new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN)),
     store,
-    botUserId: env.DISCORD_CLIENT_ID,
+    botUserId: env.DISCORD_BOT_CLIENT_ID,
   };
 
   const startTime = Date.now();

--- a/src/server/routes/interactions/index.ts
+++ b/src/server/routes/interactions/index.ts
@@ -15,7 +15,7 @@ import { handleModalSubmit } from "./modal.ts";
 const route = new Hono();
 
 route.post("/interactions", async (c) => {
-  const result = await verifyInteraction(c.req.raw, env.DISCORD_PUBLIC_KEY);
+  const result = await verifyInteraction(c.req.raw, env.DISCORD_BOT_PUBLIC_KEY);
   if (!result.valid) return c.json({ error: "Invalid signature" }, 401);
 
   const interaction = result.body as DiscordInteraction;


### PR DESCRIPTION
## Summary

- Rename `DISCORD_CLIENT_ID` / `DISCORD_PUBLIC_KEY` to `DISCORD_BOT_CLIENT_ID` / `DISCORD_BOT_PUBLIC_KEY` so all bot credentials share the `DISCORD_BOT_*` prefix.
- Move the (non-secret) guild ID out of env into `src/lib/protocol/constants.ts` as `DISCORD_GUILD_ID`, next to `DISCORD_IDS`; `scripts/register-commands.ts` now always registers guild-scoped since the ID is always present.

## Deployment

Before merging, update Vercel project env: rename `DISCORD_CLIENT_ID` → `DISCORD_BOT_CLIENT_ID`, rename `DISCORD_PUBLIC_KEY` → `DISCORD_BOT_PUBLIC_KEY`, and delete `DISCORD_GUILD_ID`. Without that, Zod env validation will fail at boot.

## Test plan

- [x] \`bun format\`, \`bun lint\`, \`bun typecheck\`, \`bun run test\` (396/396), \`bun test:coverage\`, \`bun knip\` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)