### PR TITLE
feat: add approval() tool wrapper to gate tool calls behind Discord buttons

### DIFF
--- a/src/bot/components/index.ts
+++ b/src/bot/components/index.ts
@@ -1,2 +1,3 @@
 export type { ComponentHandler, ComponentContext } from "./types";
 export { defineComponent } from "./define";
+export { toolApproval, buildToolApprovalHandler } from "./tool-approval";

--- a/src/bot/components/tool-approval.test.ts
+++ b/src/bot/components/tool-approval.test.ts
@@ -88,7 +88,7 @@ describe("toolApproval — authorization", () => {
 });
 
 describe("toolApproval — already decided / expired", () => {
-  it("sends an ephemeral reply when the approval is already decided", async () => {
+  it("converges the channel message and sends an ephemeral reply when already decided", async () => {
     const { store, handler, discord, mockAPI } = setup();
     await store.create(baseApprovalState({ status: "approved", decidedByUserId: "user-1" }));
 
@@ -98,9 +98,26 @@ describe("toolApproval — already decided / expired", () => {
       customId: "tool-approval:deny:a1",
     });
 
-    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(0);
+    // Belt-and-suspenders: even on a late click, the message is patched to
+    // reflect the stored decision so the UI converges to truth.
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(1);
     const follows = mockAPI.callsTo("interactions.followUp");
     expect((follows[0]![2] as { content: string }).content).toMatch(/already been approved/);
+  });
+
+  it("converges without a decidedByUserId field when the stored status is timeout", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState({ status: "timeout" }));
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(1);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/already been timeout/);
   });
 
   it("sends an ephemeral reply when the approval has expired (missing row)", async () => {

--- a/src/bot/components/tool-approval.test.ts
+++ b/src/bot/components/tool-approval.test.ts
@@ -1,0 +1,154 @@
+import type { API } from "@discordjs/core/http-only";
+
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalState } from "@/lib/ai/approvals";
+import type { DiscordInteraction } from "@/lib/protocol/types";
+
+import { ApprovalStore } from "@/lib/ai/approvals";
+import { InteractionType } from "@/lib/protocol/constants";
+import { asAPI, createMemoryRedis } from "@/lib/test/fixtures";
+
+import { buildToolApprovalHandler } from "./tool-approval";
+
+function buildDiscordMock() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const mock = {
+    channels: {
+      editMessage: async (channelId: string, msgId: string, body: unknown) => {
+        calls.push({ method: "channels.editMessage", args: [channelId, msgId, body] });
+        return { id: msgId };
+      },
+    },
+    interactions: {
+      followUp: async (appId: string, token: string, body: unknown) => {
+        calls.push({ method: "interactions.followUp", args: [appId, token, body] });
+        return { id: "followup-1" };
+      },
+    },
+    _calls: calls,
+  };
+  return { mock, calls };
+}
+
+function buildInteraction(customId: string, clickerId: string): DiscordInteraction {
+  return {
+    id: "i-1",
+    application_id: "app-1",
+    type: InteractionType.MessageComponent,
+    token: "tok-1",
+    version: 1,
+    member: {
+      user: { id: clickerId, username: "alice" },
+      roles: [],
+    },
+    data: { custom_id: customId, component_type: 2 },
+  };
+}
+
+function seed(
+  store: ApprovalStore,
+  overrides: Partial<ApprovalState> = {},
+): Promise<ApprovalState> {
+  const state: ApprovalState = {
+    id: "a1",
+    status: "pending",
+    toolName: "send_message",
+    input: { content: "hi" },
+    reason: "testing",
+    channelId: "ch-1",
+    messageId: "msg-5",
+    requesterUserId: "user-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+  return store.create(state).then(() => state);
+}
+
+function setup() {
+  const store = new ApprovalStore(createMemoryRedis());
+  const handler = buildToolApprovalHandler(store);
+  const { mock, calls } = buildDiscordMock();
+  const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]);
+  return { store, handler, discord: discord as API, calls };
+}
+
+describe("toolApproval component handler", () => {
+  it("edits the message and flips status when the requester clicks approve", async () => {
+    const { store, handler, discord, calls } = setup();
+    await seed(store);
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(true);
+    const edit = calls.find((c) => c.method === "channels.editMessage")!;
+    expect(edit.args[1]).toBe("msg-5");
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+    expect(after?.decidedByUserId).toBe("user-1");
+  });
+
+  it("sends an ephemeral follow-up and leaves state pending when a non-requester clicks", async () => {
+    const { store, handler, discord, calls } = setup();
+    await seed(store);
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:approve:a1", "impostor"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
+    const follow = calls.find((c) => c.method === "interactions.followUp")!;
+    expect(follow).toBeTruthy();
+    expect((follow.args[2] as { content: string }).content).toMatch(/Only <@user-1>/);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("pending");
+  });
+
+  it("sends an ephemeral reply when the approval is already decided", async () => {
+    const { store, handler, discord, calls } = setup();
+    await seed(store, { status: "approved", decidedByUserId: "user-1" });
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:deny:a1", "user-1"),
+      discord,
+      customId: "tool-approval:deny:a1",
+    });
+
+    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
+    const follow = calls.find((c) => c.method === "interactions.followUp")!;
+    expect((follow.args[2] as { content: string }).content).toMatch(/already been approved/);
+  });
+
+  it("sends an ephemeral reply when the approval has expired (missing row)", async () => {
+    const { handler, discord, calls } = setup();
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:approve:missing", "user-1"),
+      discord,
+      customId: "tool-approval:approve:missing",
+    });
+
+    const follow = calls.find((c) => c.method === "interactions.followUp")!;
+    expect((follow.args[2] as { content: string }).content).toMatch(/expired/);
+  });
+
+  it("ignores malformed custom ids", async () => {
+    const { handler, discord, calls } = setup();
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval::a1", "user-1"),
+      discord,
+      customId: "tool-approval::a1",
+    });
+
+    const follow = calls.find((c) => c.method === "interactions.followUp");
+    expect(follow).toBeTruthy();
+    expect((follow!.args[2] as { content: string }).content).toMatch(/Malformed/);
+  });
+});

--- a/src/bot/components/tool-approval.test.ts
+++ b/src/bot/components/tool-approval.test.ts
@@ -151,4 +151,92 @@ describe("toolApproval component handler", () => {
     expect(follow).toBeTruthy();
     expect((follow!.args[2] as { content: string }).content).toMatch(/Malformed/);
   });
+
+  it("skips the message edit when no messageId was stored", async () => {
+    const { store, handler, discord, calls } = setup();
+    await seed(store, { messageId: undefined });
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+  });
+
+  it("swallows an editMessage failure so the decision still persists", async () => {
+    const { store } = setup();
+    await seed(store);
+    const calls: { method: string; args: unknown[] }[] = [];
+    const mock = {
+      channels: {
+        editMessage: async (..._args: unknown[]) => {
+          calls.push({ method: "channels.editMessage", args: _args });
+          throw new Error("message was deleted");
+        },
+      },
+      interactions: {
+        followUp: async (appId: string, token: string, body: unknown) => {
+          calls.push({ method: "interactions.followUp", args: [appId, token, body] });
+          return { id: "f" };
+        },
+      },
+    };
+    const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]) as API;
+    const handler = buildToolApprovalHandler(store);
+
+    await handler.handle({
+      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(true);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+  });
+
+  it("swallows a followUp failure without throwing", async () => {
+    const { store } = setup();
+    const mock = {
+      channels: { editMessage: async () => ({ id: "x" }) },
+      interactions: {
+        followUp: async () => {
+          throw new Error("unknown interaction");
+        },
+      },
+    };
+    const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]) as API;
+    const handler = buildToolApprovalHandler(store);
+
+    await expect(
+      handler.handle({
+        interaction: buildInteraction("tool-approval:approve:missing", "user-1"),
+        discord,
+        customId: "tool-approval:approve:missing",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects clicks from anonymous sources (no member, no user)", async () => {
+    const { store, handler, discord, calls } = setup();
+    await seed(store);
+    const interaction = buildInteraction("tool-approval:approve:a1", "user-1");
+    delete interaction.member;
+    delete interaction.user;
+
+    await handler.handle({
+      interaction,
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    const follow = calls.find((c) => c.method === "interactions.followUp");
+    expect((follow!.args[2] as { content: string }).content).toMatch(/identify/i);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("pending");
+  });
 });

--- a/src/bot/components/tool-approval.test.ts
+++ b/src/bot/components/tool-approval.test.ts
@@ -1,230 +1,186 @@
 import type { API } from "@discordjs/core/http-only";
 
-import { describe, expect, it } from "vitest";
-
-import type { ApprovalState } from "@/lib/ai/approvals";
-import type { DiscordInteraction } from "@/lib/protocol/types";
+import { describe, expect, it, vi } from "vitest";
 
 import { ApprovalStore } from "@/lib/ai/approvals";
-import { InteractionType } from "@/lib/protocol/constants";
-import { asAPI, createMemoryRedis } from "@/lib/test/fixtures";
+import {
+  asAPI,
+  baseApprovalState,
+  buttonInteraction,
+  createMemoryRedis,
+  createMockAPI,
+} from "@/lib/test/fixtures";
 
-import { buildToolApprovalHandler } from "./tool-approval";
+// Mock the third-party Redis client so the `new ApprovalStore()` fallback
+// inside the handler has a safe in-memory backend when no store is injected.
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
 
-function buildDiscordMock() {
-  const calls: { method: string; args: unknown[] }[] = [];
-  const mock = {
-    channels: {
-      editMessage: async (channelId: string, msgId: string, body: unknown) => {
-        calls.push({ method: "channels.editMessage", args: [channelId, msgId, body] });
-        return { id: msgId };
-      },
-    },
-    interactions: {
-      followUp: async (appId: string, token: string, body: unknown) => {
-        calls.push({ method: "interactions.followUp", args: [appId, token, body] });
-        return { id: "followup-1" };
-      },
-    },
-    _calls: calls,
-  };
-  return { mock, calls };
-}
-
-function buildInteraction(customId: string, clickerId: string): DiscordInteraction {
-  return {
-    id: "i-1",
-    application_id: "app-1",
-    type: InteractionType.MessageComponent,
-    token: "tok-1",
-    version: 1,
-    member: {
-      user: { id: clickerId, username: "alice" },
-      roles: [],
-    },
-    data: { custom_id: customId, component_type: 2 },
-  };
-}
-
-function seed(
-  store: ApprovalStore,
-  overrides: Partial<ApprovalState> = {},
-): Promise<ApprovalState> {
-  const state: ApprovalState = {
-    id: "a1",
-    status: "pending",
-    toolName: "send_message",
-    input: { content: "hi" },
-    reason: "testing",
-    channelId: "ch-1",
-    messageId: "msg-5",
-    requesterUserId: "user-1",
-    createdAt: "2024-01-01T00:00:00Z",
-    ...overrides,
-  };
-  return store.create(state).then(() => state);
-}
+import { buildToolApprovalHandler, toolApproval } from "./tool-approval";
 
 function setup() {
   const store = new ApprovalStore(createMemoryRedis());
   const handler = buildToolApprovalHandler(store);
-  const { mock, calls } = buildDiscordMock();
-  const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]);
-  return { store, handler, discord: discord as API, calls };
+  const mockAPI = createMockAPI();
+  return { store, handler, discord: asAPI(mockAPI) as API, mockAPI };
 }
 
-describe("toolApproval component handler", () => {
+describe("toolApproval — exports", () => {
+  it("exports a default handler bound to the `tool-approval` prefix", () => {
+    expect(toolApproval.prefix).toBe("tool-approval");
+  });
+});
+
+describe("toolApproval — happy path", () => {
   it("edits the message and flips status when the requester clicks approve", async () => {
-    const { store, handler, discord, calls } = setup();
-    await seed(store);
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
       discord,
       customId: "tool-approval:approve:a1",
     });
 
-    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(true);
-    const edit = calls.find((c) => c.method === "channels.editMessage")!;
-    expect(edit.args[1]).toBe("msg-5");
+    const edits = mockAPI.callsTo("channels.editMessage");
+    expect(edits).toHaveLength(1);
+    expect(edits[0]![1]).toBe("msg-5");
     const after = await store.get("a1");
     expect(after?.status).toBe("approved");
     expect(after?.decidedByUserId).toBe("user-1");
   });
 
-  it("sends an ephemeral follow-up and leaves state pending when a non-requester clicks", async () => {
-    const { store, handler, discord, calls } = setup();
-    await seed(store);
+  it("writes a 'denied' decision when the requester clicks deny", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval:approve:a1", "impostor"),
-      discord,
-      customId: "tool-approval:approve:a1",
-    });
-
-    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
-    const follow = calls.find((c) => c.method === "interactions.followUp")!;
-    expect(follow).toBeTruthy();
-    expect((follow.args[2] as { content: string }).content).toMatch(/Only <@user-1>/);
-    const after = await store.get("a1");
-    expect(after?.status).toBe("pending");
-  });
-
-  it("sends an ephemeral reply when the approval is already decided", async () => {
-    const { store, handler, discord, calls } = setup();
-    await seed(store, { status: "approved", decidedByUserId: "user-1" });
-
-    await handler.handle({
-      interaction: buildInteraction("tool-approval:deny:a1", "user-1"),
+      interaction: buttonInteraction("tool-approval:deny:a1", "user-1"),
       discord,
       customId: "tool-approval:deny:a1",
     });
 
-    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
-    const follow = calls.find((c) => c.method === "interactions.followUp")!;
-    expect((follow.args[2] as { content: string }).content).toMatch(/already been approved/);
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(1);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("denied");
+  });
+});
+
+describe("toolApproval — authorization", () => {
+  it("sends an ephemeral follow-up and leaves state pending when a non-requester clicks", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:approve:a1", "impostor"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(0);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect(follows).toHaveLength(1);
+    expect((follows[0]![2] as { content: string }).content).toMatch(/Only <@user-1>/);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("pending");
+  });
+});
+
+describe("toolApproval — already decided / expired", () => {
+  it("sends an ephemeral reply when the approval is already decided", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState({ status: "approved", decidedByUserId: "user-1" }));
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:deny:a1", "user-1"),
+      discord,
+      customId: "tool-approval:deny:a1",
+    });
+
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(0);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/already been approved/);
   });
 
   it("sends an ephemeral reply when the approval has expired (missing row)", async () => {
-    const { handler, discord, calls } = setup();
+    const { handler, discord, mockAPI } = setup();
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval:approve:missing", "user-1"),
+      interaction: buttonInteraction("tool-approval:approve:missing", "user-1"),
       discord,
       customId: "tool-approval:approve:missing",
     });
 
-    const follow = calls.find((c) => c.method === "interactions.followUp")!;
-    expect((follow.args[2] as { content: string }).content).toMatch(/expired/);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/expired/);
   });
+});
 
+describe("toolApproval — customId parsing", () => {
   it("ignores malformed custom ids", async () => {
-    const { handler, discord, calls } = setup();
+    const { handler, discord, mockAPI } = setup();
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval::a1", "user-1"),
+      interaction: buttonInteraction("tool-approval::a1", "user-1"),
       discord,
       customId: "tool-approval::a1",
     });
 
-    const follow = calls.find((c) => c.method === "interactions.followUp");
-    expect(follow).toBeTruthy();
-    expect((follow!.args[2] as { content: string }).content).toMatch(/Malformed/);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/Malformed/);
   });
 
+  it("ignores custom ids with unknown actions", async () => {
+    const { handler, discord, mockAPI } = setup();
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:shrug:a1", "user-1"),
+      discord,
+      customId: "tool-approval:shrug:a1",
+    });
+
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/Malformed/);
+  });
+});
+
+describe("toolApproval — message + context", () => {
   it("skips the message edit when no messageId was stored", async () => {
-    const { store, handler, discord, calls } = setup();
-    await seed(store, { messageId: undefined });
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState({ messageId: undefined }));
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
       discord,
       customId: "tool-approval:approve:a1",
     });
 
-    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(false);
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(0);
     const after = await store.get("a1");
     expect(after?.status).toBe("approved");
   });
 
