### PR TITLE
fix(sandbox): use dnf for Amazon Linux toolchain install

### DIFF
--- a/scripts/create-sandbox-snapshot.ts
+++ b/scripts/create-sandbox-snapshot.ts
@@ -13,12 +13,9 @@
 
 import { Sandbox } from "@vercel/sandbox";
 
-const TOOLCHAIN_SCRIPT = [
-  "set -e",
-  "apt-get update",
-  "apt-get install -y ripgrep",
-  "type -p gh >/dev/null || (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg status=none && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' > /etc/apt/sources.list.d/github-cli.list && apt-get update && apt-get install -y gh)",
-].join(" && ");
+// Vercel Sandbox `node24` runtime runs on Amazon Linux 2023 — dnf, not apt —
+// and system commands need sudo since the default shell is non-root.
+const TOOLCHAIN_SCRIPT = ["set -e", "sudo dnf install -y --skip-broken ripgrep gh"].join(" && ");
 
 async function main() {
   console.log("Creating temporary sandbox for snapshot build…");

--- a/src/env.ts
+++ b/src/env.ts
@@ -46,7 +46,7 @@ export const env = createEnv({
     RESEND_WEBHOOK_SECRET: z.string(),
     HUNTER_API_KEY: z.string(),
     // Genuinely optional: when set, sandbox sessions boot from this prebuilt
-    // snapshot (ripgrep + gh preinstalled) and skip ~20-30s of apt-get. The
+    // snapshot (ripgrep + gh preinstalled) and skip ~20-30s of dnf install. The
     // app runs fine without it. Create one via scripts/create-sandbox-snapshot.ts.
     SANDBOX_BASE_SNAPSHOT_ID: z.string().optional(),
   },

--- a/src/lib/sandbox/hooks.test.ts
+++ b/src/lib/sandbox/hooks.test.ts
@@ -61,7 +61,7 @@ describe("buildSandboxHooks — afterStart ordering", () => {
     const hooks = buildSandboxHooks({ ...BASE_CONFIG, hasBaseSnapshot: false });
     await hooks.afterStart!(sandbox);
 
-    const first = invocations.findIndex((c) => c.includes("apt-get install"));
+    const first = invocations.findIndex((c) => c.includes("dnf install"));
     const userName = invocations.findIndex((c) => c.includes("git config --global user.name"));
     const clone = invocations.findIndex((c) => c.includes("git clone"));
     const branch = invocations.findIndex((c) => c.includes("git checkout -b"));
@@ -77,7 +77,7 @@ describe("buildSandboxHooks — afterStart ordering", () => {
     const hooks = buildSandboxHooks({ ...BASE_CONFIG, hasBaseSnapshot: true });
     await hooks.afterStart!(sandbox);
 
-    expect(invocations.some((c) => c.includes("apt-get install"))).toBe(false);
+    expect(invocations.some((c) => c.includes("dnf install"))).toBe(false);
     // Still configures git, clones, and branches.
     expect(invocations.some((c) => c.includes("git config --global user.name"))).toBe(true);
     expect(invocations.some((c) => c.includes("git clone"))).toBe(true);

--- a/src/lib/sandbox/hooks.ts
+++ b/src/lib/sandbox/hooks.ts
@@ -40,14 +40,12 @@ async function run(sandbox: Sandbox, command: string, label: string): Promise<vo
 }
 
 async function installToolchain(sandbox: Sandbox): Promise<void> {
-  // node24 base image already has git + curl. Install ripgrep (used by grep
-  // tool) and gh. bun is assumed preinstalled on the Vercel sandbox image.
-  const script = [
-    "set -e",
-    "apt-get update",
-    "apt-get install -y ripgrep",
-    "type -p gh >/dev/null || (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg status=none && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' > /etc/apt/sources.list.d/github-cli.list && apt-get update && apt-get install -y gh)",
-  ].join(" && ");
+  // Vercel Sandbox `node24` runtime runs on Amazon Linux 2023 — package
+  // manager is dnf, and sandbox commands run as a non-root user so system
+  // installs need sudo. node, git, curl, and bun are already on the image;
+  // we only pull in ripgrep (grep tool) and gh (used as a fallback by the
+  // post-finish PR step if the octokit path isn't taken).
+  const script = ["set -e", "sudo dnf install -y --skip-broken ripgrep gh"].join(" && ");
   await run(sandbox, script, "toolchain install");
 }
 

--- a/src/lib/sandbox/types.ts
+++ b/src/lib/sandbox/types.ts
@@ -152,7 +152,7 @@ export interface SandboxHooksConfig {
   baseBranch?: string;
   branch: string;
   gitUser: { name: string; email: string };
-  /** When true, skip apt-get install (the snapshot already has tools). */
+  /** When true, skip dnf install (the snapshot already has tools). */
   hasBaseSnapshot: boolean;
   /** When true, skip `git clone` + branch creation (resume from hibernation). */
   skipCloneAndBranch?: boolean;


### PR DESCRIPTION
## Summary
- Vercel Sandbox `node24` runtime runs Amazon Linux 2023, not Debian — `apt-get` doesn't exist on the base image
- Swap the `afterStart` install to `sudo dnf install -y --skip-broken ripgrep gh`
- Also update `scripts/create-sandbox-snapshot.ts` so a rebuilt snapshot uses the same script

## Context
Caught in production: admin asked the bot to modify a README via `delegate_code`, and the sandbox aborted during `afterStart` with the shell unable to find `apt-get`. The bot surfaced this as a toolchain install failure in Discord.

## Test plan
- [x] `bun run test src/lib/sandbox/hooks.test.ts` — updated assertions (`dnf install` instead of `apt-get install`) pass
- [ ] Manual smoke: admin @-mentions the bot with a coding task, confirm sandbox boots past `afterStart` and clones the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)