-  it("swallows an editMessage failure so the decision still persists", async () => {
-    const { store } = setup();
-    await seed(store);
-    const calls: { method: string; args: unknown[] }[] = [];
-    const mock = {
-      channels: {
-        editMessage: async (..._args: unknown[]) => {
-          calls.push({ method: "channels.editMessage", args: _args });
-          throw new Error("message was deleted");
-        },
-      },
-      interactions: {
-        followUp: async (appId: string, token: string, body: unknown) => {
-          calls.push({ method: "interactions.followUp", args: [appId, token, body] });
-          return { id: "f" };
-        },
-      },
-    };
-    const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]) as API;
-    const handler = buildToolApprovalHandler(store);
+  it("posts to the thread when the approval state carries a threadId", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(
+      baseApprovalState({ channelId: "ch-1", threadId: "thread-9", messageId: "msg-5" }),
+    );
 
     await handler.handle({
-      interaction: buildInteraction("tool-approval:approve:a1", "user-1"),
+      interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
       discord,
       customId: "tool-approval:approve:a1",
     });
 
-    expect(calls.some((c) => c.method === "channels.editMessage")).toBe(true);
-    const after = await store.get("a1");
-    expect(after?.status).toBe("approved");
-  });
-
-  it("swallows a followUp failure without throwing", async () => {
-    const { store } = setup();
-    const mock = {
-      channels: { editMessage: async () => ({ id: "x" }) },
-      interactions: {
-        followUp: async () => {
-          throw new Error("unknown interaction");
-        },
-      },
-    };
-    const discord = asAPI(mock as unknown as Parameters<typeof asAPI>[0]) as API;
-    const handler = buildToolApprovalHandler(store);
-
-    await expect(
-      handler.handle({
-        interaction: buildInteraction("tool-approval:approve:missing", "user-1"),
-        discord,
-        customId: "tool-approval:approve:missing",
-      }),
-    ).resolves.toBeUndefined();
+    const edits = mockAPI.callsTo("channels.editMessage");
+    expect(edits[0]![0]).toBe("thread-9");
   });
 
   it("rejects clicks from anonymous sources (no member, no user)", async () => {
-    const { store, handler, discord, calls } = setup();
-    await seed(store);
-    const interaction = buildInteraction("tool-approval:approve:a1", "user-1");
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+    const interaction = buttonInteraction("tool-approval:approve:a1", "user-1");
     delete interaction.member;
     delete interaction.user;
 
@@ -234,9 +190,82 @@ describe("toolApproval component handler", () => {
       customId: "tool-approval:approve:a1",
     });
 
-    const follow = calls.find((c) => c.method === "interactions.followUp");
-    expect((follow!.args[2] as { content: string }).content).toMatch(/identify/i);
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/identify/i);
     const after = await store.get("a1");
     expect(after?.status).toBe("pending");
+  });
+
+  it("resolves the clicker id via interaction.user when there is no member (DM context)", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+    const interaction = buttonInteraction("tool-approval:approve:a1", "user-1");
+    delete interaction.member;
+    interaction.user = { id: "user-1", username: "alice" };
+
+    await handler.handle({
+      interaction,
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(1);
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+  });
+});
+
+describe("toolApproval — Discord error paths", () => {
+  it("swallows an editMessage failure so the decision still persists", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+    vi.spyOn(mockAPI.channels, "editMessage").mockRejectedValueOnce(
+      new Error("message was deleted"),
+    );
+
+    await expect(
+      handler.handle({
+        interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
+        discord,
+        customId: "tool-approval:approve:a1",
+      }),
+    ).resolves.toBeUndefined();
+
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+  });
+
+  it("swallows a followUp failure without throwing", async () => {
+    const { handler, discord, mockAPI } = setup();
+    vi.spyOn(mockAPI.interactions, "followUp").mockRejectedValueOnce(
+      new Error("unknown interaction"),
+    );
+
+    await expect(
+      handler.handle({
+        interaction: buttonInteraction("tool-approval:approve:missing", "user-1"),
+        discord,
+        customId: "tool-approval:approve:missing",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("toolApproval — default store fallback", () => {
+  it("falls back to a fresh ApprovalStore() when none is injected", async () => {
+    // No injected store → handler constructs `new ApprovalStore()`, which
+    // pulls the mocked `Redis.fromEnv()` in-memory backend. The row doesn't
+    // exist there, so the handler reports the approval as expired.
+    const handler = buildToolApprovalHandler();
+    const mockAPI = createMockAPI();
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:approve:nothing", "user-1"),
+      discord: asAPI(mockAPI) as API,
+      customId: "tool-approval:approve:nothing",
+    });
+
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/expired/);
   });
 });

--- a/src/bot/components/tool-approval.test.ts
+++ b/src/bot/components/tool-approval.test.ts
@@ -143,6 +143,19 @@ describe("toolApproval — customId parsing", () => {
     const follows = mockAPI.callsTo("interactions.followUp");
     expect((follows[0]![2] as { content: string }).content).toMatch(/Malformed/);
   });
+
+  it("rejects custom ids with no approval id part", async () => {
+    const { handler, discord, mockAPI } = setup();
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:approve", "user-1"),
+      discord,
+      customId: "tool-approval:approve",
+    });
+
+    const follows = mockAPI.callsTo("interactions.followUp");
+    expect((follows[0]![2] as { content: string }).content).toMatch(/Malformed/);
+  });
 });
 
 describe("toolApproval — message + context", () => {
@@ -248,6 +261,51 @@ describe("toolApproval — Discord error paths", () => {
         customId: "tool-approval:approve:missing",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("swallows an editMessage failure thrown as a non-Error value", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+    vi.spyOn(mockAPI.channels, "editMessage").mockRejectedValueOnce("plain string reason");
+
+    await expect(
+      handler.handle({
+        interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
+        discord,
+        customId: "tool-approval:approve:a1",
+      }),
+    ).resolves.toBeUndefined();
+    const after = await store.get("a1");
+    expect(after?.status).toBe("approved");
+  });
+
+  it("swallows a followUp failure thrown as a non-Error value", async () => {
+    const { handler, discord, mockAPI } = setup();
+    vi.spyOn(mockAPI.interactions, "followUp").mockRejectedValueOnce({ code: "boom" });
+
+    await expect(
+      handler.handle({
+        interaction: buttonInteraction("tool-approval:approve:missing", "user-1"),
+        discord,
+        customId: "tool-approval:approve:missing",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back to the read state when decide() returns null mid-flight", async () => {
+    const { store, handler, discord, mockAPI } = setup();
+    await store.create(baseApprovalState());
+    // Simulate the row being evicted between the initial `get` and `decide`,
+    // so `const finalState = updated ?? state` picks the `state` branch.
+    vi.spyOn(store, "decide").mockResolvedValueOnce(null);
+
+    await handler.handle({
+      interaction: buttonInteraction("tool-approval:approve:a1", "user-1"),
+      discord,
+      customId: "tool-approval:approve:a1",
+    });
+
+    expect(mockAPI.callsTo("channels.editMessage")).toHaveLength(1);
   });
 });
 

--- a/src/bot/components/tool-approval.ts
+++ b/src/bot/components/tool-approval.ts
@@ -1,0 +1,123 @@
+import type { API } from "@discordjs/core/http-only";
+
+import { log } from "evlog";
+
+import type { ApprovalState, ApprovalStoreLike } from "@/lib/ai/approvals";
+import type { DiscordInteraction } from "@/lib/protocol/types";
+
+import { ApprovalStore, buildDecisionEmbed } from "@/lib/ai/approvals";
+
+import type { ComponentHandler } from "./types";
+
+import { defineComponent } from "./define";
+
+type DecidedStatus = Exclude<ApprovalState["status"], "pending">;
+
+const EPHEMERAL_FLAG = 64;
+
+/**
+ * Build the Discord component handler for Approve / Deny buttons. Exposed as
+ * a factory so tests can inject a store backed by the in-memory Redis fixture;
+ * production auto-discovery picks up `toolApproval` below.
+ */
+export function buildToolApprovalHandler(store?: ApprovalStoreLike): ComponentHandler {
+  return defineComponent({
+    prefix: "tool-approval",
+    async handle(ctx) {
+      const { interaction, discord, customId } = ctx;
+
+      const parsed = parseCustomId(customId);
+      if (!parsed) {
+        await sendEphemeral(discord, interaction, "Malformed approval button.");
+        return;
+      }
+      const { action, id } = parsed;
+
+      const stateStore: ApprovalStoreLike = store ?? new ApprovalStore();
+      const state = await stateStore.get(id);
+
+      if (!state) {
+        await sendEphemeral(
+          discord,
+          interaction,
+          "This approval request has expired or was already processed.",
+        );
+        return;
+      }
+
+      const clickerId = interaction.member?.user.id ?? interaction.user?.id;
+      if (!clickerId) {
+        await sendEphemeral(discord, interaction, "Could not identify the clicker.");
+        return;
+      }
+
+      if (clickerId !== state.requesterUserId) {
+        await sendEphemeral(
+          discord,
+          interaction,
+          `Only <@${state.requesterUserId}> can approve this request.`,
+        );
+        return;
+      }
+
+      if (state.status !== "pending") {
+        await sendEphemeral(discord, interaction, `This request has already been ${state.status}.`);
+        return;
+      }
+
+      const newStatus: DecidedStatus = action === "approve" ? "approved" : "denied";
+      const updated = await stateStore.decide(id, newStatus, clickerId);
+      const finalState = updated ?? state;
+
+      await editOriginalMessage(discord, finalState, newStatus, clickerId);
+    },
+  });
+}
+
+export const toolApproval = buildToolApprovalHandler();
+
+function parseCustomId(customId: string): { action: "approve" | "deny"; id: string } | null {
+  const [, action, id] = customId.split(":");
+  if (!id) return null;
+  if (action !== "approve" && action !== "deny") return null;
+  return { action, id };
+}
+
+async function sendEphemeral(
+  discord: API,
+  interaction: DiscordInteraction,
+  content: string,
+): Promise<void> {
+  try {
+    await discord.interactions.followUp(interaction.application_id, interaction.token, {
+      content,
+      flags: EPHEMERAL_FLAG,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    log.warn("tool-approval", `Failed to send ephemeral reply: ${message}`);
+  }
+}
+
+async function editOriginalMessage(
+  discord: API,
+  state: ApprovalState,
+  action: DecidedStatus,
+  decidedByUserId: string,
+): Promise<void> {
+  if (!state.messageId) {
+    log.warn("tool-approval", `No messageId stored for approval ${state.id}; skipping edit.`);
+    return;
+  }
+  const targetChannelId = state.threadId ?? state.channelId;
+  const decisionEmbed = buildDecisionEmbed(state, action, decidedByUserId);
+  try {
+    await discord.channels.editMessage(targetChannelId, state.messageId, {
+      embeds: [decisionEmbed],
+      components: [],
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    log.warn("tool-approval", `Failed to edit approval message ${state.messageId}: ${message}`);
+  }
+}

--- a/src/bot/components/tool-approval.ts
+++ b/src/bot/components/tool-approval.ts
@@ -61,6 +61,9 @@ export function buildToolApprovalHandler(store?: ApprovalStoreLike): ComponentHa
       }
 
       if (state.status !== "pending") {
+        // Best-effort: converge the channel message to the stored decision
+        // in case the wrapper's timeout path or a previous edit failed.
+        await editOriginalMessage(discord, state, state.status, state.decidedByUserId ?? null);
         await sendEphemeral(discord, interaction, `This request has already been ${state.status}.`);
         return;
       }
@@ -103,7 +106,7 @@ async function editOriginalMessage(
   discord: API,
   state: ApprovalState,
   action: DecidedStatus,
-  decidedByUserId: string,
+  decidedByUserId: string | null,
 ): Promise<void> {
   if (!state.messageId) {
     log.warn("tool-approval", `No messageId stored for approval ${state.id}; skipping edit.`);

--- a/src/lib/ai/approvals/helpers.test.ts
+++ b/src/lib/ai/approvals/helpers.test.ts
@@ -53,12 +53,11 @@ describe("formatToolCall", () => {
     expect(out).toContain("maybe=undefined");
   });
 
-  it("falls back to String() when JSON.stringify throws (circular)", () => {
+  it("falls back to a placeholder when JSON.stringify throws (circular)", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     const out = formatToolCall(undefined, "t", { ref: circular });
-    // Should not throw; renders using String()
-    expect(out).toContain("ref=");
+    expect(out).toContain("ref=<unserializable>");
   });
 
   it("truncates long non-string values with a trailing ellipsis (no trailing quote)", () => {

--- a/src/lib/ai/approvals/helpers.test.ts
+++ b/src/lib/ai/approvals/helpers.test.ts
@@ -144,4 +144,21 @@ describe("buildDecisionEmbed", () => {
     expect(e.fields?.find((f) => f.name === "Decided by")).toBeUndefined();
     expect(e.footer?.text).toMatch(/Timed Out.*auto-expired/);
   });
+
+  it("renders the reason placeholder when state.reason is empty", () => {
+    const e = buildDecisionEmbed({ ...state, reason: "" }, "approved", "user-1");
+    const reasonField = e.fields?.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("(not provided)");
+  });
+
+  it("uses the current time as the timestamp when state.decidedAt is missing", () => {
+    const e = buildDecisionEmbed({ ...state, decidedAt: undefined }, "approved", "user-1");
+    expect(e.timestamp).toBeTruthy();
+    expect(new Date(e.timestamp!).toString()).not.toBe("Invalid Date");
+  });
+
+  it("omits the Decided-by field when decidedByUserId is null even for non-timeout actions", () => {
+    const e = buildDecisionEmbed(state, "approved", null);
+    expect(e.fields?.find((f) => f.name === "Decided by")).toBeUndefined();
+  });
 });

--- a/src/lib/ai/approvals/helpers.test.ts
+++ b/src/lib/ai/approvals/helpers.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalState } from "./types.ts";
+
+import {
+  buildApprovalComponents,
+  buildApprovalEmbed,
+  buildDecisionEmbed,
+  formatToolCall,
+} from "./helpers.ts";
+
+describe("formatToolCall", () => {
+  it("renders dot notation for delegate tools", () => {
+    const out = formatToolCall("github", "create_pr", {
+      title: "Fix bug",
+      branch: "fix/bug",
+    });
+    expect(out).toBe(`delegate_github.create_pr(\n    title="Fix bug",\n    branch="fix/bug",\n)`);
+  });
+
+  it("renders bare tool name when no delegate is set", () => {
+    const out = formatToolCall(undefined, "send_message", { content: "hi" });
+    expect(out).toBe(`send_message(\n    content="hi",\n)`);
+  });
+
+  it("omits parens body when input is empty", () => {
+    expect(formatToolCall(undefined, "ping", {})).toBe("ping()");
+  });
+
+  it("strips _reason before rendering", () => {
+    const out = formatToolCall(undefined, "x", { keep: 1, _reason: "because" });
+    expect(out).toBe(`x(\n    keep=1,\n)`);
+  });
+
+  it("treats array inputs as empty-kwargs calls", () => {
+    expect(formatToolCall(undefined, "x", [1, 2, 3])).toBe("x()");
+  });
+
+  it("truncates long string values with an ellipsis", () => {
+    const long = "x".repeat(500);
+    const out = formatToolCall(undefined, "t", { big: long });
+    expect(out).toContain("…");
+    expect(out.length).toBeLessThan(300);
+  });
+
+  it("serializes nested objects as JSON", () => {
+    const out = formatToolCall(undefined, "t", { opts: { a: 1, b: true } });
+    expect(out).toContain(`opts={"a":1,"b":true}`);
+  });
+});
+
+describe("buildApprovalEmbed", () => {
+  it("uses amber color and includes the reason", () => {
+    const embed = buildApprovalEmbed({
+      toolName: "ping",
+      input: {},
+      reason: "testing",
+      timeoutMs: 240_000,
+    });
+    expect(embed.color).toBe(0xffaa00);
+    expect(embed.fields?.[0]).toEqual({ name: "Reason", value: "testing" });
+    expect(embed.footer?.text).toMatch(/auto-denies in 4m/);
+  });
+
+  it("falls back to a placeholder when the reason is blank", () => {
+    const embed = buildApprovalEmbed({
+      toolName: "ping",
+      input: {},
+      reason: "",
+      timeoutMs: 60_000,
+    });
+    expect(embed.fields?.[0]?.value).toBe("(not provided)");
+  });
+
+  it("embeds the tool call in a py code block", () => {
+    const embed = buildApprovalEmbed({
+      delegateName: "github",
+      toolName: "create_pr",
+      input: { title: "fix" },
+      reason: "r",
+      timeoutMs: 240_000,
+    });
+    expect(embed.description).toContain("```py\ndelegate_github.create_pr(");
+  });
+});
+
+describe("buildApprovalComponents", () => {
+  it("returns an action row with Approve + Deny buttons carrying the id", () => {
+    const [row] = buildApprovalComponents("abc123");
+    expect(row.type).toBe(1);
+    expect(row.components).toHaveLength(2);
+    const ids = row.components.map((c) => (c as { custom_id: string }).custom_id);
+    expect(ids).toEqual(["tool-approval:approve:abc123", "tool-approval:deny:abc123"]);
+  });
+});
+
+describe("buildDecisionEmbed", () => {
+  const state: ApprovalState = {
+    id: "x",
+    status: "approved",
+    toolName: "ping",
+    input: {},
+    reason: "r",
+    channelId: "ch-1",
+    requesterUserId: "user-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    decidedAt: "2024-01-01T00:01:00Z",
+  };
+
+  it("green color + Decided by field for approved", () => {
+    const e = buildDecisionEmbed(state, "approved", "user-1");
+    expect(e.color).toBe(0x34d399);
+    const decided = e.fields?.find((f) => f.name === "Decided by");
+    expect(decided?.value).toBe("<@user-1>");
+  });
+
+  it("red color for denied", () => {
+    const e = buildDecisionEmbed(state, "denied", "user-1");
+    expect(e.color).toBe(0xef4444);
+  });
+
+  it("grey color + no Decided-by for timeout", () => {
+    const e = buildDecisionEmbed(state, "timeout", null);
+    expect(e.color).toBe(0x9ca3af);
+    expect(e.fields?.find((f) => f.name === "Decided by")).toBeUndefined();
+    expect(e.footer?.text).toMatch(/Timed Out.*auto-expired/);
+  });
+});

--- a/src/lib/ai/approvals/helpers.test.ts
+++ b/src/lib/ai/approvals/helpers.test.ts
@@ -47,6 +47,26 @@ describe("formatToolCall", () => {
     const out = formatToolCall(undefined, "t", { opts: { a: 1, b: true } });
     expect(out).toContain(`opts={"a":1,"b":true}`);
   });
+
+  it("renders undefined values as 'undefined' (not 'null')", () => {
+    const out = formatToolCall(undefined, "t", { maybe: undefined });
+    expect(out).toContain("maybe=undefined");
+  });
+
+  it("falls back to String() when JSON.stringify throws (circular)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const out = formatToolCall(undefined, "t", { ref: circular });
+    // Should not throw; renders using String()
+    expect(out).toContain("ref=");
+  });
+
+  it("truncates long non-string values with a trailing ellipsis (no trailing quote)", () => {
+    const longArray = Array.from({ length: 500 }, (_, i) => i);
+    const out = formatToolCall(undefined, "t", { nums: longArray });
+    expect(out).toContain("…");
+    expect(out).not.toContain(`…"`);
+  });
 });
 
 describe("buildApprovalEmbed", () => {

--- a/src/lib/ai/approvals/helpers.ts
+++ b/src/lib/ai/approvals/helpers.ts
@@ -29,7 +29,10 @@ function formatValue(v: unknown): string {
   try {
     s = JSON.stringify(v);
   } catch {
-    s = String(v);
+    // Circular / non-serializable payload — show a placeholder rather than
+    // relying on `String(v)`, which produces `[object Object]` for most
+    // structured values.
+    s = "<unserializable>";
   }
   if (s.length <= MAX_VALUE_LEN) return s;
   const wrapped = s.at(0) === '"';

--- a/src/lib/ai/approvals/helpers.ts
+++ b/src/lib/ai/approvals/helpers.ts
@@ -1,0 +1,133 @@
+import type {
+  APIActionRowComponent,
+  APIComponentInMessageActionRow,
+  APIEmbed,
+} from "discord-api-types/v10";
+
+import { ButtonStyle, ComponentType } from "discord-api-types/v10";
+
+import type { ApprovalState, BuildApprovalEmbedArgs } from "./types.ts";
+
+const COLOR_AMBER = 0xffaa00;
+const COLOR_GREEN = 0x34d399;
+const COLOR_RED = 0xef4444;
+const COLOR_GREY = 0x9ca3af;
+
+const MAX_VALUE_LEN = 200;
+
+type DecidedStatus = Exclude<ApprovalState["status"], "pending">;
+
+const STATUS_STYLE: Record<DecidedStatus, { color: number; label: string; icon: string }> = {
+  approved: { color: COLOR_GREEN, label: "Approved", icon: "✅" },
+  denied: { color: COLOR_RED, label: "Denied", icon: "❌" },
+  timeout: { color: COLOR_GREY, label: "Timed Out", icon: "⏱" },
+};
+
+function formatValue(v: unknown): string {
+  let s: string;
+  try {
+    s = JSON.stringify(v);
+  } catch {
+    s = String(v);
+  }
+  if (s === undefined) s = "null";
+  if (s.length <= MAX_VALUE_LEN) return s;
+  const wrapped = s.at(0) === '"';
+  const body = wrapped ? s.slice(1, MAX_VALUE_LEN - 2) : s.slice(0, MAX_VALUE_LEN - 1);
+  return wrapped ? `"${body}…"` : `${body}…`;
+}
+
+/**
+ * Render a python-style dot-notation call for display in the approval prompt.
+ * Strips the wrapper-injected `_reason` field so the agent's justification
+ * doesn't clutter the visible parameters.
+ *
+ * - With `delegateName`: `delegate_<name>.<tool>(\n    k=v,\n)`.
+ * - Without: `<tool>(\n    k=v,\n)`.
+ * - Empty params: `<tool>()`.
+ */
+export function formatToolCall(
+  delegateName: string | undefined,
+  toolName: string,
+  input: unknown,
+): string {
+  const obj =
+    input && typeof input === "object" && !Array.isArray(input)
+      ? { ...(input as Record<string, unknown>) }
+      : {};
+  delete obj._reason;
+
+  const prefix = delegateName ? `delegate_${delegateName}.${toolName}` : toolName;
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return `${prefix}()`;
+
+  const lines = entries.map(([k, v]) => `    ${k}=${formatValue(v)},`).join("\n");
+  return `${prefix}(\n${lines}\n)`;
+}
+
+export function buildApprovalEmbed(args: BuildApprovalEmbedArgs): APIEmbed {
+  const callStr = formatToolCall(args.delegateName, args.toolName, args.input);
+  const minutes = Math.max(1, Math.round(args.timeoutMs / 60_000));
+  return {
+    color: COLOR_AMBER,
+    author: { name: "🛂 Wack Hack · Permission Requested" },
+    description: `\`\`\`py\n${callStr}\n\`\`\``,
+    fields: [{ name: "Reason", value: args.reason || "(not provided)" }],
+    footer: { text: `Only the requester can approve · auto-denies in ${minutes}m` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function buildApprovalComponents(
+  approvalId: string,
+): APIActionRowComponent<APIComponentInMessageActionRow>[] {
+  return [
+    {
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Success,
+          label: "Approve",
+          emoji: { name: "✅" },
+          custom_id: `tool-approval:approve:${approvalId}`,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Danger,
+          label: "Deny",
+          emoji: { name: "❌" },
+          custom_id: `tool-approval:deny:${approvalId}`,
+        },
+      ],
+    },
+  ];
+}
+
+export function buildDecisionEmbed(
+  state: ApprovalState,
+  action: DecidedStatus,
+  decidedByUserId: string | null,
+): APIEmbed {
+  const style = STATUS_STYLE[action];
+  const callStr = formatToolCall(state.delegateName, state.toolName, state.input);
+
+  const fields: APIEmbed["fields"] = [{ name: "Reason", value: state.reason || "(not provided)" }];
+  if (action !== "timeout" && decidedByUserId) {
+    fields.push({ name: "Decided by", value: `<@${decidedByUserId}>` });
+  }
+
+  const footerText =
+    action === "timeout"
+      ? `${style.icon} ${style.label} · auto-expired`
+      : `${style.icon} ${style.label}${decidedByUserId ? "" : ""}`;
+
+  return {
+    color: style.color,
+    author: { name: `Wack Hack · Permission ${style.label}` },
+    description: `\`\`\`py\n${callStr}\n\`\`\``,
+    fields,
+    footer: { text: footerText },
+    timestamp: state.decidedAt ?? new Date().toISOString(),
+  };
+}

--- a/src/lib/ai/approvals/helpers.ts
+++ b/src/lib/ai/approvals/helpers.ts
@@ -24,13 +24,13 @@ const STATUS_STYLE: Record<DecidedStatus, { color: number; label: string; icon: 
 };
 
 function formatValue(v: unknown): string {
+  if (v === undefined) return "undefined";
   let s: string;
   try {
     s = JSON.stringify(v);
   } catch {
     s = String(v);
   }
-  if (s === undefined) s = "null";
   if (s.length <= MAX_VALUE_LEN) return s;
   const wrapped = s.at(0) === '"';
   const body = wrapped ? s.slice(1, MAX_VALUE_LEN - 2) : s.slice(0, MAX_VALUE_LEN - 1);
@@ -120,7 +120,7 @@ export function buildDecisionEmbed(
   const footerText =
     action === "timeout"
       ? `${style.icon} ${style.label} · auto-expired`
-      : `${style.icon} ${style.label}${decidedByUserId ? "" : ""}`;
+      : `${style.icon} ${style.label}`;
 
   return {
     color: style.color,

--- a/src/lib/ai/approvals/index.test.ts
+++ b/src/lib/ai/approvals/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { noopTool } from "@/lib/test/fixtures";
+
+import { approval, getApprovalOptions, hasApprovalMarker } from "./index.ts";
+
+describe("approval", () => {
+  describe("approval()", () => {
+    it("returns the same reference it was given", () => {
+      const t = noopTool("a");
+      expect(approval(t)).toBe(t);
+    });
+
+    it("marks the tool so hasApprovalMarker returns true", () => {
+      const t = approval(noopTool("gated"));
+      expect(hasApprovalMarker(t)).toBe(true);
+    });
+
+    it("stores the options so getApprovalOptions returns them", () => {
+      const t = approval(noopTool("gated"), { reason: "destructive" });
+      expect(getApprovalOptions(t)).toEqual({ reason: "destructive" });
+    });
+
+    it("defaults to an empty options object when none is given", () => {
+      const t = approval(noopTool("gated"));
+      expect(getApprovalOptions(t)).toEqual({});
+    });
+  });
+
+  describe("hasApprovalMarker() / getApprovalOptions()", () => {
+    it("returns false/null for unmarked tools", () => {
+      const t = noopTool("plain");
+      expect(hasApprovalMarker(t)).toBe(false);
+      expect(getApprovalOptions(t)).toBeNull();
+    });
+
+    it("returns null for non-object values", () => {
+      expect(getApprovalOptions(null)).toBeNull();
+      expect(getApprovalOptions(undefined)).toBeNull();
+      expect(getApprovalOptions("string")).toBeNull();
+      expect(getApprovalOptions(42)).toBeNull();
+    });
+  });
+});

--- a/src/lib/ai/approvals/index.ts
+++ b/src/lib/ai/approvals/index.ts
@@ -1,0 +1,38 @@
+import type { ApprovalOptions } from "./types.ts";
+
+const APPROVAL_MARKER = Symbol("approval");
+
+/** Mark a tool as requiring per-call user approval before execution. */
+export function approval<T>(t: T, opts: ApprovalOptions = {}): T {
+  (t as Record<symbol, ApprovalOptions>)[APPROVAL_MARKER] = opts;
+  return t;
+}
+
+/** Return the approval options if the tool is marked, else null. */
+export function getApprovalOptions(t: unknown): ApprovalOptions | null {
+  if (!t || typeof t !== "object") return null;
+  const marker = (t as Record<symbol, unknown>)[APPROVAL_MARKER];
+  return marker ? (marker as ApprovalOptions) : null;
+}
+
+/** True iff the tool has the approval marker. */
+export function hasApprovalMarker(t: unknown): boolean {
+  return getApprovalOptions(t) !== null;
+}
+
+export { wrapApprovalTools } from "./runtime.ts";
+export { ApprovalStore } from "./store.ts";
+export {
+  buildApprovalComponents,
+  buildApprovalEmbed,
+  buildDecisionEmbed,
+  formatToolCall,
+} from "./helpers.ts";
+export type {
+  ApprovalOptions,
+  ApprovalState,
+  ApprovalStoreLike,
+  BuildApprovalEmbedArgs,
+  WaitForOptions,
+  WrapApprovalOptions,
+} from "./types.ts";

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { AgentContext } from "@/lib/ai/context";
@@ -8,6 +8,20 @@ import { createMemoryRedis, messagePacket } from "@/lib/test/fixtures";
 import { approval } from "./index.ts";
 import { wrapApprovalTools } from "./runtime.ts";
 import { ApprovalStore } from "./store.ts";
+
+// Mock the third-party Discord REST client at the module level so the wrapper
+// exercises its real `discord.post(...)` path without hitting the network.
+const { restPost } = vi.hoisted(() => ({
+  restPost: vi.fn<(route: string, opts: { body: unknown }) => Promise<unknown>>(),
+}));
+vi.mock("@discordjs/rest", () => ({
+  REST: class {
+    setToken() {
+      return this;
+    }
+    post = restPost;
+  },
+}));
 
 const context = AgentContext.fromPacket(messagePacket("hello"));
 
@@ -19,17 +33,6 @@ function gatedTool() {
       execute: async ({ name }: { name: string }) => `created ${name}`,
     }),
   );
-}
-
-type PostMessageMock = ReturnType<
-  typeof vi.fn<(channelId: string, body: unknown) => Promise<{ id: string }>>
->;
-
-function extractApprovalId(postMessage: PostMessageMock, callIdx = 0): string {
-  const [, body] = postMessage.mock.calls[callIdx]!;
-  const customId = (body as { components: [{ components: [{ custom_id: string }] }] }).components[0]
-    .components[0].custom_id;
-  return customId.split(":")[2]!;
 }
 
 function runtimeOpts(): Parameters<NonNullable<ReturnType<typeof gatedTool>["execute"]>>[1] {
@@ -47,6 +50,21 @@ function startExec(t: unknown, input: Record<string, unknown>) {
   })();
   return { values, drain };
 }
+
+function extractApprovalId(callIdx = 0): string {
+  const [, opts] = restPost.mock.calls[callIdx]!;
+  const body = opts.body as { components: [{ components: [{ custom_id: string }] }] };
+  return body.components[0].components[0].custom_id.split(":")[2]!;
+}
+
+beforeEach(() => {
+  restPost.mockReset();
+  restPost.mockResolvedValue({ id: "msg-1" });
+});
+
+afterEach(() => {
+  restPost.mockReset();
+});
 
 describe("wrapApprovalTools — shape", () => {
   it("passes through unmarked tools by identity", () => {
@@ -87,22 +105,30 @@ describe("wrapApprovalTools — shape", () => {
     expect(schema.safeParse({ name: "x" }).success).toBe(true);
     expect(schema.safeParse({ name: "x", _reason: "override" }).success).toBe(true);
   });
+
+  it("wraps tools whose inputSchema is not a ZodObject without extending it", () => {
+    const nonObjectSchema = z.union([z.string(), z.number()]);
+    const gated = approval(
+      tool({
+        description: "raw",
+        inputSchema: nonObjectSchema,
+        execute: async () => "ok",
+      }),
+    );
+    const out = wrapApprovalTools({ t: gated }, { context });
+    expect(out.t.inputSchema).toBe(nonObjectSchema);
+  });
 });
 
 describe("wrapApprovalTools — decisions", () => {
   it("runs the original tool when the approval is marked approved", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => ({ id: "msg-1" }));
-
-    const out = wrapApprovalTools(
-      { make: gatedTool() },
-      { context, store, postMessage, timeoutMs: 10_000 },
-    );
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 10_000 });
 
     const { values, drain } = startExec(out.make, { name: "widget", _reason: "needed" });
 
     await new Promise((r) => setTimeout(r, 20));
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
 
     await drain;
@@ -111,16 +137,11 @@ describe("wrapApprovalTools — decisions", () => {
 
   it("returns a denial string when the approval is denied", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => ({ id: "msg-2" }));
-
-    const out = wrapApprovalTools(
-      { make: gatedTool() },
-      { context, store, postMessage, timeoutMs: 10_000 },
-    );
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 10_000 });
     const { values, drain } = startExec(out.make, { name: "widget", _reason: "maybe" });
 
     await new Promise((r) => setTimeout(r, 20));
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "denied", context.userId);
 
     await drain;
@@ -129,12 +150,7 @@ describe("wrapApprovalTools — decisions", () => {
 
   it("returns a timeout string when the approval polling deadline passes", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => ({ id: "msg-t" }));
-
-    const out = wrapApprovalTools(
-      { make: gatedTool() },
-      { context, store, postMessage, timeoutMs: 50 },
-    );
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
     const { values, drain } = startExec(out.make, { name: "widget", _reason: "tick" });
     await drain;
     expect(values.at(-1)).toMatch(/timed out/i);
@@ -144,7 +160,6 @@ describe("wrapApprovalTools — decisions", () => {
 describe("wrapApprovalTools — streaming", () => {
   it("forwards every value yielded by a streaming original tool", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => ({ id: "msg-s" }));
     const streamingTool = approval(
       tool({
         description: "streaming",
@@ -157,14 +172,11 @@ describe("wrapApprovalTools — streaming", () => {
       }),
     );
 
-    const out = wrapApprovalTools(
-      { s: streamingTool },
-      { context, store, postMessage, timeoutMs: 10_000 },
-    );
+    const out = wrapApprovalTools({ s: streamingTool }, { context, store, timeoutMs: 10_000 });
     const { values, drain } = startExec(out.s, { _reason: "stream" });
 
     await new Promise((r) => setTimeout(r, 20));
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
 
     await drain;
@@ -172,12 +184,48 @@ describe("wrapApprovalTools — streaming", () => {
   });
 });
 
-describe("wrapApprovalTools — edge cases", () => {
-  it("surfaces a message-send failure without running the original tool", async () => {
+describe("wrapApprovalTools — Discord integration", () => {
+  it("posts to the channel via the real REST client path", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => {
-      throw new Error("network down");
-    });
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 10_000 });
+    const { drain } = startExec(out.t, { name: "x", _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(restPost).toHaveBeenCalledTimes(1);
+    const [route, opts] = restPost.mock.calls[0]!;
+    expect(route).toContain(context.channel.id);
+    const body = opts.body as { content: string; allowed_mentions: { users: string[] } };
+    expect(body.content).toBe(`<@${context.userId}>`);
+    expect(body.allowed_mentions.users).toEqual([context.userId]);
+
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+
+  it("posts into the thread when the context has one", async () => {
+    const threadedContext = AgentContext.fromPacket(
+      messagePacket("hi", { thread: { parentId: "parent-1", parentName: "general" } }),
+    );
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools(
+      { t: gatedTool() },
+      { context: threadedContext, store, timeoutMs: 10_000 },
+    );
+    const { drain } = startExec(out.t, { name: "x", _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [route] = restPost.mock.calls[0]!;
+    expect(route).toContain(threadedContext.thread!.id);
+
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+
+  it("surfaces a post failure without running the original tool", async () => {
+    restPost.mockRejectedValueOnce(new Error("network down"));
+    const store = new ApprovalStore(createMemoryRedis());
     const innerExec = vi.fn(async () => "should-not-run");
     const gated = approval(
       tool({
@@ -187,17 +235,18 @@ describe("wrapApprovalTools — edge cases", () => {
       }),
     );
 
-    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage });
+    const out = wrapApprovalTools({ t: gated }, { context, store });
     const { values, drain } = startExec(out.t, { x: "a", _reason: "r" });
     await drain;
 
     expect(values.at(-1)).toMatch(/failed to send/i);
     expect(innerExec).not.toHaveBeenCalled();
   });
+});
 
+describe("wrapApprovalTools — reason handling", () => {
   it("strips _reason from the input before invoking the original execute", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage = vi.fn(async () => ({ id: "m" }));
     const innerExec = vi.fn(async (input: { x: string }) => `got ${input.x}`);
     const gated = approval(
       tool({
@@ -207,11 +256,11 @@ describe("wrapApprovalTools — edge cases", () => {
       }),
     );
 
-    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const out = wrapApprovalTools({ t: gated }, { context, store, timeoutMs: 10_000 });
     const { drain } = startExec(out.t, { x: "hello", _reason: "because" });
 
     await new Promise((r) => setTimeout(r, 20));
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
 
     await drain;
@@ -222,7 +271,6 @@ describe("wrapApprovalTools — edge cases", () => {
 
   it("uses the static reason when the agent omits _reason", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage: PostMessageMock = vi.fn(async () => ({ id: "m" }));
     const gated = approval(
       tool({
         description: "t",
@@ -232,23 +280,22 @@ describe("wrapApprovalTools — edge cases", () => {
       { reason: "static fallback" },
     );
 
-    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const out = wrapApprovalTools({ t: gated }, { context, store, timeoutMs: 10_000 });
     const { drain } = startExec(out.t, {});
 
     await new Promise((r) => setTimeout(r, 20));
-    const [, body] = postMessage.mock.calls[0]!;
-    const embed = (body as { embeds: { fields: { name: string; value: string }[] }[] }).embeds[0];
-    const reasonField = embed.fields.find((f) => f.name === "Reason");
+    const [, opts] = restPost.mock.calls[0]!;
+    const body = opts.body as { embeds: { fields: { name: string; value: string }[] }[] };
+    const reasonField = body.embeds[0].fields.find((f) => f.name === "Reason");
     expect(reasonField?.value).toBe("static fallback");
 
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
     await drain;
   });
 
   it("prefers the agent-supplied _reason over the static reason", async () => {
     const store = new ApprovalStore(createMemoryRedis());
-    const postMessage: PostMessageMock = vi.fn(async () => ({ id: "m" }));
     const gated = approval(
       tool({
         description: "t",
@@ -258,38 +305,74 @@ describe("wrapApprovalTools — edge cases", () => {
       { reason: "static fallback" },
     );
 
-    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const out = wrapApprovalTools({ t: gated }, { context, store, timeoutMs: 10_000 });
     const { drain } = startExec(out.t, { _reason: "dynamic override" });
 
     await new Promise((r) => setTimeout(r, 20));
-    const [, body] = postMessage.mock.calls[0]!;
-    const embed = (body as { embeds: { fields: { name: string; value: string }[] }[] }).embeds[0];
-    const reasonField = embed.fields.find((f) => f.name === "Reason");
+    const [, opts] = restPost.mock.calls[0]!;
+    const body = opts.body as { embeds: { fields: { name: string; value: string }[] }[] };
+    const reasonField = body.embeds[0].fields.find((f) => f.name === "Reason");
     expect(reasonField?.value).toBe("dynamic override");
 
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
     await drain;
   });
 
-  it("passes a TTL derived from timeoutMs to store.create", async () => {
+  it("falls back to '(not provided)' when neither _reason nor staticReason is set", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 10_000 });
+    // Bypass Zod by calling execute directly with no _reason — the wrapper
+    // should still resolve a reason string for the embed.
+    const { drain } = startExec(out.t, { name: "x" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [, opts] = restPost.mock.calls[0]!;
+    const body = opts.body as { embeds: { fields: { name: string; value: string }[] }[] };
+    const reasonField = body.embeds[0].fields.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("(not provided)");
+
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+});
+
+describe("wrapApprovalTools — no execute", () => {
+  it("yields a 'nothing ran' string when the marked tool has no execute", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    // Build a raw tool-shaped object without an execute function, then mark it.
+    const bare = approval({
+      description: "no exec",
+      inputSchema: z.object({}),
+    } as unknown as ReturnType<typeof gatedTool>);
+
+    const out = wrapApprovalTools({ t: bare }, { context, store, timeoutMs: 10_000 });
+    const { values, drain } = startExec(out.t, { _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+
+    expect(values.at(-1)).toMatch(/nothing ran/);
+  });
+});
+
+describe("wrapApprovalTools — TTL", () => {
+  it("derives TTL from timeoutMs + a 60s buffer", async () => {
     const store = new ApprovalStore(createMemoryRedis());
     const createSpy = vi.spyOn(store, "create");
-    const postMessage = vi.fn(async () => ({ id: "m" }));
 
-    const out = wrapApprovalTools(
-      { t: gatedTool() },
-      { context, store, postMessage, timeoutMs: 120_000 },
-    );
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 120_000 });
     const { drain } = startExec(out.t, { name: "x", _reason: "r" });
 
     await new Promise((r) => setTimeout(r, 20));
     expect(createSpy).toHaveBeenCalledTimes(1);
     const [, ttlArg] = createSpy.mock.calls[0]!;
-    // 120s timeout + 60s buffer = 180s TTL
-    expect(ttlArg).toBe(180);
+    expect(ttlArg).toBe(180); // 120s + 60s buffer
 
-    const id = extractApprovalId(postMessage);
+    const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
     await drain;
   });

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -23,6 +23,12 @@ vi.mock("@discordjs/rest", () => ({
   },
 }));
 
+// Mock the third-party Upstash Redis client so `new ApprovalStore()` (the
+// default path when no store is injected) uses an in-memory backend.
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
+
 const context = AgentContext.fromPacket(messagePacket("hello"));
 
 function gatedTool() {
@@ -117,6 +123,27 @@ describe("wrapApprovalTools — shape", () => {
     );
     const out = wrapApprovalTools({ t: gated }, { context });
     expect(out.t.inputSchema).toBe(nonObjectSchema);
+  });
+
+  it("substitutes an empty object schema when the original has no inputSchema", () => {
+    // Raw tool object with no schema. approval() just tags it.
+    const bare = approval({ description: "raw" } as unknown as ReturnType<typeof gatedTool>);
+    const out = wrapApprovalTools({ t: bare }, { context });
+    // Should not throw and should produce a callable tool definition.
+    expect(out.t.inputSchema).toBeDefined();
+  });
+
+  it("tolerates tools that carry no description when wrapping", () => {
+    const bare = approval(
+      tool({
+        // no description
+        inputSchema: z.object({}),
+        execute: async () => "ok",
+      }) as unknown as ReturnType<typeof gatedTool>,
+    );
+    const out = wrapApprovalTools({ t: bare }, { context });
+    // Wrapper's synthesized description still carries the approval note.
+    expect(out.t.description).toMatch(/Requires user approval/);
   });
 });
 
@@ -242,6 +269,35 @@ describe("wrapApprovalTools — Discord integration", () => {
     expect(values.at(-1)).toMatch(/failed to send/i);
     expect(innerExec).not.toHaveBeenCalled();
   });
+
+  it("surfaces a post failure thrown as a non-Error value", async () => {
+    restPost.mockRejectedValueOnce("plain string reason");
+    const store = new ApprovalStore(createMemoryRedis());
+    const innerExec = vi.fn(async () => "should-not-run");
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({ x: z.string() }),
+        execute: innerExec,
+      }),
+    );
+
+    const out = wrapApprovalTools({ t: gated }, { context, store });
+    const { values, drain } = startExec(out.t, { x: "a", _reason: "r" });
+    await drain;
+
+    expect(values.at(-1)).toMatch(/unknown error/);
+    expect(innerExec).not.toHaveBeenCalled();
+  });
+
+  it("uses a default ApprovalStore when none is injected (real Redis.fromEnv path)", async () => {
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, timeoutMs: 50 });
+    const { values, drain } = startExec(out.t, { name: "x", _reason: "r" });
+    // No store injected → `new ApprovalStore()` path runs. Wait for the
+    // wrapper's internal polling deadline to pass; it'll yield a timeout.
+    await drain;
+    expect(values.at(-1)).toMatch(/timed out/i);
+  });
 });
 
 describe("wrapApprovalTools — reason handling", () => {
@@ -293,7 +349,9 @@ describe("wrapApprovalTools — reason handling", () => {
     await store.decide(id, "approved", context.userId);
     await drain;
   });
+});
 
+describe("wrapApprovalTools — reason precedence", () => {
   it("prefers the agent-supplied _reason over the static reason", async () => {
     const store = new ApprovalStore(createMemoryRedis());
     const gated = approval(
@@ -335,6 +393,80 @@ describe("wrapApprovalTools — reason handling", () => {
     const id = extractApprovalId();
     await store.decide(id, "approved", context.userId);
     await drain;
+  });
+});
+
+describe("wrapApprovalTools — defensive input handling", () => {
+  it("handles a null raw input by using the static reason", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({}),
+        execute: async () => "ok",
+      }),
+      { reason: "fallback reason" },
+    );
+    const out = wrapApprovalTools({ t: gated }, { context, store, timeoutMs: 10_000 });
+    // Type-cast to bypass the wrapper's input signature — the AI SDK can't
+    // actually send null after Zod validation, but the extractReason guard
+    // must still handle it defensively.
+    const { drain } = startExec(out.t, null as unknown as Record<string, unknown>);
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [, opts] = restPost.mock.calls[0]!;
+    const body = opts.body as { embeds: { fields: { name: string; value: string }[] }[] };
+    const reasonField = body.embeds[0].fields.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("fallback reason");
+
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+
+  it("handles a null raw input with no static reason via the default placeholder", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 10_000 });
+    const { drain } = startExec(out.t, null as unknown as Record<string, unknown>);
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [, opts] = restPost.mock.calls[0]!;
+    const body = opts.body as { embeds: { fields: { name: string; value: string }[] }[] };
+    const reasonField = body.embeds[0].fields.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("(not provided)");
+
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+});
+
+describe("wrapApprovalTools — abort signal extraction", () => {
+  it("ignores a non-object runtime", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 50 });
+    // Call execute with `undefined` for the runtime arg — extractAbortSignal
+    // must take the non-object branch and return undefined.
+    const exec = (out.t as { execute: (input: unknown, opts: unknown) => unknown }).execute;
+    const iter = exec({ name: "x", _reason: "r" }, undefined) as AsyncIterable<unknown>;
+    const values: unknown[] = [];
+    for await (const v of iter) values.push(v);
+    expect(values.at(-1)).toMatch(/timed out/i);
+  });
+
+  it("ignores a runtime whose abortSignal is not an AbortSignal", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ t: gatedTool() }, { context, store, timeoutMs: 50 });
+    const exec = (out.t as { execute: (input: unknown, opts: unknown) => unknown }).execute;
+    // Pass a string where an AbortSignal is expected — the `instanceof`
+    // check must fall through to the `undefined` branch.
+    const iter = exec(
+      { name: "x", _reason: "r" },
+      { abortSignal: "not-a-signal" },
+    ) as AsyncIterable<unknown>;
+    const values: unknown[] = [];
+    for await (const v of iter) values.push(v);
+    expect(values.at(-1)).toMatch(/timed out/i);
   });
 });
 

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -10,9 +10,11 @@ import { wrapApprovalTools } from "./runtime.ts";
 import { ApprovalStore } from "./store.ts";
 
 // Mock the third-party Discord REST client at the module level so the wrapper
-// exercises its real `discord.post(...)` path without hitting the network.
-const { restPost } = vi.hoisted(() => ({
+// exercises its real `discord.post(...)` / `discord.patch(...)` paths
+// without hitting the network.
+const { restPost, restPatch } = vi.hoisted(() => ({
   restPost: vi.fn<(route: string, opts: { body: unknown }) => Promise<unknown>>(),
+  restPatch: vi.fn<(route: string, opts: { body: unknown }) => Promise<unknown>>(),
 }));
 vi.mock("@discordjs/rest", () => ({
   REST: class {
@@ -20,6 +22,7 @@ vi.mock("@discordjs/rest", () => ({
       return this;
     }
     post = restPost;
+    patch = restPatch;
   },
 }));
 
@@ -66,10 +69,13 @@ function extractApprovalId(callIdx = 0): string {
 beforeEach(() => {
   restPost.mockReset();
   restPost.mockResolvedValue({ id: "msg-1" });
+  restPatch.mockReset();
+  restPatch.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
   restPost.mockReset();
+  restPatch.mockReset();
 });
 
 describe("wrapApprovalTools — shape", () => {
@@ -112,7 +118,7 @@ describe("wrapApprovalTools — shape", () => {
     expect(schema.safeParse({ name: "x", _reason: "override" }).success).toBe(true);
   });
 
-  it("wraps tools whose inputSchema is not a ZodObject without extending it", () => {
+  it("throws when the original inputSchema isn't a ZodObject (would silently drop args)", () => {
     const nonObjectSchema = z.union([z.string(), z.number()]);
     const gated = approval(
       tool({
@@ -121,16 +127,15 @@ describe("wrapApprovalTools — shape", () => {
         execute: async () => "ok",
       }),
     );
-    const out = wrapApprovalTools({ t: gated }, { context });
-    expect(out.t.inputSchema).toBe(nonObjectSchema);
+    expect(() => wrapApprovalTools({ t: gated }, { context })).toThrow(/ZodObject inputSchema/);
   });
 
-  it("substitutes an empty object schema when the original has no inputSchema", () => {
+  it("substitutes a `{ _reason }` object schema when the original has no inputSchema", () => {
     // Raw tool object with no schema. approval() just tags it.
     const bare = approval({ description: "raw" } as unknown as ReturnType<typeof gatedTool>);
     const out = wrapApprovalTools({ t: bare }, { context });
-    // Should not throw and should produce a callable tool definition.
-    expect(out.t.inputSchema).toBeDefined();
+    const schema = out.t.inputSchema as z.ZodObject<z.ZodRawShape>;
+    expect(schema.shape._reason).toBeDefined();
   });
 
   it("tolerates tools that carry no description when wrapping", () => {
@@ -180,6 +185,102 @@ describe("wrapApprovalTools — decisions", () => {
     const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
     const { values, drain } = startExec(out.make, { name: "widget", _reason: "tick" });
     await drain;
+    expect(values.at(-1)).toMatch(/timed out/i);
+  });
+});
+
+describe("wrapApprovalTools — message convergence on non-approved", () => {
+  it("patches the original message to a decision embed on timeout", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
+    const { values, drain } = startExec(out.make, { name: "x", _reason: "r" });
+    await drain;
+
+    expect(values.at(-1)).toMatch(/timed out/i);
+    expect(restPatch).toHaveBeenCalledTimes(1);
+    const [, opts] = restPatch.mock.calls[0]!;
+    const body = opts.body as { components: unknown[]; embeds: unknown[] };
+    expect(body.components).toEqual([]); // buttons cleared
+    expect(body.embeds).toHaveLength(1);
+  });
+
+  it("patches the original message to a decision embed on deny", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 10_000 });
+    const { drain } = startExec(out.make, { name: "x", _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId();
+    await store.decide(id, "denied", context.userId);
+    await drain;
+
+    expect(restPatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not patch on approve (the inner tool runs and the request resolves normally)", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 10_000 });
+    const { drain } = startExec(out.make, { name: "x", _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId();
+    await store.decide(id, "approved", context.userId);
+    await drain;
+
+    expect(restPatch).not.toHaveBeenCalled();
+  });
+
+  it("swallows a patch failure so the denial still surfaces to the model", async () => {
+    restPatch.mockRejectedValueOnce(new Error("message gone"));
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
+    const { values, drain } = startExec(out.make, { name: "x", _reason: "r" });
+    await drain;
+
+    expect(values.at(-1)).toMatch(/timed out/i);
+  });
+
+  it("skips the patch when no messageId was ever stored (synthetic timeout)", async () => {
+    // If the initial post never succeeded, the approval row has no messageId
+    // and there's nothing to converge.
+    restPost.mockRejectedValueOnce(new Error("network down"));
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
+    const { drain } = startExec(out.make, { name: "x", _reason: "r" });
+    await drain;
+
+    expect(restPatch).not.toHaveBeenCalled();
+  });
+
+  it("skips the patch when waitFor returns a synthetic timeout (row vanished)", async () => {
+    // Force waitFor to return the synthetic fallback by stubbing the store:
+    // the row was created + the message posted, but `waitFor` resolves with
+    // a missing-messageId synthetic. `convergeApprovalMessage` must bail.
+    const store = new ApprovalStore(createMemoryRedis());
+    vi.spyOn(store, "waitFor").mockResolvedValueOnce({
+      id: "x",
+      status: "timeout",
+      toolName: "",
+      input: null,
+      reason: "",
+      channelId: "",
+      requesterUserId: "",
+      createdAt: "",
+    });
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
+    const { drain } = startExec(out.make, { name: "x", _reason: "r" });
+    await drain;
+
+    expect(restPatch).not.toHaveBeenCalled();
+  });
+
+  it("swallows a non-Error throw from the patch call", async () => {
+    restPatch.mockRejectedValueOnce("plain-string-reason");
+    const store = new ApprovalStore(createMemoryRedis());
+    const out = wrapApprovalTools({ make: gatedTool() }, { context, store, timeoutMs: 50 });
+    const { values, drain } = startExec(out.make, { name: "x", _reason: "r" });
+    await drain;
+
     expect(values.at(-1)).toMatch(/timed out/i);
   });
 });

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -38,6 +38,16 @@ function runtimeOpts(): Parameters<NonNullable<ReturnType<typeof gatedTool>["exe
   >[1];
 }
 
+function startExec(t: unknown, input: Record<string, unknown>) {
+  const exec = (t as { execute: (input: unknown, opts: unknown) => unknown }).execute;
+  const iter = exec(input, runtimeOpts()) as AsyncIterable<unknown>;
+  const values: unknown[] = [];
+  const drain = (async () => {
+    for await (const v of iter) values.push(v);
+  })();
+  return { values, drain };
+}
+
 describe("wrapApprovalTools — shape", () => {
   it("passes through unmarked tools by identity", () => {
     const plain = tool({
@@ -55,6 +65,28 @@ describe("wrapApprovalTools — shape", () => {
     expect(schema.shape._reason).toBeDefined();
     expect(schema.shape.name).toBeDefined();
   });
+
+  it("makes _reason required when no static reason is configured", () => {
+    const out = wrapApprovalTools({ t: gatedTool() }, { context });
+    const schema = out.t.inputSchema as z.ZodObject<z.ZodRawShape>;
+    expect(schema.safeParse({ name: "x" }).success).toBe(false);
+    expect(schema.safeParse({ name: "x", _reason: "r" }).success).toBe(true);
+  });
+
+  it("makes _reason optional when a static reason is configured", () => {
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({ name: z.string() }),
+        execute: async () => "ok",
+      }),
+      { reason: "default" },
+    );
+    const out = wrapApprovalTools({ t: gated }, { context });
+    const schema = out.t.inputSchema as z.ZodObject<z.ZodRawShape>;
+    expect(schema.safeParse({ name: "x" }).success).toBe(true);
+    expect(schema.safeParse({ name: "x", _reason: "override" }).success).toBe(true);
+  });
 });
 
 describe("wrapApprovalTools — decisions", () => {
@@ -67,16 +99,14 @@ describe("wrapApprovalTools — decisions", () => {
       { context, store, postMessage, timeoutMs: 10_000 },
     );
 
-    const pending = out.make.execute!(
-      { name: "widget", _reason: "needed" },
-      runtimeOpts(),
-    ) as Promise<unknown>;
+    const { values, drain } = startExec(out.make, { name: "widget", _reason: "needed" });
 
     await new Promise((r) => setTimeout(r, 20));
     const id = extractApprovalId(postMessage);
     await store.decide(id, "approved", context.userId);
 
-    expect(await pending).toBe("created widget");
+    await drain;
+    expect(values.at(-1)).toBe("created widget");
   });
 
   it("returns a denial string when the approval is denied", async () => {
@@ -87,16 +117,58 @@ describe("wrapApprovalTools — decisions", () => {
       { make: gatedTool() },
       { context, store, postMessage, timeoutMs: 10_000 },
     );
-    const pending = out.make.execute!(
-      { name: "widget", _reason: "maybe" },
-      runtimeOpts(),
-    ) as Promise<unknown>;
+    const { values, drain } = startExec(out.make, { name: "widget", _reason: "maybe" });
 
     await new Promise((r) => setTimeout(r, 20));
     const id = extractApprovalId(postMessage);
     await store.decide(id, "denied", context.userId);
 
-    expect(await pending).toMatch(/denied permission/);
+    await drain;
+    expect(values.at(-1)).toMatch(/denied permission/);
+  });
+
+  it("returns a timeout string when the approval polling deadline passes", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => ({ id: "msg-t" }));
+
+    const out = wrapApprovalTools(
+      { make: gatedTool() },
+      { context, store, postMessage, timeoutMs: 50 },
+    );
+    const { values, drain } = startExec(out.make, { name: "widget", _reason: "tick" });
+    await drain;
+    expect(values.at(-1)).toMatch(/timed out/i);
+  });
+});
+
+describe("wrapApprovalTools — streaming", () => {
+  it("forwards every value yielded by a streaming original tool", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => ({ id: "msg-s" }));
+    const streamingTool = approval(
+      tool({
+        description: "streaming",
+        inputSchema: z.object({}),
+        async *execute() {
+          yield "a";
+          yield "b";
+          yield "c";
+        },
+      }),
+    );
+
+    const out = wrapApprovalTools(
+      { s: streamingTool },
+      { context, store, postMessage, timeoutMs: 10_000 },
+    );
+    const { values, drain } = startExec(out.s, { _reason: "stream" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+
+    await drain;
+    expect(values).toEqual(["a", "b", "c"]);
   });
 });
 
@@ -116,9 +188,10 @@ describe("wrapApprovalTools — edge cases", () => {
     );
 
     const out = wrapApprovalTools({ t: gated }, { context, store, postMessage });
-    const result = await out.t.execute!({ x: "a", _reason: "r" }, runtimeOpts());
+    const { values, drain } = startExec(out.t, { x: "a", _reason: "r" });
+    await drain;
 
-    expect(result).toMatch(/failed to send/i);
+    expect(values.at(-1)).toMatch(/failed to send/i);
     expect(innerExec).not.toHaveBeenCalled();
   });
 
@@ -135,18 +208,89 @@ describe("wrapApprovalTools — edge cases", () => {
     );
 
     const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
-    const pending = out.t.execute!(
-      { x: "hello", _reason: "because" },
-      runtimeOpts(),
-    ) as Promise<unknown>;
+    const { drain } = startExec(out.t, { x: "hello", _reason: "because" });
 
     await new Promise((r) => setTimeout(r, 20));
     const id = extractApprovalId(postMessage);
     await store.decide(id, "approved", context.userId);
 
-    await pending;
+    await drain;
 
     const [innerInput] = innerExec.mock.calls[0]!;
     expect(innerInput).toEqual({ x: "hello" });
+  });
+
+  it("uses the static reason when the agent omits _reason", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage: PostMessageMock = vi.fn(async () => ({ id: "m" }));
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({}),
+        execute: async () => "ok",
+      }),
+      { reason: "static fallback" },
+    );
+
+    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const { drain } = startExec(out.t, {});
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [, body] = postMessage.mock.calls[0]!;
+    const embed = (body as { embeds: { fields: { name: string; value: string }[] }[] }).embeds[0];
+    const reasonField = embed.fields.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("static fallback");
+
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+
+  it("prefers the agent-supplied _reason over the static reason", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage: PostMessageMock = vi.fn(async () => ({ id: "m" }));
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({}),
+        execute: async () => "ok",
+      }),
+      { reason: "static fallback" },
+    );
+
+    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const { drain } = startExec(out.t, { _reason: "dynamic override" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const [, body] = postMessage.mock.calls[0]!;
+    const embed = (body as { embeds: { fields: { name: string; value: string }[] }[] }).embeds[0];
+    const reasonField = embed.fields.find((f) => f.name === "Reason");
+    expect(reasonField?.value).toBe("dynamic override");
+
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+    await drain;
+  });
+
+  it("passes a TTL derived from timeoutMs to store.create", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const createSpy = vi.spyOn(store, "create");
+    const postMessage = vi.fn(async () => ({ id: "m" }));
+
+    const out = wrapApprovalTools(
+      { t: gatedTool() },
+      { context, store, postMessage, timeoutMs: 120_000 },
+    );
+    const { drain } = startExec(out.t, { name: "x", _reason: "r" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const [, ttlArg] = createSpy.mock.calls[0]!;
+    // 120s timeout + 60s buffer = 180s TTL
+    expect(ttlArg).toBe(180);
+
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+    await drain;
   });
 });

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -1,0 +1,152 @@
+import { tool } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { AgentContext } from "@/lib/ai/context";
+import { createMemoryRedis, messagePacket } from "@/lib/test/fixtures";
+
+import { approval } from "./index.ts";
+import { wrapApprovalTools } from "./runtime.ts";
+import { ApprovalStore } from "./store.ts";
+
+const context = AgentContext.fromPacket(messagePacket("hello"));
+
+function gatedTool() {
+  return approval(
+    tool({
+      description: "Create a thing",
+      inputSchema: z.object({ name: z.string() }),
+      execute: async ({ name }: { name: string }) => `created ${name}`,
+    }),
+  );
+}
+
+type PostMessageMock = ReturnType<
+  typeof vi.fn<(channelId: string, body: unknown) => Promise<{ id: string }>>
+>;
+
+function extractApprovalId(postMessage: PostMessageMock, callIdx = 0): string {
+  const [, body] = postMessage.mock.calls[callIdx]!;
+  const customId = (body as { components: [{ components: [{ custom_id: string }] }] }).components[0]
+    .components[0].custom_id;
+  return customId.split(":")[2]!;
+}
+
+function runtimeOpts(): Parameters<NonNullable<ReturnType<typeof gatedTool>["execute"]>>[1] {
+  return { abortSignal: new AbortController().signal } as Parameters<
+    NonNullable<ReturnType<typeof gatedTool>["execute"]>
+  >[1];
+}
+
+describe("wrapApprovalTools — shape", () => {
+  it("passes through unmarked tools by identity", () => {
+    const plain = tool({
+      description: "plain",
+      inputSchema: z.object({}),
+      execute: async () => "ok",
+    });
+    const out = wrapApprovalTools({ plain }, { context });
+    expect(out.plain).toBe(plain);
+  });
+
+  it("replaces marked tools with a wrapper whose schema includes _reason", () => {
+    const out = wrapApprovalTools({ t: gatedTool() }, { context });
+    const schema = out.t.inputSchema as z.ZodObject<z.ZodRawShape>;
+    expect(schema.shape._reason).toBeDefined();
+    expect(schema.shape.name).toBeDefined();
+  });
+});
+
+describe("wrapApprovalTools — decisions", () => {
+  it("runs the original tool when the approval is marked approved", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => ({ id: "msg-1" }));
+
+    const out = wrapApprovalTools(
+      { make: gatedTool() },
+      { context, store, postMessage, timeoutMs: 10_000 },
+    );
+
+    const pending = out.make.execute!(
+      { name: "widget", _reason: "needed" },
+      runtimeOpts(),
+    ) as Promise<unknown>;
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+
+    expect(await pending).toBe("created widget");
+  });
+
+  it("returns a denial string when the approval is denied", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => ({ id: "msg-2" }));
+
+    const out = wrapApprovalTools(
+      { make: gatedTool() },
+      { context, store, postMessage, timeoutMs: 10_000 },
+    );
+    const pending = out.make.execute!(
+      { name: "widget", _reason: "maybe" },
+      runtimeOpts(),
+    ) as Promise<unknown>;
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "denied", context.userId);
+
+    expect(await pending).toMatch(/denied permission/);
+  });
+});
+
+describe("wrapApprovalTools — edge cases", () => {
+  it("surfaces a message-send failure without running the original tool", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const innerExec = vi.fn(async () => "should-not-run");
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({ x: z.string() }),
+        execute: innerExec,
+      }),
+    );
+
+    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage });
+    const result = await out.t.execute!({ x: "a", _reason: "r" }, runtimeOpts());
+
+    expect(result).toMatch(/failed to send/i);
+    expect(innerExec).not.toHaveBeenCalled();
+  });
+
+  it("strips _reason from the input before invoking the original execute", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    const postMessage = vi.fn(async () => ({ id: "m" }));
+    const innerExec = vi.fn(async (input: { x: string }) => `got ${input.x}`);
+    const gated = approval(
+      tool({
+        description: "t",
+        inputSchema: z.object({ x: z.string() }),
+        execute: innerExec,
+      }),
+    );
+
+    const out = wrapApprovalTools({ t: gated }, { context, store, postMessage, timeoutMs: 10_000 });
+    const pending = out.t.execute!(
+      { x: "hello", _reason: "because" },
+      runtimeOpts(),
+    ) as Promise<unknown>;
+
+    await new Promise((r) => setTimeout(r, 20));
+    const id = extractApprovalId(postMessage);
+    await store.decide(id, "approved", context.userId);
+
+    await pending;
+
+    const [innerInput] = innerExec.mock.calls[0]!;
+    expect(innerInput).toEqual({ x: "hello" });
+  });
+});

--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -30,6 +30,68 @@ export function wrapApprovalTools(tools: ToolSet, opts: WrapApprovalOptions): To
   return out;
 }
 
+function buildWrappedSchema(
+  originalSchema: z.ZodTypeAny | undefined,
+  staticReason: string | undefined,
+): z.ZodTypeAny {
+  const description = staticReason
+    ? "Short explanation of why this tool call is needed. Shown to the user for approval. Optional — falls back to the configured static reason when omitted."
+    : "Short explanation of why this tool call is needed. Shown to the user for approval.";
+  const reasonSchema = staticReason
+    ? z.string().optional().describe(description)
+    : z.string().describe(description);
+
+  if (originalSchema instanceof z.ZodObject) {
+    return originalSchema.extend({ _reason: reasonSchema });
+  }
+  return originalSchema ?? z.object({});
+}
+
+function buildWrappedDescription(
+  originalDescription: string | undefined,
+  staticReason: string | undefined,
+): string {
+  const note = staticReason
+    ? "⚠️ Requires user approval before execution. You may include a concise `_reason`; when omitted, the tool's configured static reason is used."
+    : "⚠️ Requires user approval before execution. You MUST include a concise `_reason` in your arguments explaining why this action is needed.";
+  return `${originalDescription ?? ""}\n\n${note}`;
+}
+
+async function postApprovalMessage(args: {
+  channelId: string;
+  requesterUserId: string;
+  embed: ReturnType<typeof buildApprovalEmbed>;
+  components: ReturnType<typeof buildApprovalComponents>;
+}): Promise<{ id: string }> {
+  const { channelId, requesterUserId, embed, components } = args;
+  return (await discord.post(Routes.channelMessages(channelId), {
+    body: {
+      content: `<@${requesterUserId}>`,
+      embeds: [embed],
+      components,
+      allowed_mentions: { users: [requesterUserId], parse: [] },
+    },
+  })) as { id: string };
+}
+
+async function* runApproved(
+  originalExecute: RuntimeExecuteFn | undefined,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  runtime: unknown,
+): AsyncGenerator<unknown> {
+  if (!originalExecute) {
+    yield `Tool \`${toolName}\` has no execute function; approval succeeded but nothing ran.`;
+    return;
+  }
+  const result = originalExecute(toolInput, runtime);
+  if (isAsyncIterable(result)) {
+    for await (const v of result) yield v;
+    return;
+  }
+  yield await (result as Promise<unknown>);
+}
+
 function wrapWithApproval(
   original: Tool,
   toolName: string,
@@ -39,44 +101,28 @@ function wrapWithApproval(
   const timeoutMs = wrapOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const ttlSeconds = Math.ceil(timeoutMs / 1000) + TTL_BUFFER_SECONDS;
   const staticReason = markerOpts.reason;
-
-  const originalSchema = original.inputSchema as z.ZodTypeAny | undefined;
-  const reasonDescription = staticReason
-    ? "Short explanation of why this tool call is needed. Shown to the user for approval. Optional — falls back to the configured static reason when omitted."
-    : "Short explanation of why this tool call is needed. Shown to the user for approval.";
-  const reasonSchema = staticReason
-    ? z.string().optional().describe(reasonDescription)
-    : z.string().describe(reasonDescription);
-
-  const schemaToUse: z.ZodTypeAny =
-    originalSchema instanceof z.ZodObject
-      ? originalSchema.extend({ _reason: reasonSchema })
-      : (originalSchema ?? z.object({}));
-
+  const schemaToUse = buildWrappedSchema(
+    original.inputSchema as z.ZodTypeAny | undefined,
+    staticReason,
+  );
   const originalExecute = original.execute as RuntimeExecuteFn | undefined;
-  const approvalNote = staticReason
-    ? "⚠️ Requires user approval before execution. You may include a concise `_reason`; when omitted, the tool's configured static reason is used."
-    : "⚠️ Requires user approval before execution. You MUST include a concise `_reason` in your arguments explaining why this action is needed.";
 
   return tool({
-    description: `${original.description ?? ""}\n\n${approvalNote}`,
+    description: buildWrappedDescription(original.description, staticReason),
     inputSchema: schemaToUse,
     execute: async function* (rawInput: unknown, runtime: unknown) {
-      const context = wrapOpts.context;
+      const { context, delegateName } = wrapOpts;
       const channelId = context.channel.id;
       const threadId = context.thread?.id;
       const requesterUserId = context.userId;
-
       const { reason, toolInput } = extractReason(rawInput, staticReason);
 
       const approvalId = crypto.randomUUID();
       const store = wrapOpts.store ?? new ApprovalStore();
-      const postMessage = wrapOpts.postMessage ?? defaultPostMessage;
-
       const state: ApprovalState = {
         id: approvalId,
         status: "pending",
-        delegateName: wrapOpts.delegateName,
+        delegateName,
         toolName,
         input: toolInput,
         reason,
@@ -85,25 +131,20 @@ function wrapWithApproval(
         requesterUserId,
         createdAt: new Date().toISOString(),
       };
-
       await store.create(state, ttlSeconds);
 
-      const targetChannelId = threadId ?? channelId;
-      const embed = buildApprovalEmbed({
-        delegateName: wrapOpts.delegateName,
-        toolName,
-        input: toolInput,
-        reason,
-        timeoutMs,
-      });
-      const components = buildApprovalComponents(approvalId);
-
       try {
-        const msg = await postMessage(targetChannelId, {
-          content: `<@${requesterUserId}>`,
-          embeds: [embed],
-          components,
-          allowed_mentions: { users: [requesterUserId], parse: [] },
+        const msg = await postApprovalMessage({
+          channelId: threadId ?? channelId,
+          requesterUserId,
+          embed: buildApprovalEmbed({
+            delegateName,
+            toolName,
+            input: toolInput,
+            reason,
+            timeoutMs,
+          }),
+          components: buildApprovalComponents(approvalId),
         });
         await store.setMessageId(approvalId, msg.id, ttlSeconds);
       } catch (err: unknown) {
@@ -115,26 +156,11 @@ function wrapWithApproval(
 
       const abortSignal = extractAbortSignal(runtime);
       const final = await store.waitFor(approvalId, { timeoutMs, signal: abortSignal });
-
       if (final.status !== "approved") {
         yield denialMessage(final.status, toolName);
         return;
       }
-
-      if (!originalExecute) {
-        yield `Tool \`${toolName}\` has no execute function; approval succeeded but nothing ran.`;
-        return;
-      }
-
-      // Call the original and forward its output. If it's an async iterable
-      // (streaming tool), yield every intermediate value so the approval
-      // wrapper is transparent to the caller's streaming contract.
-      const result = originalExecute(toolInput, runtime);
-      if (isAsyncIterable(result)) {
-        for await (const v of result) yield v;
-        return;
-      }
-      yield await (result as Promise<unknown>);
+      yield* runApproved(originalExecute, toolName, toolInput, runtime);
     },
   });
 }
@@ -169,19 +195,14 @@ function isAsyncIterable(v: unknown): v is AsyncIterable<unknown> {
   );
 }
 
-function denialMessage(status: ApprovalState["status"], toolName: string): string {
+function denialMessage(
+  status: Exclude<ApprovalState["status"], "approved">,
+  toolName: string,
+): string {
   if (status === "denied") {
     return `The user denied permission to run \`${toolName}\`. Do not retry this tool call.`;
   }
-  if (status === "timeout") {
-    return `The approval request for \`${toolName}\` timed out. Do not retry this tool call.`;
-  }
-  return `The approval for \`${toolName}\` is not approved (status: ${status}). Do not retry.`;
-}
-
-async function defaultPostMessage(
-  channelId: string,
-  body: Record<string, unknown>,
-): Promise<{ id: string }> {
-  return (await discord.post(Routes.channelMessages(channelId), { body })) as { id: string };
+  // status is narrowed to "timeout" — the wrapper only calls this for
+  // terminal non-approved states produced by `waitFor()`.
+  return `The approval request for \`${toolName}\` timed out. Do not retry this tool call.`;
 }

--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -11,6 +11,7 @@ import { getApprovalOptions } from "./index.ts";
 import { ApprovalStore } from "./store.ts";
 
 const DEFAULT_TIMEOUT_MS = 240_000;
+const TTL_BUFFER_SECONDS = 60;
 
 type RuntimeExecuteFn = (input: unknown, runtime: unknown) => unknown;
 
@@ -36,26 +37,31 @@ function wrapWithApproval(
   wrapOpts: WrapApprovalOptions,
 ): Tool {
   const timeoutMs = wrapOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const ttlSeconds = Math.ceil(timeoutMs / 1000) + TTL_BUFFER_SECONDS;
   const staticReason = markerOpts.reason;
 
   const originalSchema = original.inputSchema as z.ZodTypeAny | undefined;
+  const reasonDescription = staticReason
+    ? "Short explanation of why this tool call is needed. Shown to the user for approval. Optional — falls back to the configured static reason when omitted."
+    : "Short explanation of why this tool call is needed. Shown to the user for approval.";
+  const reasonSchema = staticReason
+    ? z.string().optional().describe(reasonDescription)
+    : z.string().describe(reasonDescription);
+
   const schemaToUse: z.ZodTypeAny =
     originalSchema instanceof z.ZodObject
-      ? originalSchema.extend({
-          _reason: z
-            .string()
-            .describe(
-              "Short explanation of why this tool call is needed. Shown to the user for approval.",
-            ),
-        })
+      ? originalSchema.extend({ _reason: reasonSchema })
       : (originalSchema ?? z.object({}));
 
   const originalExecute = original.execute as RuntimeExecuteFn | undefined;
+  const approvalNote = staticReason
+    ? "⚠️ Requires user approval before execution. You may include a concise `_reason`; when omitted, the tool's configured static reason is used."
+    : "⚠️ Requires user approval before execution. You MUST include a concise `_reason` in your arguments explaining why this action is needed.";
 
   return tool({
-    description: `${original.description ?? ""}\n\n⚠️ Requires user approval before execution. You MUST include a concise \`_reason\` in your arguments explaining why this action is needed.`,
+    description: `${original.description ?? ""}\n\n${approvalNote}`,
     inputSchema: schemaToUse,
-    execute: async (rawInput: unknown, runtime: unknown) => {
+    execute: async function* (rawInput: unknown, runtime: unknown) {
       const context = wrapOpts.context;
       const channelId = context.channel.id;
       const threadId = context.thread?.id;
@@ -80,7 +86,7 @@ function wrapWithApproval(
         createdAt: new Date().toISOString(),
       };
 
-      await store.create(state);
+      await store.create(state, ttlSeconds);
 
       const targetChannelId = threadId ?? channelId;
       const embed = buildApprovalEmbed({
@@ -99,17 +105,36 @@ function wrapWithApproval(
           components,
           allowed_mentions: { users: [requesterUserId], parse: [] },
         });
-        await store.setMessageId(approvalId, msg.id);
+        await store.setMessageId(approvalId, msg.id, ttlSeconds);
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : "unknown error";
         log.error("approval", `Failed to send approval prompt: ${errorMessage}`);
-        return `Approval prompt failed to send (${errorMessage}). The tool was NOT run.`;
+        yield `Approval prompt failed to send (${errorMessage}). The tool was NOT run.`;
+        return;
       }
 
       const abortSignal = extractAbortSignal(runtime);
       const final = await store.waitFor(approvalId, { timeoutMs, signal: abortSignal });
 
-      return runFinal({ final, originalExecute, toolInput, runtime, toolName });
+      if (final.status !== "approved") {
+        yield denialMessage(final.status, toolName);
+        return;
+      }
+
+      if (!originalExecute) {
+        yield `Tool \`${toolName}\` has no execute function; approval succeeded but nothing ran.`;
+        return;
+      }
+
+      // Call the original and forward its output. If it's an async iterable
+      // (streaming tool), yield every intermediate value so the approval
+      // wrapper is transparent to the caller's streaming contract.
+      const result = originalExecute(toolInput, runtime);
+      if (isAsyncIterable(result)) {
+        for await (const v of result) yield v;
+        return;
+      }
+      yield await (result as Promise<unknown>);
     },
   });
 }
@@ -134,31 +159,6 @@ function extractAbortSignal(runtime: unknown): AbortSignal | undefined {
   if (!runtime || typeof runtime !== "object") return undefined;
   const sig = (runtime as { abortSignal?: unknown }).abortSignal;
   return sig instanceof AbortSignal ? sig : undefined;
-}
-
-async function runFinal(args: {
-  final: ApprovalState;
-  originalExecute: RuntimeExecuteFn | undefined;
-  toolInput: Record<string, unknown>;
-  runtime: unknown;
-  toolName: string;
-}): Promise<unknown> {
-  const { final, originalExecute, toolInput, runtime, toolName } = args;
-
-  if (final.status === "approved") {
-    if (!originalExecute) {
-      return `Tool \`${toolName}\` has no execute function; approval succeeded but nothing ran.`;
-    }
-    const result = originalExecute(toolInput, runtime);
-    if (isAsyncIterable(result)) {
-      let last: unknown = undefined;
-      for await (const v of result) last = v;
-      return last;
-    }
-    return await (result as Promise<unknown>);
-  }
-
-  return denialMessage(final.status, toolName);
 }
 
 function isAsyncIterable(v: unknown): v is AsyncIterable<unknown> {

--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -1,0 +1,187 @@
+import { tool, type Tool, type ToolSet } from "ai";
+import { Routes } from "discord-api-types/v10";
+import { log } from "evlog";
+import { z } from "zod";
+
+import type { ApprovalState, WrapApprovalOptions } from "./types.ts";
+
+import { discord } from "../tools/discord/client.ts";
+import { buildApprovalComponents, buildApprovalEmbed } from "./helpers.ts";
+import { getApprovalOptions } from "./index.ts";
+import { ApprovalStore } from "./store.ts";
+
+const DEFAULT_TIMEOUT_MS = 240_000;
+
+type RuntimeExecuteFn = (input: unknown, runtime: unknown) => unknown;
+
+/**
+ * Wrap every tool in a ToolSet that carries the approval marker. Unmarked
+ * tools pass through unchanged. Pass `delegateName` from subagent call sites
+ * so the approval prompt renders the full `delegate_<name>.<tool>(...)`
+ * signature; omit it at the orchestrator layer.
+ */
+export function wrapApprovalTools(tools: ToolSet, opts: WrapApprovalOptions): ToolSet {
+  const out: ToolSet = {};
+  for (const [name, t] of Object.entries(tools)) {
+    const markerOpts = getApprovalOptions(t);
+    out[name] = markerOpts ? wrapWithApproval(t as Tool, name, markerOpts, opts) : t;
+  }
+  return out;
+}
+
+function wrapWithApproval(
+  original: Tool,
+  toolName: string,
+  markerOpts: { reason?: string },
+  wrapOpts: WrapApprovalOptions,
+): Tool {
+  const timeoutMs = wrapOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const staticReason = markerOpts.reason;
+
+  const originalSchema = original.inputSchema as z.ZodTypeAny | undefined;
+  const schemaToUse: z.ZodTypeAny =
+    originalSchema instanceof z.ZodObject
+      ? originalSchema.extend({
+          _reason: z
+            .string()
+            .describe(
+              "Short explanation of why this tool call is needed. Shown to the user for approval.",
+            ),
+        })
+      : (originalSchema ?? z.object({}));
+
+  const originalExecute = original.execute as RuntimeExecuteFn | undefined;
+
+  return tool({
+    description: `${original.description ?? ""}\n\n⚠️ Requires user approval before execution. You MUST include a concise \`_reason\` in your arguments explaining why this action is needed.`,
+    inputSchema: schemaToUse,
+    execute: async (rawInput: unknown, runtime: unknown) => {
+      const context = wrapOpts.context;
+      const channelId = context.channel.id;
+      const threadId = context.thread?.id;
+      const requesterUserId = context.userId;
+
+      const { reason, toolInput } = extractReason(rawInput, staticReason);
+
+      const approvalId = crypto.randomUUID();
+      const store = wrapOpts.store ?? new ApprovalStore();
+      const postMessage = wrapOpts.postMessage ?? defaultPostMessage;
+
+      const state: ApprovalState = {
+        id: approvalId,
+        status: "pending",
+        delegateName: wrapOpts.delegateName,
+        toolName,
+        input: toolInput,
+        reason,
+        channelId,
+        threadId,
+        requesterUserId,
+        createdAt: new Date().toISOString(),
+      };
+
+      await store.create(state);
+
+      const targetChannelId = threadId ?? channelId;
+      const embed = buildApprovalEmbed({
+        delegateName: wrapOpts.delegateName,
+        toolName,
+        input: toolInput,
+        reason,
+        timeoutMs,
+      });
+      const components = buildApprovalComponents(approvalId);
+
+      try {
+        const msg = await postMessage(targetChannelId, {
+          content: `<@${requesterUserId}>`,
+          embeds: [embed],
+          components,
+          allowed_mentions: { users: [requesterUserId], parse: [] },
+        });
+        await store.setMessageId(approvalId, msg.id);
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : "unknown error";
+        log.error("approval", `Failed to send approval prompt: ${errorMessage}`);
+        return `Approval prompt failed to send (${errorMessage}). The tool was NOT run.`;
+      }
+
+      const abortSignal = extractAbortSignal(runtime);
+      const final = await store.waitFor(approvalId, { timeoutMs, signal: abortSignal });
+
+      return runFinal({ final, originalExecute, toolInput, runtime, toolName });
+    },
+  });
+}
+
+function extractReason(
+  raw: unknown,
+  staticReason: string | undefined,
+): { reason: string; toolInput: Record<string, unknown> } {
+  if (!raw || typeof raw !== "object") {
+    return { reason: staticReason ?? "(not provided)", toolInput: {} };
+  }
+  const obj = { ...(raw as Record<string, unknown>) };
+  const supplied = typeof obj._reason === "string" ? obj._reason.trim() : "";
+  delete obj._reason;
+  return {
+    reason: supplied || staticReason || "(not provided)",
+    toolInput: obj,
+  };
+}
+
+function extractAbortSignal(runtime: unknown): AbortSignal | undefined {
+  if (!runtime || typeof runtime !== "object") return undefined;
+  const sig = (runtime as { abortSignal?: unknown }).abortSignal;
+  return sig instanceof AbortSignal ? sig : undefined;
+}
+
+async function runFinal(args: {
+  final: ApprovalState;
+  originalExecute: RuntimeExecuteFn | undefined;
+  toolInput: Record<string, unknown>;
+  runtime: unknown;
+  toolName: string;
+}): Promise<unknown> {
+  const { final, originalExecute, toolInput, runtime, toolName } = args;
+
+  if (final.status === "approved") {
+    if (!originalExecute) {
+      return `Tool \`${toolName}\` has no execute function; approval succeeded but nothing ran.`;
+    }
+    const result = originalExecute(toolInput, runtime);
+    if (isAsyncIterable(result)) {
+      let last: unknown = undefined;
+      for await (const v of result) last = v;
+      return last;
+    }
+    return await (result as Promise<unknown>);
+  }
+
+  return denialMessage(final.status, toolName);
+}
+
+function isAsyncIterable(v: unknown): v is AsyncIterable<unknown> {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
+  );
+}
+
+function denialMessage(status: ApprovalState["status"], toolName: string): string {
+  if (status === "denied") {
+    return `The user denied permission to run \`${toolName}\`. Do not retry this tool call.`;
+  }
+  if (status === "timeout") {
+    return `The approval request for \`${toolName}\` timed out. Do not retry this tool call.`;
+  }
+  return `The approval for \`${toolName}\` is not approved (status: ${status}). Do not retry.`;
+}
+
+async function defaultPostMessage(
+  channelId: string,
+  body: Record<string, unknown>,
+): Promise<{ id: string }> {
+  return (await discord.post(Routes.channelMessages(channelId), { body })) as { id: string };
+}

--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import type { ApprovalState, WrapApprovalOptions } from "./types.ts";
 
 import { discord } from "../tools/discord/client.ts";
-import { buildApprovalComponents, buildApprovalEmbed } from "./helpers.ts";
+import { buildApprovalComponents, buildApprovalEmbed, buildDecisionEmbed } from "./helpers.ts";
 import { getApprovalOptions } from "./index.ts";
 import { ApprovalStore } from "./store.ts";
 
@@ -41,10 +41,19 @@ function buildWrappedSchema(
     ? z.string().optional().describe(description)
     : z.string().describe(description);
 
+  if (originalSchema === undefined) {
+    return z.object({ _reason: reasonSchema });
+  }
   if (originalSchema instanceof z.ZodObject) {
     return originalSchema.extend({ _reason: reasonSchema });
   }
-  return originalSchema ?? z.object({});
+  // Silently passing a non-object schema through would mean `_reason` never
+  // lands in the schema and `extractReason` would drop whatever primitive /
+  // array / union input the agent actually sent. Fail fast at wrap time so
+  // the misconfiguration is caught in tests, not at runtime.
+  throw new Error(
+    "approval() can only be applied to tools with a ZodObject inputSchema (or no inputSchema).",
+  );
 }
 
 function buildWrappedDescription(
@@ -72,6 +81,32 @@ async function postApprovalMessage(args: {
       allowed_mentions: { users: [requesterUserId], parse: [] },
     },
   })) as { id: string };
+}
+
+/**
+ * Best-effort swap of the original approval embed for the terminal decision
+ * embed (green / red / grey) and remove the buttons. Called from the wrapper
+ * when the approval resolves to a non-approved status so the channel UI
+ * converges to what's stored — especially the timeout path, which otherwise
+ * leaves the prompt amber with live buttons indefinitely.
+ */
+async function convergeApprovalMessage(state: ApprovalState): Promise<void> {
+  if (!state.messageId || state.status === "pending" || state.status === "approved") return;
+  const channelId = state.threadId ?? state.channelId;
+  try {
+    await discord.patch(Routes.channelMessage(channelId, state.messageId), {
+      body: {
+        embeds: [buildDecisionEmbed(state, state.status, state.decidedByUserId ?? null)],
+        components: [],
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    log.warn(
+      "approval",
+      `Failed to converge approval message ${state.messageId} to ${state.status}: ${message}`,
+    );
+  }
 }
 
 async function* runApproved(
@@ -157,6 +192,7 @@ function wrapWithApproval(
       const abortSignal = extractAbortSignal(runtime);
       const final = await store.waitFor(approvalId, { timeoutMs, signal: abortSignal });
       if (final.status !== "approved") {
+        await convergeApprovalMessage(final);
         yield denialMessage(final.status, toolName);
         return;
       }

--- a/src/lib/ai/approvals/store.test.ts
+++ b/src/lib/ai/approvals/store.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createMemoryRedis } from "@/lib/test/fixtures";
+
+import type { ApprovalState } from "./types.ts";
+
+import { ApprovalStore } from "./store.ts";
+
+function baseState(overrides: Partial<ApprovalState> = {}): ApprovalState {
+  return {
+    id: "a1",
+    status: "pending",
+    toolName: "doit",
+    input: { foo: "bar" },
+    reason: "because",
+    channelId: "ch-1",
+    requesterUserId: "user-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ApprovalStore CRUD", () => {
+  it("create + get round-trips state", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const got = await store.get("a1");
+    expect(got?.toolName).toBe("doit");
+    expect(got?.status).toBe("pending");
+  });
+
+  it("get returns null for missing ids", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    expect(await store.get("nope")).toBeNull();
+  });
+
+  it("setMessageId updates only the messageId", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    await store.setMessageId("a1", "msg-9");
+    const got = await store.get("a1");
+    expect(got?.messageId).toBe("msg-9");
+    expect(got?.toolName).toBe("doit");
+  });
+
+  it("setMessageId is a no-op when the row is missing", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.setMessageId("gone", "msg-9");
+    expect(await store.get("gone")).toBeNull();
+  });
+});
+
+describe("ApprovalStore.decide", () => {
+  it("flips pending → approved and records decidedByUserId", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const out = await store.decide("a1", "approved", "user-1");
+    expect(out?.status).toBe("approved");
+    expect(out?.decidedByUserId).toBe("user-1");
+    expect(out?.decidedAt).toBeTruthy();
+  });
+
+  it("returns null when the row doesn't exist", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    expect(await store.decide("gone", "approved", "user-1")).toBeNull();
+  });
+
+  it("is idempotent — calling twice returns the first decision", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    await store.decide("a1", "approved", "user-1");
+    const second = await store.decide("a1", "denied", "user-2");
+    expect(second?.status).toBe("approved");
+    expect(second?.decidedByUserId).toBe("user-1");
+  });
+});
+
+describe("ApprovalStore.waitFor", () => {
+  it("returns once the status flips", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new ApprovalStore(createMemoryRedis());
+      await store.create(baseState());
+      const pending = store.waitFor("a1", { intervalMs: 10, timeoutMs: 10_000 });
+      await vi.advanceTimersByTimeAsync(10);
+      await store.decide("a1", "approved", "user-1");
+      await vi.advanceTimersByTimeAsync(20);
+      const out = await pending;
+      expect(out.status).toBe("approved");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns timeout and flips the row when the deadline passes", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new ApprovalStore(createMemoryRedis());
+      await store.create(baseState());
+      const pending = store.waitFor("a1", { intervalMs: 10, timeoutMs: 50 });
+      await vi.advanceTimersByTimeAsync(200);
+      const out = await pending;
+      expect(out.status).toBe("timeout");
+      const row = await store.get("a1");
+      expect(row?.status).toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns synthetic timeout if the row vanished mid-wait (TTL)", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    // Don't create any row at all.
+    const out = await store.waitFor("missing", { intervalMs: 10, timeoutMs: 50 });
+    expect(out.status).toBe("timeout");
+  });
+
+  it("rejects when the abort signal fires", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const controller = new AbortController();
+    const pending = store.waitFor("a1", {
+      intervalMs: 20,
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/);
+  });
+});

--- a/src/lib/ai/approvals/store.test.ts
+++ b/src/lib/ai/approvals/store.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { baseApprovalState as baseState, createMemoryRedis } from "@/lib/test/fixtures";
 
+// Mock the third-party Upstash client so `new ApprovalStore()` (no redis
+// arg) has a safe in-memory backend exercising the default-constructor
+// branch `redis ?? Redis.fromEnv()`.
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
+
 import { ApprovalStore } from "./store.ts";
 
 describe("ApprovalStore CRUD", () => {
@@ -41,6 +48,21 @@ describe("ApprovalStore CRUD", () => {
     await store.setMessageId("gone", "msg-9");
     expect(await store.get("gone")).toBeNull();
   });
+
+  it("setMessageId uses the default TTL when ttlSeconds is omitted", async () => {
+    const redis = createMemoryRedis();
+    const store = new ApprovalStore(redis);
+    await store.create(baseState());
+    const setSpy = vi.spyOn(redis, "set");
+    await store.setMessageId("a1", "msg-new");
+    const [, , opts] = setSpy.mock.calls[0]!;
+    expect((opts as { ex?: number }).ex).toBe(300);
+  });
+
+  it("default constructor builds a store backed by Redis.fromEnv", async () => {
+    const store = new ApprovalStore();
+    expect(await store.get("missing")).toBeNull();
+  });
 });
 
 describe("ApprovalStore.decide", () => {
@@ -78,6 +100,21 @@ describe("ApprovalStore.decide", () => {
     expect(["approved", "timeout"]).toContain(a?.status);
     const persisted = await store.get("a1");
     expect(persisted?.status).toBe(a?.status);
+  });
+
+  it("returns the bare primary when a lost-race reader finds no claim row", async () => {
+    // Simulate the pathological race where our caller loses the claim SETNX
+    // but the claim key has vanished (TTL hit / external delete) by the time
+    // we re-read it for merge. `winner ? … : primary` takes the false branch.
+    const redis = createMemoryRedis();
+    const store = new ApprovalStore(redis);
+    await store.create(baseState());
+    // After create, set up spies so only the decide() interior is affected.
+    vi.spyOn(redis, "set").mockResolvedValueOnce(null); // claim SETNX "lost"
+    // First get = primary (returns baseState), second get = claim (missing).
+    vi.spyOn(redis, "get").mockResolvedValueOnce(baseState()).mockResolvedValueOnce(null);
+    const out = await store.decide("a1", "denied", "user-2");
+    expect(out?.status).toBe("pending"); // bare primary returned as-is
   });
 });
 
@@ -120,7 +157,9 @@ describe("ApprovalStore.waitFor", () => {
     const out = await store.waitFor("missing", { intervalMs: 10, timeoutMs: 50 });
     expect(out.status).toBe("timeout");
   });
+});
 
+describe("ApprovalStore.waitFor — abort handling", () => {
   it("rejects when the abort signal fires before the first sleep starts", async () => {
     const store = new ApprovalStore(createMemoryRedis());
     await store.create(baseState());
@@ -163,5 +202,46 @@ describe("ApprovalStore.waitFor", () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow(/aborted/);
+  });
+});
+
+describe("ApprovalStore.waitFor — defaults + deadline", () => {
+  it("uses default timeout + interval when no opts are supplied", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new ApprovalStore(createMemoryRedis());
+      await store.create(baseState());
+      const pending = store.waitFor("a1");
+      await vi.advanceTimersByTimeAsync(100);
+      await store.decide("a1", "approved", "user-1");
+      await vi.advanceTimersByTimeAsync(2000);
+      const out = await pending;
+      expect(out.status).toBe("approved");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns syntheticTimeout when the row is deleted before the deadline flip", async () => {
+    const redis = createMemoryRedis();
+    const store = new ApprovalStore(redis);
+    await store.create(baseState());
+    // Delete the primary row mid-wait so the polling loop catches it missing.
+    // The `if (!state) return this.syntheticTimeout(id)` branch is exercised.
+    await redis.del("approval:a1");
+    const out = await store.waitFor("a1", { intervalMs: 5, timeoutMs: 50 });
+    expect(out.status).toBe("timeout");
+    expect(out.toolName).toBe(""); // synthetic marker
+  });
+
+  it("falls back to syntheticTimeout when the deadline decide() returns null", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    // Force the deadline branch and make the final decide return null — the
+    // `decided ?? syntheticTimeout(id)` fallback in waitFor fires.
+    vi.spyOn(store, "decide").mockResolvedValueOnce(null);
+    const out = await store.waitFor("a1", { intervalMs: 5, timeoutMs: 10 });
+    expect(out.status).toBe("timeout");
+    expect(out.toolName).toBe("");
   });
 });

--- a/src/lib/ai/approvals/store.test.ts
+++ b/src/lib/ai/approvals/store.test.ts
@@ -1,24 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createMemoryRedis } from "@/lib/test/fixtures";
-
-import type { ApprovalState } from "./types.ts";
+import { baseApprovalState as baseState, createMemoryRedis } from "@/lib/test/fixtures";
 
 import { ApprovalStore } from "./store.ts";
-
-function baseState(overrides: Partial<ApprovalState> = {}): ApprovalState {
-  return {
-    id: "a1",
-    status: "pending",
-    toolName: "doit",
-    input: { foo: "bar" },
-    reason: "because",
-    channelId: "ch-1",
-    requesterUserId: "user-1",
-    createdAt: "2024-01-01T00:00:00Z",
-    ...overrides,
-  };
-}
 
 describe("ApprovalStore CRUD", () => {
   it("create + get round-trips state", async () => {
@@ -137,7 +121,7 @@ describe("ApprovalStore.waitFor", () => {
     expect(out.status).toBe("timeout");
   });
 
-  it("rejects when the abort signal fires", async () => {
+  it("rejects when the abort signal fires before the first sleep starts", async () => {
     const store = new ApprovalStore(createMemoryRedis());
     await store.create(baseState());
     const controller = new AbortController();
@@ -148,5 +132,36 @@ describe("ApprovalStore.waitFor", () => {
     });
     controller.abort();
     await expect(pending).rejects.toThrow(/aborted/);
+  });
+
+  it("rejects when the abort signal fires while a sleep is already waiting", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const controller = new AbortController();
+    const pending = store.waitFor("a1", {
+      intervalMs: 60_000,
+      timeoutMs: 120_000,
+      signal: controller.signal,
+    });
+    // Let the first iteration reach `sleep()` before aborting so the listener
+    // path (not the synchronous pre-check) is exercised.
+    await new Promise((r) => setTimeout(r, 30));
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/);
+  });
+
+  it("is a no-op when a pre-aborted signal is supplied to sleep via the inner branch", async () => {
+    // Pre-aborted signal: waitFor's outer check throws first, so sleep is not reached.
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      store.waitFor("a1", {
+        intervalMs: 10,
+        timeoutMs: 10_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
   });
 });

--- a/src/lib/ai/approvals/store.test.ts
+++ b/src/lib/ai/approvals/store.test.ts
@@ -29,6 +29,15 @@ describe("ApprovalStore CRUD", () => {
     expect(got?.status).toBe("pending");
   });
 
+  it("create passes a ttlSeconds override through to Redis", async () => {
+    const redis = createMemoryRedis();
+    const setSpy = vi.spyOn(redis, "set");
+    const store = new ApprovalStore(redis);
+    await store.create(baseState(), 999);
+    const [, , opts] = setSpy.mock.calls[0]!;
+    expect((opts as { ex?: number }).ex).toBe(999);
+  });
+
   it("get returns null for missing ids", async () => {
     const store = new ApprovalStore(createMemoryRedis());
     expect(await store.get("nope")).toBeNull();
@@ -72,6 +81,19 @@ describe("ApprovalStore.decide", () => {
     const second = await store.decide("a1", "denied", "user-2");
     expect(second?.status).toBe("approved");
     expect(second?.decidedByUserId).toBe("user-1");
+  });
+
+  it("serializes concurrent decides — exactly one wins, both see the winner", async () => {
+    const store = new ApprovalStore(createMemoryRedis());
+    await store.create(baseState());
+    const [a, b] = await Promise.all([
+      store.decide("a1", "approved", "user-1"),
+      store.decide("a1", "timeout", null),
+    ]);
+    expect(a?.status).toBe(b?.status);
+    expect(["approved", "timeout"]).toContain(a?.status);
+    const persisted = await store.get("a1");
+    expect(persisted?.status).toBe(a?.status);
   });
 });
 

--- a/src/lib/ai/approvals/store.ts
+++ b/src/lib/ai/approvals/store.ts
@@ -1,0 +1,120 @@
+import { Redis } from "@upstash/redis";
+
+import type { RedisLike } from "@/bot/types";
+
+import type { ApprovalState, ApprovalStoreLike, WaitForOptions } from "./types.ts";
+
+const KEY_PREFIX = "approval:";
+const TTL_SECONDS = 300;
+const DEFAULT_TIMEOUT_MS = 240_000;
+const DEFAULT_INTERVAL_MS = 1500;
+
+/**
+ * Upstash-backed store for pending tool-approval requests. State is TTL'd so
+ * abandoned approvals expire without cleanup. Mirrors the shape of
+ * `ConversationStore` — accepts an injected `RedisLike` so tests can run
+ * against the in-memory fixture.
+ */
+export class ApprovalStore implements ApprovalStoreLike {
+  private redis: RedisLike;
+
+  constructor(redis?: RedisLike) {
+    this.redis = redis ?? Redis.fromEnv();
+  }
+
+  private key(id: string): string {
+    return `${KEY_PREFIX}${id}`;
+  }
+
+  async create(state: ApprovalState): Promise<void> {
+    await this.redis.set(this.key(state.id), state, { ex: TTL_SECONDS });
+  }
+
+  async get(id: string): Promise<ApprovalState | null> {
+    return this.redis.get<ApprovalState>(this.key(id));
+  }
+
+  async setMessageId(id: string, messageId: string): Promise<void> {
+    const state = await this.get(id);
+    if (!state) return;
+    await this.redis.set(this.key(id), { ...state, messageId }, { ex: TTL_SECONDS });
+  }
+
+  /**
+   * Flip a pending approval to a final status. Returns the updated state, or
+   * `null` if the approval no longer exists (TTL expired between creation
+   * and decision). No-op if the approval is already in a non-pending state —
+   * returns the existing row so callers can observe who decided first.
+   */
+  async decide(
+    id: string,
+    status: Exclude<ApprovalState["status"], "pending">,
+    decidedByUserId: string | null,
+  ): Promise<ApprovalState | null> {
+    const state = await this.get(id);
+    if (!state) return null;
+    if (state.status !== "pending") return state;
+    const updated: ApprovalState = {
+      ...state,
+      status,
+      decidedByUserId: decidedByUserId ?? undefined,
+      decidedAt: new Date().toISOString(),
+    };
+    await this.redis.set(this.key(id), updated, { ex: TTL_SECONDS });
+    return updated;
+  }
+
+  /**
+   * Poll for a terminal status up to `timeoutMs`. Resolves to the final state
+   * whether the approval was decided, expired (TTL), or the polling loop hit
+   * its own timeout. Honors `AbortSignal` — rejects with `Error("aborted")`.
+   */
+  async waitFor(id: string, opts: WaitForOptions = {}): Promise<ApprovalState> {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      if (opts.signal?.aborted) throw new Error("aborted");
+      const state = await this.get(id);
+      if (!state) return this.syntheticTimeout(id);
+      if (state.status !== "pending") return state;
+      await sleep(intervalMs, opts.signal);
+    }
+
+    // Polling deadline hit — flip the row so a late click can't still execute.
+    const decided = await this.decide(id, "timeout", null);
+    return decided ?? this.syntheticTimeout(id);
+  }
+
+  private syntheticTimeout(id: string): ApprovalState {
+    return {
+      id,
+      status: "timeout",
+      toolName: "",
+      input: null,
+      reason: "",
+      channelId: "",
+      requesterUserId: "",
+      createdAt: "",
+    };
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/lib/ai/approvals/store.ts
+++ b/src/lib/ai/approvals/store.ts
@@ -5,15 +5,22 @@ import type { RedisLike } from "@/bot/types";
 import type { ApprovalState, ApprovalStoreLike, WaitForOptions } from "./types.ts";
 
 const KEY_PREFIX = "approval:";
-const TTL_SECONDS = 300;
+const CLAIM_SUFFIX = ":claim";
+const DEFAULT_TTL_SECONDS = 300;
 const DEFAULT_TIMEOUT_MS = 240_000;
 const DEFAULT_INTERVAL_MS = 1500;
 
+type DecisionPatch = Pick<ApprovalState, "status" | "decidedByUserId" | "decidedAt">;
+
 /**
  * Upstash-backed store for pending tool-approval requests. State is TTL'd so
- * abandoned approvals expire without cleanup. Mirrors the shape of
- * `ConversationStore` — accepts an injected `RedisLike` so tests can run
- * against the in-memory fixture.
+ * abandoned approvals expire without cleanup.
+ *
+ * Transitions from `pending` are atomic: `decide()` uses a separate claim key
+ * set with `NX` so concurrent calls (e.g. a button click racing `waitFor`'s
+ * timeout path) agree on a single winner. Readers merge the claim into the
+ * primary row in `get()` so the winning decision is visible immediately, even
+ * before the winner has finished writing the primary row back.
  */
 export class ApprovalStore implements ApprovalStoreLike {
   private redis: RedisLike;
@@ -26,41 +33,74 @@ export class ApprovalStore implements ApprovalStoreLike {
     return `${KEY_PREFIX}${id}`;
   }
 
-  async create(state: ApprovalState): Promise<void> {
-    await this.redis.set(this.key(state.id), state, { ex: TTL_SECONDS });
+  private claimKey(id: string): string {
+    return `${KEY_PREFIX}${id}${CLAIM_SUFFIX}`;
+  }
+
+  async create(state: ApprovalState, ttlSeconds: number = DEFAULT_TTL_SECONDS): Promise<void> {
+    await this.redis.set(this.key(state.id), state, { ex: ttlSeconds });
   }
 
   async get(id: string): Promise<ApprovalState | null> {
-    return this.redis.get<ApprovalState>(this.key(id));
+    const [primary, claim] = await Promise.all([
+      this.redis.get<ApprovalState>(this.key(id)),
+      this.redis.get<DecisionPatch>(this.claimKey(id)),
+    ]);
+    if (!primary) return null;
+    if (!claim) return primary;
+    return { ...primary, ...claim };
   }
 
-  async setMessageId(id: string, messageId: string): Promise<void> {
-    const state = await this.get(id);
-    if (!state) return;
-    await this.redis.set(this.key(id), { ...state, messageId }, { ex: TTL_SECONDS });
+  async setMessageId(
+    id: string,
+    messageId: string,
+    ttlSeconds: number = DEFAULT_TTL_SECONDS,
+  ): Promise<void> {
+    const primary = await this.redis.get<ApprovalState>(this.key(id));
+    if (!primary) return;
+    await this.redis.set(this.key(id), { ...primary, messageId }, { ex: ttlSeconds });
   }
 
   /**
-   * Flip a pending approval to a final status. Returns the updated state, or
-   * `null` if the approval no longer exists (TTL expired between creation
-   * and decision). No-op if the approval is already in a non-pending state —
-   * returns the existing row so callers can observe who decided first.
+   * Flip a pending approval to a final status atomically. Returns the updated
+   * state, or `null` if the approval no longer exists (TTL expired between
+   * creation and decision).
+   *
+   * The transition is serialized across concurrent callers via a Redis-level
+   * `SET ... NX` on a separate claim key: the first writer wins, subsequent
+   * writers see the claim, skip the primary write, and return the merged
+   * state reflecting the winner's decision.
    */
   async decide(
     id: string,
     status: Exclude<ApprovalState["status"], "pending">,
     decidedByUserId: string | null,
   ): Promise<ApprovalState | null> {
-    const state = await this.get(id);
-    if (!state) return null;
-    if (state.status !== "pending") return state;
-    const updated: ApprovalState = {
-      ...state,
+    const decidedAt = new Date().toISOString();
+    const patch: DecisionPatch = {
       status,
       decidedByUserId: decidedByUserId ?? undefined,
-      decidedAt: new Date().toISOString(),
+      decidedAt,
     };
-    await this.redis.set(this.key(id), updated, { ex: TTL_SECONDS });
+
+    const claimed = await this.redis.set(this.claimKey(id), patch, {
+      nx: true,
+      ex: DEFAULT_TTL_SECONDS,
+    });
+
+    const primary = await this.redis.get<ApprovalState>(this.key(id));
+    if (!primary) return null;
+
+    if (claimed === null) {
+      // Lost the race — read the winner's claim and return the merged view.
+      const winner = await this.redis.get<DecisionPatch>(this.claimKey(id));
+      return winner ? { ...primary, ...winner } : primary;
+    }
+
+    // Won the race — write the updated primary so readers without the claim
+    // merge logic still see the terminal status.
+    const updated: ApprovalState = { ...primary, ...patch };
+    await this.redis.set(this.key(id), updated, { ex: DEFAULT_TTL_SECONDS });
     return updated;
   }
 

--- a/src/lib/ai/approvals/types.ts
+++ b/src/lib/ai/approvals/types.ts
@@ -53,9 +53,9 @@ export interface WrapApprovalOptions {
  * class can live in a non-types file without creating a cycle.
  */
 export interface ApprovalStoreLike {
-  create(state: ApprovalState): Promise<void>;
+  create(state: ApprovalState, ttlSeconds?: number): Promise<void>;
   get(id: string): Promise<ApprovalState | null>;
-  setMessageId(id: string, messageId: string): Promise<void>;
+  setMessageId(id: string, messageId: string, ttlSeconds?: number): Promise<void>;
   decide(
     id: string,
     status: Exclude<ApprovalState["status"], "pending">,

--- a/src/lib/ai/approvals/types.ts
+++ b/src/lib/ai/approvals/types.ts
@@ -38,14 +38,17 @@ export interface WaitForOptions {
   signal?: AbortSignal;
 }
 
-/** Injection points for `wrapApprovalTools()` — runtime uses the defaults, tests swap them out. */
+/**
+ * Injection points for `wrapApprovalTools()`. The `store` slot exists so tests
+ * can swap in an `ApprovalStore` constructed against the in-memory Redis
+ * fixture — Discord REST is mocked separately via `@discordjs/rest`.
+ */
 export interface WrapApprovalOptions {
   context: AgentContext;
   /** Subagent domain name (e.g. "github"). Omit for top-level orchestrator tools. */
   delegateName?: string;
   timeoutMs?: number;
   store?: ApprovalStoreLike;
-  postMessage?: (channelId: string, body: Record<string, unknown>) => Promise<{ id: string }>;
 }
 
 /**

--- a/src/lib/ai/approvals/types.ts
+++ b/src/lib/ai/approvals/types.ts
@@ -1,0 +1,74 @@
+import type { AgentContext } from "../context.ts";
+
+/** Options bound to a tool via the `approval()` marker. */
+export interface ApprovalOptions {
+  /**
+   * Optional static reason shown in the approval prompt when the agent does
+   * not supply one via `_reason`. Leave undefined to require the agent to
+   * always justify each call at runtime.
+   */
+  reason?: string;
+}
+
+/**
+ * Persisted approval state. Written by the wrapper, polled by the wrapper's
+ * wait loop, and flipped by the Discord component handler. The status union
+ * is inline so no exported string-union type escapes this module.
+ */
+export interface ApprovalState {
+  id: string;
+  status: "pending" | "approved" | "denied" | "timeout";
+  delegateName?: string;
+  toolName: string;
+  input: unknown;
+  reason: string;
+  channelId: string;
+  threadId?: string;
+  messageId?: string;
+  requesterUserId: string;
+  decidedByUserId?: string;
+  createdAt: string;
+  decidedAt?: string;
+}
+
+/** Knobs for `ApprovalStore.waitFor()`. */
+export interface WaitForOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+}
+
+/** Injection points for `wrapApprovalTools()` — runtime uses the defaults, tests swap them out. */
+export interface WrapApprovalOptions {
+  context: AgentContext;
+  /** Subagent domain name (e.g. "github"). Omit for top-level orchestrator tools. */
+  delegateName?: string;
+  timeoutMs?: number;
+  store?: ApprovalStoreLike;
+  postMessage?: (channelId: string, body: Record<string, unknown>) => Promise<{ id: string }>;
+}
+
+/**
+ * Minimal surface `wrapApprovalTools` needs from the store, so the concrete
+ * class can live in a non-types file without creating a cycle.
+ */
+export interface ApprovalStoreLike {
+  create(state: ApprovalState): Promise<void>;
+  get(id: string): Promise<ApprovalState | null>;
+  setMessageId(id: string, messageId: string): Promise<void>;
+  decide(
+    id: string,
+    status: Exclude<ApprovalState["status"], "pending">,
+    decidedByUserId: string | null,
+  ): Promise<ApprovalState | null>;
+  waitFor(id: string, opts?: WaitForOptions): Promise<ApprovalState>;
+}
+
+/** Arguments for `buildApprovalEmbed`. */
+export interface BuildApprovalEmbedArgs {
+  delegateName?: string;
+  toolName: string;
+  input: unknown;
+  reason: string;
+  timeoutMs: number;
+}

--- a/src/lib/ai/delegates.test.ts
+++ b/src/lib/ai/delegates.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { UserRole } from "@/lib/ai/constants";
+import { AgentContext } from "@/lib/ai/context";
 import { TurnUsageTracker } from "@/lib/ai/turn-usage";
+import { DISCORD_IDS } from "@/lib/protocol/constants";
+import { messagePacket } from "@/lib/test/fixtures";
+
+function contextFor(role: UserRole): AgentContext {
+  const memberRoles =
+    role === UserRole.Admin
+      ? [DISCORD_IDS.roles.ADMIN]
+      : role === UserRole.Organizer
+        ? [DISCORD_IDS.roles.ORGANIZER]
+        : [];
+  return AgentContext.fromPacket(messagePacket("hello", { memberRoles }));
+}
 
 // Mock the generated manifest so tests aren't coupled to the real skill set.
 vi.mock("@/lib/ai/skills/generated/manifest", () => ({
@@ -97,10 +110,10 @@ vi.mock("@/lib/ai/tools/shopping", () => ({}));
 
 // Stub createDelegationTool so we can see what spec each domain was passed.
 vi.mock("@/lib/ai/subagent", () => ({
-  createDelegationTool: vi.fn((spec: unknown, role: unknown, _metrics: unknown) => ({
+  createDelegationTool: vi.fn((spec: unknown, context: unknown, _metrics: unknown) => ({
     __marker: "delegation-tool",
     spec,
-    role,
+    context,
   })),
 }));
 
@@ -111,14 +124,14 @@ const createDelegationToolMock = vi.mocked(createDelegationTool);
 describe("buildDelegationTools", () => {
   it("returns an empty set for public users (all delegate skills are gated above public)", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Public, new TurnUsageTracker());
+    const tools = buildDelegationTools(contextFor(UserRole.Public), new TurnUsageTracker());
     expect(tools).toEqual({});
     expect(createDelegationToolMock).not.toHaveBeenCalled();
   });
 
   it("exposes only organizer-accessible delegate skills to organizers", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Organizer, new TurnUsageTracker());
+    const tools = buildDelegationTools(contextFor(UserRole.Organizer), new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_finance",
@@ -130,7 +143,7 @@ describe("buildDelegationTools", () => {
 
   it("exposes every delegate skill to admins", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
+    const tools = buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_finance",
@@ -143,23 +156,23 @@ describe("buildDelegationTools", () => {
 
   it("skips inline-mode skills even when the role qualifies", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
+    const tools = buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
     expect(tools).not.toHaveProperty("delegate_discord");
   });
 
   it("passes the skill description and instructions through to createDelegationTool", () => {
     createDelegationToolMock.mockClear();
-    buildDelegationTools(UserRole.Admin, new TurnUsageTracker());
+    buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
 
     const linearCall = createDelegationToolMock.mock.calls.find(
       ([spec]) => (spec as { description: string }).description === "Linear delegate",
     );
     expect(linearCall).toBeDefined();
-    const [spec, role] = linearCall!;
+    const [spec, context] = linearCall!;
     expect((spec as { systemPrompt: string }).systemPrompt).toBe("Linear instructions.");
     expect((spec as { baseToolNames: readonly string[] }).baseToolNames).toContain(
       "search_entities",
     );
-    expect(role).toBe(UserRole.Admin);
+    expect((context as AgentContext).role).toBe(UserRole.Admin);
   });
 });

--- a/src/lib/ai/delegates.test.ts
+++ b/src/lib/ai/delegates.test.ts
@@ -3,18 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { UserRole } from "@/lib/ai/constants";
 import { AgentContext } from "@/lib/ai/context";
 import { TurnUsageTracker } from "@/lib/ai/turn-usage";
-import { DISCORD_IDS } from "@/lib/protocol/constants";
-import { messagePacket } from "@/lib/test/fixtures";
-
-function contextFor(role: UserRole): AgentContext {
-  const memberRoles =
-    role === UserRole.Admin
-      ? [DISCORD_IDS.roles.ADMIN]
-      : role === UserRole.Organizer
-        ? [DISCORD_IDS.roles.ORGANIZER]
-        : [];
-  return AgentContext.fromPacket(messagePacket("hello", { memberRoles }));
-}
+import { contextForRole } from "@/lib/test/fixtures";
 
 // Mock the generated manifest so tests aren't coupled to the real skill set.
 vi.mock("@/lib/ai/skills/generated/manifest", () => ({
@@ -124,14 +113,14 @@ const createDelegationToolMock = vi.mocked(createDelegationTool);
 describe("buildDelegationTools", () => {
   it("returns an empty set for public users (all delegate skills are gated above public)", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(contextFor(UserRole.Public), new TurnUsageTracker());
+    const tools = buildDelegationTools(contextForRole(UserRole.Public), new TurnUsageTracker());
     expect(tools).toEqual({});
     expect(createDelegationToolMock).not.toHaveBeenCalled();
   });
 
   it("exposes only organizer-accessible delegate skills to organizers", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(contextFor(UserRole.Organizer), new TurnUsageTracker());
+    const tools = buildDelegationTools(contextForRole(UserRole.Organizer), new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_finance",
@@ -143,7 +132,7 @@ describe("buildDelegationTools", () => {
 
   it("exposes every delegate skill to admins", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
+    const tools = buildDelegationTools(contextForRole(UserRole.Admin), new TurnUsageTracker());
     expect(Object.keys(tools).sort()).toEqual([
       "delegate_figma",
       "delegate_finance",
@@ -156,13 +145,13 @@ describe("buildDelegationTools", () => {
 
   it("skips inline-mode skills even when the role qualifies", () => {
     createDelegationToolMock.mockClear();
-    const tools = buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
+    const tools = buildDelegationTools(contextForRole(UserRole.Admin), new TurnUsageTracker());
     expect(tools).not.toHaveProperty("delegate_discord");
   });
 
   it("passes the skill description and instructions through to createDelegationTool", () => {
     createDelegationToolMock.mockClear();
-    buildDelegationTools(contextFor(UserRole.Admin), new TurnUsageTracker());
+    buildDelegationTools(contextForRole(UserRole.Admin), new TurnUsageTracker());
 
     const linearCall = createDelegationToolMock.mock.calls.find(
       ([spec]) => (spec as { description: string }).description === "Linear delegate",

--- a/src/lib/ai/delegates.ts
+++ b/src/lib/ai/delegates.ts
@@ -1,6 +1,6 @@
 import type { ToolSet } from "ai";
 
-import type { UserRole } from "./constants.ts";
+import type { AgentContext } from "./context.ts";
 import type { TurnUsageTracker } from "./turn-usage.ts";
 
 import { SKILL_MANIFEST as DISCORD_SUBSKILLS } from "./skills/generated/domains/discord.ts";
@@ -101,10 +101,10 @@ const DOMAINS = {
 const registry = new SkillRegistry(SKILL_MANIFEST);
 
 /** Build delegation tools for every delegate-mode skill the role can access. */
-export function buildDelegationTools(role: UserRole, tracker: TurnUsageTracker): ToolSet {
+export function buildDelegationTools(context: AgentContext, tracker: TurnUsageTracker): ToolSet {
   const tools: ToolSet = {};
   for (const [name, config] of Object.entries(DOMAINS)) {
-    const skill = registry.loadSkill(name, role);
+    const skill = registry.loadSkill(name, context.role);
     if (!skill || skill.mode !== "delegate") continue;
     tools[DELEGATE_PREFIX + name] = createDelegationTool(
       {
@@ -113,7 +113,7 @@ export function buildDelegationTools(role: UserRole, tracker: TurnUsageTracker):
         systemPrompt: skill.instructions,
         ...config,
       },
-      role,
+      context,
       tracker,
     );
   }

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -2,6 +2,7 @@ import { ToolLoopAgent, type ToolSet } from "ai";
 
 import type { TurnUsageTracker } from "./turn-usage.ts";
 
+import { wrapApprovalTools } from "./approvals/index.ts";
 import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
 import { AgentContext } from "./context.ts";
 import { buildDelegationTools } from "./delegates.ts";
@@ -20,15 +21,16 @@ export { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
  * scheduler's `memberRoles` for propagation into persisted task meta.
  */
 export function getOrchestratorTools(context: AgentContext, tracker: TurnUsageTracker): ToolSet {
-  return {
+  const tools: ToolSet = {
     currentTime,
     documentation,
     resolve_organizer,
     scheduleTask: createScheduleTask(context),
     listScheduledTasks,
     cancelTask,
-    ...buildDelegationTools(context.role, tracker),
+    ...buildDelegationTools(context, tracker),
   };
+  return wrapApprovalTools(tools, { context });
 }
 
 export function createOrchestrator(context: AgentContext, tracker: TurnUsageTracker) {

--- a/src/lib/ai/skills/index.ts
+++ b/src/lib/ai/skills/index.ts
@@ -2,4 +2,4 @@ export { SkillRegistry } from "./registry.ts";
 export { createLoadSkillTool } from "./loader.ts";
 export { computeActiveTools } from "./runtime.ts";
 export { admin, filterAdmin } from "./admin.ts";
-export type { SkillMeta, SkillBundle } from "./types.ts";
+export type { SkillBundle, SkillMeta } from "./types.ts";

--- a/src/lib/ai/subagent.test.ts
+++ b/src/lib/ai/subagent.test.ts
@@ -4,11 +4,9 @@ import type { MockLanguageModelV3 } from "ai/test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { UserRole } from "@/lib/ai/constants";
-import { AgentContext } from "@/lib/ai/context";
-import { DISCORD_IDS } from "@/lib/protocol/constants";
 import {
+  contextForRole,
   installMockProvider,
-  messagePacket,
   noopTool,
   streamingTextModel,
   TEST_SKILLS,
@@ -31,24 +29,22 @@ const baseSpec = {
   baseToolNames: ["search_entities", "retrieve_entities"] as const,
 };
 
-function contextFor(role: UserRole): AgentContext {
-  const memberRoles =
-    role === UserRole.Admin
-      ? [DISCORD_IDS.roles.ADMIN]
-      : role === UserRole.Organizer
-        ? [DISCORD_IDS.roles.ORGANIZER]
-        : [];
-  return AgentContext.fromPacket(messagePacket("hello", { memberRoles }));
-}
-
 describe("createDelegationTool — tool shape", () => {
   it("returns a tool with the spec description", () => {
-    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
+    const t = createDelegationTool(
+      baseSpec,
+      contextForRole(UserRole.Admin),
+      new TurnUsageTracker(),
+    );
     expect(t.description).toBe("Test delegation");
   });
 
   it("validates the task input schema", () => {
-    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
+    const t = createDelegationTool(
+      baseSpec,
+      contextForRole(UserRole.Admin),
+      new TurnUsageTracker(),
+    );
     const schema = t.inputSchema as unknown as {
       safeParse: (input: unknown) => { success: boolean };
     };
@@ -71,7 +67,7 @@ describe("createDelegationTool — execute() against MockLanguageModelV3", () =>
   });
 
   async function drain(spec: typeof baseSpec, role: UserRole) {
-    const t = createDelegationTool(spec, contextFor(role), new TurnUsageTracker());
+    const t = createDelegationTool(spec, contextForRole(role), new TurnUsageTracker());
     const received: UIMessage[] = [];
     const gen = t.execute!(
       { task: "do the thing" },
@@ -139,7 +135,11 @@ describe("createDelegationTool — toModelOutput()", () => {
   }
 
   it("extracts the last text part from the final UIMessage", () => {
-    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
+    const t = createDelegationTool(
+      baseSpec,
+      contextForRole(UserRole.Admin),
+      new TurnUsageTracker(),
+    );
     const output = uiMessage([
       { type: "text", text: "first" },
       { type: "tool-call" },
@@ -151,7 +151,11 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back to a completion message when no text parts exist", () => {
-    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
+    const t = createDelegationTool(
+      baseSpec,
+      contextForRole(UserRole.Admin),
+      new TurnUsageTracker(),
+    );
     const output = uiMessage([{ type: "tool-call" }]);
     expect(
       t.toModelOutput!({ output } as Parameters<NonNullable<typeof t.toModelOutput>>[0]),
@@ -159,7 +163,11 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back when output is undefined", () => {
-    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
+    const t = createDelegationTool(
+      baseSpec,
+      contextForRole(UserRole.Admin),
+      new TurnUsageTracker(),
+    );
     expect(
       t.toModelOutput!({ output: undefined } as unknown as Parameters<
         NonNullable<typeof t.toModelOutput>

--- a/src/lib/ai/subagent.test.ts
+++ b/src/lib/ai/subagent.test.ts
@@ -4,8 +4,11 @@ import type { MockLanguageModelV3 } from "ai/test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { UserRole } from "@/lib/ai/constants";
+import { AgentContext } from "@/lib/ai/context";
+import { DISCORD_IDS } from "@/lib/protocol/constants";
 import {
   installMockProvider,
+  messagePacket,
   noopTool,
   streamingTextModel,
   TEST_SKILLS,
@@ -28,14 +31,24 @@ const baseSpec = {
   baseToolNames: ["search_entities", "retrieve_entities"] as const,
 };
 
+function contextFor(role: UserRole): AgentContext {
+  const memberRoles =
+    role === UserRole.Admin
+      ? [DISCORD_IDS.roles.ADMIN]
+      : role === UserRole.Organizer
+        ? [DISCORD_IDS.roles.ORGANIZER]
+        : [];
+  return AgentContext.fromPacket(messagePacket("hello", { memberRoles }));
+}
+
 describe("createDelegationTool — tool shape", () => {
   it("returns a tool with the spec description", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
+    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
     expect(t.description).toBe("Test delegation");
   });
 
   it("validates the task input schema", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
+    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
     const schema = t.inputSchema as unknown as {
       safeParse: (input: unknown) => { success: boolean };
     };
@@ -58,7 +71,7 @@ describe("createDelegationTool — execute() against MockLanguageModelV3", () =>
   });
 
   async function drain(spec: typeof baseSpec, role: UserRole) {
-    const t = createDelegationTool(spec, role, new TurnUsageTracker());
+    const t = createDelegationTool(spec, contextFor(role), new TurnUsageTracker());
     const received: UIMessage[] = [];
     const gen = t.execute!(
       { task: "do the thing" },
@@ -126,7 +139,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   }
 
   it("extracts the last text part from the final UIMessage", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
+    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
     const output = uiMessage([
       { type: "text", text: "first" },
       { type: "tool-call" },
@@ -138,7 +151,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back to a completion message when no text parts exist", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
+    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
     const output = uiMessage([{ type: "tool-call" }]);
     expect(
       t.toModelOutput!({ output } as Parameters<NonNullable<typeof t.toModelOutput>>[0]),
@@ -146,7 +159,7 @@ describe("createDelegationTool — toModelOutput()", () => {
   });
 
   it("falls back when output is undefined", () => {
-    const t = createDelegationTool(baseSpec, UserRole.Admin, new TurnUsageTracker());
+    const t = createDelegationTool(baseSpec, contextFor(UserRole.Admin), new TurnUsageTracker());
     expect(
       t.toModelOutput!({ output: undefined } as unknown as Parameters<
         NonNullable<typeof t.toModelOutput>

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -11,8 +11,10 @@ import { z } from "zod";
 
 import { countMetric, recordDistribution } from "@/lib/metrics";
 
+import type { AgentContext } from "./context.ts";
 import type { SubagentSpec } from "./types.ts";
 
+import { wrapApprovalTools } from "./approvals/index.ts";
 import { SUBAGENT_MODEL, SUBAGENT_PREAMBLE, UserRole } from "./constants.ts";
 import {
   SkillRegistry,
@@ -39,9 +41,10 @@ export type { SubagentSpec } from "./types.ts";
  */
 export function createDelegationTool(
   spec: SubagentSpec,
-  role: UserRole,
+  context: AgentContext,
   tracker: TurnUsageTracker,
 ) {
+  const role = context.role;
   return tool({
     description: spec.description,
     inputSchema: z.object({
@@ -56,7 +59,11 @@ export function createDelegationTool(
       )}`;
 
       const allTools: ToolSet = { ...spec.tools, loadSkill };
-      const tools = role === UserRole.Admin ? allTools : filterAdmin(allTools);
+      const roleFiltered = role === UserRole.Admin ? allTools : filterAdmin(allTools);
+      const tools = wrapApprovalTools(roleFiltered, {
+        context,
+        delegateName: spec.name,
+      });
 
       const baseToolNames = [...spec.baseToolNames, "loadSkill"];
       type ToolKey = keyof typeof tools;

--- a/src/lib/test/fixtures/ai.ts
+++ b/src/lib/test/fixtures/ai.ts
@@ -4,6 +4,28 @@ import { tool } from "ai";
 import { MockLanguageModelV3, MockProviderV3, simulateReadableStream } from "ai/test";
 import { z } from "zod";
 
+import { UserRole } from "@/lib/ai/constants";
+import { AgentContext } from "@/lib/ai/context";
+import { DISCORD_IDS } from "@/lib/protocol/constants";
+
+import { messagePacket } from "./packets";
+
+/**
+ * Build an `AgentContext` whose `role` resolves to the requested tier by
+ * populating `memberRoles` with the matching Discord role ID. Consolidates
+ * the duplicate helpers that delegate/subagent/schedule tests used to
+ * hand-roll.
+ */
+export function contextForRole(role: UserRole): AgentContext {
+  const memberRoles =
+    role === UserRole.Admin
+      ? [DISCORD_IDS.roles.ADMIN]
+      : role === UserRole.Organizer
+        ? [DISCORD_IDS.roles.ORGANIZER]
+        : [];
+  return AgentContext.fromPacket(messagePacket("hello", { memberRoles }));
+}
+
 /** No-op AI SDK tool that returns its name when invoked. */
 export function noopTool(name: string) {
   return tool({

--- a/src/lib/test/fixtures/approvals.ts
+++ b/src/lib/test/fixtures/approvals.ts
@@ -1,0 +1,36 @@
+import type { ApprovalState } from "@/lib/ai/approvals";
+import type { DiscordInteraction } from "@/lib/protocol/types";
+
+import { InteractionType } from "@/lib/protocol/constants";
+
+/** Build an `ApprovalState` with sensible defaults for store / handler tests. */
+export function baseApprovalState(overrides: Partial<ApprovalState> = {}): ApprovalState {
+  return {
+    id: "a1",
+    status: "pending",
+    toolName: "doit",
+    input: { foo: "bar" },
+    reason: "because",
+    channelId: "ch-1",
+    messageId: "msg-5",
+    requesterUserId: "user-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/** Build a minimal `MessageComponent` button-click interaction for handler tests. */
+export function buttonInteraction(customId: string, clickerId: string): DiscordInteraction {
+  return {
+    id: "i-1",
+    application_id: "app-1",
+    type: InteractionType.MessageComponent,
+    token: "tok-1",
+    version: 1,
+    member: {
+      user: { id: clickerId, username: "alice" },
+      roles: [],
+    },
+    data: { custom_id: customId, component_type: 2 },
+  };
+}

--- a/src/lib/test/fixtures/discord.ts
+++ b/src/lib/test/fixtures/discord.ts
@@ -8,19 +8,21 @@ function fakeMessage(id: string, content: string): DiscordMessage {
   return { id, content, channel_id: "ch-test" } as DiscordMessage;
 }
 
+type MessageBody = { content?: string; [key: string]: unknown };
+
 export function createMockAPI(): MockDiscord {
   const calls: MockCall[] = [];
   let counter = 0;
 
   return {
     channels: {
-      createMessage: async (channelId: string, body: { content: string }) => {
+      createMessage: async (channelId: string, body: MessageBody) => {
         calls.push({ method: "channels.createMessage", args: [channelId, body] });
-        return fakeMessage(`msg-${++counter}`, body.content);
+        return fakeMessage(`msg-${++counter}`, body.content ?? "");
       },
-      editMessage: async (channelId: string, msgId: string, body: { content: string }) => {
+      editMessage: async (channelId: string, msgId: string, body: MessageBody) => {
         calls.push({ method: "channels.editMessage", args: [channelId, msgId, body] });
-        return fakeMessage(msgId, body.content);
+        return fakeMessage(msgId, body.content ?? "");
       },
       getMessage: async (channelId: string, msgId: string) => {
         calls.push({ method: "channels.getMessage", args: [channelId, msgId] });
@@ -77,9 +79,13 @@ export function createMockAPI(): MockDiscord {
       },
     },
     interactions: {
-      editReply: async (appId: string, token: string, body: { content: string }) => {
+      editReply: async (appId: string, token: string, body: MessageBody) => {
         calls.push({ method: "interactions.editReply", args: [appId, token, body] });
-        return fakeMessage("msg-interaction", body.content);
+        return fakeMessage("msg-interaction", body.content ?? "");
+      },
+      followUp: async (appId: string, token: string, body: MessageBody) => {
+        calls.push({ method: "interactions.followUp", args: [appId, token, body] });
+        return fakeMessage(`followup-${++counter}`, body.content ?? "");
       },
     },
     _calls: calls,

--- a/src/lib/test/fixtures/index.ts
+++ b/src/lib/test/fixtures/index.ts
@@ -1,3 +1,4 @@
+export { baseApprovalState, buttonInteraction } from "./approvals";
 export { createMemoryRedis, memoryStore } from "./redis";
 export {
   messagePacket,
@@ -13,6 +14,7 @@ export { createMockAPI, asAPI } from "./discord";
 export { toolOpts } from "../constants";
 export { TEST_SKILLS } from "./constants";
 export {
+  contextForRole,
   noopTool,
   streamingTextModel,
   installMockProvider,


### PR DESCRIPTION
## Summary

Mirrors the existing `admin()` marker pattern. `approval(tool)` tags a tool; at call time the wrapper extends the input schema with a required `_reason`, posts an amber Discord embed with Approve / Deny buttons pinging the requester, polls Upstash Redis for the decision (4 min timeout), then either runs the original `execute` or returns a denial string to the model. Works at both orchestrator and subagent layers (`delegate_<name>.<tool>(...)` vs bare `<tool>(...)`); only the original requester can decide. Files are namespaced under `src/lib/ai/approvals/`.

## Test plan

- [x] `bun format`, `bun lint`, `bun typecheck`, `bun run test` (529 passed), `bun test:coverage` (97% lines), `bun knip` — all green
- [ ] Manually mark a low-risk tool with `approval()` and confirm the Discord embed renders, approve/deny/timeout paths all work, and the message edits to a green/red decision embed after the click

🤖 Generated with [Claude Code](https://claude.com/claude-code)