### PR TITLE
docs: sync README and docs with current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,29 @@ AI-powered Discord bot for [Purdue Hackers](https://purduehackers.com). Wack Hac
 
 ### Domains
 
-- **Discord** — manage channels, threads, messages, members, roles, emojis, webhooks, and scheduled events.
-- **GitHub** — browse and edit repositories, file issues and PRs, read file contents, trigger workflows, manage deployments, packages, projects, secrets, and org settings.
-- **Linear** — create and triage issues, run views, comment, manage projects, initiatives, updates, documents, reminders, customer requests, and users.
+Subagents are grouped by what they touch, not by how they're wired up. Organizer role unlocks everything except `delegate_code`, which is admin-only.
+
+**Communication & knowledge**
+
+- **Discord** — channels, threads, messages, members, roles, emojis, webhooks, scheduled events.
 - **Notion** — read and write pages, query and update databases, post and resolve comments.
-- **Documentation** — search and quote from [ask.purduehackers.com](https://ask.purduehackers.com) so the bot can answer questions grounded in Purdue Hackers' own docs.
+- **Documentation** — search and quote from [ask.purduehackers.com](https://ask.purduehackers.com) for questions grounded in Purdue Hackers' own docs.
+
+**Engineering**
+
+- **GitHub** — repositories, issues, PRs, file contents, workflows, deployments, packages, projects, secrets, org settings.
+- **Linear** — issues, views, projects, initiatives, updates, documents, reminders, customer requests, users.
+- **Sentry** — error monitoring, events, stack traces, releases, alerts.
+- **Vercel** — projects, deployments, runtime logs, env vars, domains, edge config, feature flags, rolling releases, marketplace integrations (Turso/Upstash/Neon), sandboxes, firewall.
+- **Figma** — files, components, styles, design tokens, variables, comments, dev resources.
+- **Code** (admin-only) — autonomous coding agent that runs inside a Vercel Sandbox against a `purduehackers/*` repo, makes changes on a feature branch, runs checks, and opens a PR.
+
+**Operations**
+
+- **Finance** — read-only Hack Club Bank lookups: balances, transactions, donations, invoices, card spend.
+- **Shopping** — Amazon product search and a shared virtual cart/wishlist.
+- **Sales** — Notion CRM (Companies/Contacts/Deals), Hunter.io email finder, Resend outreach send/tracking.
+- **CMS** — Payload CMS at [cms.purduehackers.com](https://cms.purduehackers.com): events, RSVPs, hack-night sessions, email campaigns, media, microgrants, shelter projects, users.
 
 Built on [Next.js](https://nextjs.org) App Router + [Hono](https://hono.dev) (via `hono/vercel`), [AI SDK](https://ai-sdk.dev) v6, and [Workflow DevKit](https://useworkflow.dev). Deployed on Vercel with Fluid Compute.
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -8,14 +8,16 @@ The subagent is **progressive**: it starts with a small discovery toolkit plus a
 
 ## Contents
 
-| Doc                                      | Topic                                                                                |
-| ---------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Orchestrator](./orchestrator.md)        | Model, system prompt, base tools, delegate tools.                                    |
-| [AgentContext](./context.md)             | Execution context (user, channel, date, role), `buildInstructions`, serialization.   |
-| [Delegation & subagents](./subagents.md) | `createDelegationTool`, per-subagent config, preliminary results, `toModelOutput`.   |
-| [Streaming](./streaming.md)              | `streamTurn`: the live Discord message edit loop.                                    |
-| [Role-based access](./roles.md)          | `UserRole`, `ROLE_IDS`, `buildDelegationTools`, `filterAdmin`, `getAvailableSkills`. |
-| [Adding a base tool](./adding-tools.md)  | How to add a new flat tool to the orchestrator (not a delegate domain).              |
+| Doc                                      | Topic                                                                                  |
+| ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| [Orchestrator](./orchestrator.md)        | Model, system prompt, base tools, delegate tools.                                      |
+| [AgentContext](./context.md)             | Execution context (user, channel, date, role), `buildInstructions`, serialization.     |
+| [Delegation & subagents](./subagents.md) | `createDelegationTool`, per-subagent config, `DOMAIN_SPEC_OVERRIDES`, `toModelOutput`. |
+| [Code sandbox](./code-sandbox.md)        | `delegate_code` — Vercel Sandbox provisioning, credential brokering, `postFinish` PR.  |
+| [Approvals](./approvals.md)              | `approval()` wrapper, Discord button prompt, `ApprovalStore`, `wrapApprovalTools`.     |
+| [Streaming](./streaming.md)              | `streamTurn`: the live Discord message edit loop.                                      |
+| [Role-based access](./roles.md)          | `UserRole`, `ROLE_IDS`, `buildDelegationTools`, `filterAdmin`, `getAvailableSkills`.   |
+| [Adding a base tool](./adding-tools.md)  | How to add a new flat tool to the orchestrator (not a delegate domain).                |
 
 ## Where they plug in
 

--- a/docs/agents/approvals.md
+++ b/docs/agents/approvals.md
@@ -1,0 +1,86 @@
+# Approvals
+
+`approval()` is a marker that gates individual tool calls behind a Discord button prompt. A wrapped tool cannot run until the requesting user clicks **Approve**; if they click **Deny** or ignore the prompt for too long, the tool returns a short diagnostic instead of executing.
+
+The feature lives entirely in `src/lib/ai/approvals/`:
+
+| File         | What it is                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `index.ts`   | The public API — `approval()` marker, `getApprovalOptions`, `hasApprovalMarker`, re-exports.               |
+| `runtime.ts` | `wrapApprovalTools(tools, opts)` — walks a `ToolSet`, replaces any marked tool with an approval-gated one. |
+| `store.ts`   | `ApprovalStore` — Redis-backed state for a pending approval (create, get, decide, `waitFor`).              |
+| `helpers.ts` | `buildApprovalEmbed`, `buildApprovalComponents`, `buildDecisionEmbed`, `formatToolCall` — the Discord UI.  |
+| `types.ts`   | `ApprovalOptions`, `ApprovalState`, `WrapApprovalOptions`.                                                 |
+
+## Marking a tool
+
+```ts
+import { approval } from "@/lib/ai/approvals";
+import { tool } from "ai";
+import { z } from "zod";
+
+export const wipe_channel = approval(
+  tool({
+    description: "Delete every message in the current channel.",
+    inputSchema: z.object({
+      channel_id: z.string(),
+    }),
+    execute: async ({ channel_id }) => {
+      // ...
+    },
+  }),
+  { reason: "Wiping a channel deletes history permanently." },
+);
+```
+
+`approval(tool, opts?)` mutates the tool in place and returns it. The marker is a hidden `Symbol`, so it doesn't interfere with the AI SDK's metadata. The optional `reason` becomes the fallback justification shown to the user when the agent doesn't supply one via `_reason`.
+
+## What the agent sees
+
+`wrapApprovalTools` rewrites a marked tool's `inputSchema` to add an injected `_reason: string` field. The description gets an appended note that explains `_reason` is required (or optional, if a static `reason` was set). The rest of the tool's schema is preserved verbatim — the agent sees its original arguments plus `_reason`.
+
+If the wrapped tool's original `inputSchema` is not a `ZodObject`, `wrapApprovalTools` throws at wrap time (not runtime). The constraint exists because `_reason` has to live on a plain object shape for the wrapper to be able to extract it.
+
+## What the user sees
+
+When the agent calls a wrapped tool, the wrapper:
+
+1. Creates an `ApprovalState` in Redis (pending, keyed by a UUID, TTL = timeout + 60s buffer).
+2. Posts an amber embed to the channel (or thread, if the conversation is in one) pinging the requester. The embed renders the call as a python-style signature: `delegate_<domain>.<tool>(k=v, …)` with `_reason` stripped, plus a "Reason" field showing the agent's justification.
+3. Attaches two buttons — ✅ Approve and ❌ Deny — each with a `custom_id` of `tool-approval:<action>:<approvalId>`.
+4. Calls `store.waitFor(approvalId, { timeoutMs, signal })` to block the tool's execution until a decision is recorded.
+
+Only the requester can approve. When they click a button, the Discord component handler at `src/bot/components/tool-approval.ts` calls `store.decide(approvalId, "approved" | "denied", decidedByUserId)`. The wrapper's poll loop picks up the new state and either runs the original `execute` (yielding its output back into the agent's message stream) or yields a denial message without running it.
+
+If nobody decides within the timeout, the wrapper marks the state as `"timeout"` and the Discord message is swapped for a grey "auto-expired" embed. The default timeout is 240 seconds.
+
+## Wiring it in
+
+Subagent wiring happens inside `createDelegationTool` — after `filterAdmin` strips admin-only tools for non-admin callers, `wrapApprovalTools(tools, { context, delegateName })` replaces any marked tool with its approval-gated version. The `delegateName` is how the prompt renders `delegate_<domain>.<tool>(...)`.
+
+Orchestrator base tools are wrapped the same way but without a `delegateName`, so the prompt renders just `<tool>(...)`. Today the only orchestrator-level approvals are `schedule_task` and `cancel_task` (see [Workflows § scheduled tasks](../workflows/scheduling.md)), both in `src/lib/ai/tools/schedule/index.ts`:
+
+```ts
+export const schedule_task = approval(
+  tool({
+    description: "Schedule a one-time or recurring task…",
+    // …
+  }),
+);
+
+export const cancel_task = approval(
+  tool({
+    description: "Cancel a previously scheduled task…",
+    // …
+  }),
+);
+```
+
+Neither needs a static `reason` because both take a natural-language `description` from the agent anyway.
+
+## Stacking with other markers
+
+- `admin()` — hides a tool entirely from non-admin roles. Applied in `filterAdmin(tools)` before `wrapApprovalTools`, so an admin-marked tool that's also approval-marked will simply not be visible to an organizer.
+- `minRole` on a skill — gates the entire skill (and all its tools) behind a role; orthogonal to `approval()`.
+
+Approvals are about **per-call consent**, not access control. Use `admin()` when a tool should never be reachable by an organizer; use `approval()` when they _can_ reach it but should pause to confirm each use.

--- a/docs/agents/code-sandbox.md
+++ b/docs/agents/code-sandbox.md
@@ -1,0 +1,100 @@
+# Code sandbox (`delegate_code`)
+
+`delegate_code` is the only subagent that runs a coding loop against a real repository checkout. It is **admin-only** because it takes writes actions on `purduehackers/*` repositories — any organizer can ask it to read code, but only an admin can delegate to it.
+
+Unlike the other delegates, `delegate_code` doesn't just call APIs. It provisions an ephemeral [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) (a Firecracker microVM), clones the target repo into it, lets the subagent run `read` / `grep` / `edit` / `exec` tools against that filesystem, and commits + opens a PR on the way out.
+
+## Overview
+
+```
+  admin mentions @bot ──▶ orchestrator ──▶ delegate_code({ repo, task })
+                                                   │
+                                                   ▼
+                                    buildCodeExperimentalContext
+                                                   │
+                                    ┌──────────────┴──────────────┐
+                                    │ Vercel Sandbox (microVM)    │
+                                    │  · git clone <repo>          │
+                                    │  · feature branch            │
+                                    │  · installation token broker │
+                                    └──────────────┬──────────────┘
+                                                   │
+                                                   ▼
+                                    Subagent loop (claude-opus-4.7, 60 steps)
+                                    tools: read, grep, glob, list_dir, edit,
+                                            exec, todo_write, …
+                                                   │
+                                                   ▼
+                                              codePostFinish
+                                                   │
+                                       git add -A → commit → push → open PR
+                                                   │
+                                                   ▼
+                                     Subagent's final message +
+                                     "**PR**: <url>" appended
+```
+
+## Where the pieces live
+
+| File                                      | What it is                                                                                 |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `src/lib/ai/delegates.ts`                 | `DOMAIN_SPEC_OVERRIDES.code` — model, step cap, schema, context builder, post-finish       |
+| `src/lib/ai/tools/code/delegation.ts`     | `codeDelegationInputSchema`, `buildCodeExperimentalContext`, `codePostFinish`              |
+| `src/lib/ai/tools/code/`                  | The actual coding tools exposed inside the subagent (`read`, `grep`, `edit`, `exec`, etc.) |
+| `src/lib/sandbox/vercel-sandbox.ts`       | `VercelSandbox` — the `Sandbox` interface implementation                                   |
+| `src/lib/sandbox/session.ts`              | Redis-backed session registry (one session per Discord thread)                             |
+| `src/lib/sandbox/credential-brokering.ts` | Injects GitHub App tokens into outbound traffic via the sandbox network policy             |
+| `src/workflows/sandbox-lifecycle.ts`      | Durable workflow that hibernates the sandbox before its timeout fires                      |
+| `scripts/create-sandbox-snapshot.ts`      | Builds a base snapshot with `ripgrep` + `gh` preinstalled                                  |
+
+## Sandbox provisioning
+
+`buildCodeExperimentalContext` runs before the subagent starts. It:
+
+1. Resolves a `threadKey` from `agentContext.thread?.id ?? agentContext.channel.id` — this is the idempotency key for the session.
+2. Mints a fresh GitHub App installation access token via Octokit (`octokit.auth({ type: "installation" })`).
+3. Calls `getOrCreateSession({ threadKey, repo, githubToken, gitUser, baseSnapshotId })`:
+   - If Redis has a live session for this thread, it's reused. The subagent picks up the same feature branch from the previous turn.
+   - Otherwise a new `VercelSandbox` is created, the repo is cloned, and a feature branch (`phoenix-agent/<slug>-<suffix>`) is checked out.
+4. Returns `{ sandbox, repo, branch, repoDir, threadKey }` — this object is wired into every coding tool's `execute(input, runtime)` via `runtime.experimental_context`.
+
+The `Sandbox` interface in `src/lib/sandbox/types.ts` is the contract the coding tools code against. Today the only implementation is `VercelSandbox`, but the abstraction exists so tests can swap in an in-memory fake.
+
+## Credential brokering
+
+The subagent never sees GitHub credentials. Instead, `buildGitHubCredentialBrokeringPolicy(token)` (in `credential-brokering.ts`) produces a sandbox network policy that transparently rewrites outbound traffic to github.com, api.github.com, uploads.github.com, and codeload.github.com — adding an `Authorization` header keyed to the installation token.
+
+This means the subagent runs stock `git push`, `gh pr create`, `curl api.github.com` and auth "just works" without any token being readable from inside the VM. Exfiltration via logs, env vars, or `cat ~/.git-credentials` all fail because the token lives in the network policy, not the filesystem.
+
+## Snapshot optimization
+
+Sandbox cold starts run `dnf install -y ripgrep gh` which takes 20-30 seconds. If `SANDBOX_BASE_SNAPSHOT_ID` is set, `getOrCreateSession` boots from that pre-seeded snapshot instead. Build one by running:
+
+```bash
+bun scripts/create-sandbox-snapshot.ts
+```
+
+Copy the ID it prints into your Vercel environment as `SANDBOX_BASE_SNAPSHOT_ID`. The app runs fine without it — the var is genuinely optional.
+
+## `codePostFinish`
+
+After the subagent emits its final "Summary" / "Answer" message, `codePostFinish` runs as an async generator that yields additional `UIMessage`s (which the orchestrator surfaces as the subagent's apparent trailing output).
+
+1. `git status --porcelain` — if the working tree is clean, yield "No changes to commit" and return.
+2. Parse a commit message. The expected format is a trailing `**Commit message**: <message>` line in the subagent's final text; if that's missing, the first non-empty line is used (truncated to 72 chars).
+3. `git add -A && git commit -m <msg>`.
+4. `git push -u origin <branch>` (3-minute timeout).
+5. Check for an existing open PR (`pulls.list({ head: "<org>:<branch>", state: "open" })`). If there is one, reuse its URL. Otherwise `pulls.create` against the repo's default branch with a body built from:
+   - The subagent's final text (minus the trailing `**Commit message**: …` line).
+   - An attribution footer naming the Discord user who asked.
+6. Yield a final message appending `**PR**: <url>` to the subagent's summary.
+
+If any step fails, the generator yields a short diagnostic and returns — the subagent's own text is still visible to the user, and the feature branch state is whatever it was when the failure occurred.
+
+## Session lifecycle
+
+The lifecycle workflow at `src/workflows/sandbox-lifecycle.ts` runs per-session and hibernates the sandbox about 90 seconds before its timeout fires. Hibernation snapshots the VM's state to Redis with a longer TTL (6 hours) so a paused conversation can resume without losing its branch or working directory. A fully released session (via `releaseSession`) tears the VM down and clears the snapshot.
+
+## When to use `delegate_code`
+
+Only delegate to `code` when the user explicitly asks for code changes to a specific repository — bug fixes, features, refactors, version bumps, test authoring, etc. Read-only questions should go through `delegate_github` instead; the coding sandbox is expensive to spin up and the coding agent is tuned for modifying code rather than summarizing it.

--- a/docs/agents/orchestrator.md
+++ b/docs/agents/orchestrator.md
@@ -17,7 +17,8 @@ These are always present, regardless of role:
 
 - **`current_time`** — current wall clock and timezone, used for date math.
 - **`documentation`** — search and quote from [ask.purduehackers.com](https://ask.purduehackers.com).
-- **`schedule_task`**, **`list_scheduled_tasks`**, **`cancel_task`** — scheduling tools that publish to, read from, or cancel jobs in the `tasks` queue. `schedule_task` and `cancel_task` are wrapped with `approval()` so the user confirms via Discord buttons. See [Workflows § scheduled tasks](../workflows/scheduling.md).
+- **`resolve_organizer`** — authoritative name-to-platform-ID lookup for the Purdue Hackers organizer roster stored in Vercel Edge Config. Returns the caller's Discord/Linear/Notion/Sentry/GitHub/Figma IDs so the orchestrator can forward real IDs to delegates instead of free-text names. The `/identity` slash command is what writes into that roster. See `src/lib/protocol/organizers/` for the reader/writer.
+- **`schedule_task`**, **`list_scheduled_tasks`**, **`cancel_task`** — scheduling tools that publish to, read from, or cancel jobs in the `tasks` queue. `schedule_task` and `cancel_task` are wrapped with [`approval()`](./approvals.md) so the user confirms via Discord buttons. See [Workflows § scheduled tasks](../workflows/scheduling.md).
 
 ## Delegate tools
 
@@ -35,7 +36,7 @@ The static template is defined at the top of `orchestrator.ts`. It has four sect
 
 - `<identity>` — role, audience, first-person voice.
 - `<date>` — a `{{DATE}}` placeholder that `buildInstructions` replaces with `context.date`.
-- `<tools>` — a human-readable description of the base and delegate tools, so the model knows when to pick each one. **When you add a base tool, update this section.**
+- `<tools>` — a human-readable description of the base and delegate tools, so the model knows when to pick each one. It covers the full 12-domain delegate set (listed in [Delegation & subagents](./subagents.md) along with their per-domain overrides); `delegate_code` is called out separately as admin-only. **When you add a base tool or a new delegate domain, update this section.**
 - `<tone>`, `<formatting>` — output style rules (Discord markdown, 2000 char limit, no preamble, etc.).
 
 `context.buildInstructions(SYSTEM_PROMPT)` additionally appends an `<execution_context>` YAML block with the user, channel, thread (if any), and date so the model has direct visibility into "who's talking and where".

--- a/docs/agents/subagents.md
+++ b/docs/agents/subagents.md
@@ -22,15 +22,15 @@ This is what actually goes into the orchestrator's message history — the full 
 
 ## Subagent configuration
 
-| Field         | Value                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Model         | `SUBAGENT_MODEL` constant in `src/lib/ai/constants.ts`, currently `anthropic/claude-haiku-4.5`                      |
-| Instructions  | `SUBAGENT_PREAMBLE` + the domain's `SKILL.md` body, with `{{SKILL_MENU}}` substituted                               |
-| Tools         | All domain tools + `loadSkill`, then run through `filterAdmin(allTools)` when role is not admin                     |
-| `activeTools` | Initially `[...spec.baseToolNames, "loadSkill"]` — discovery tools plus the always-present `loadSkill`              |
-| `prepareStep` | Re-computes `activeTools` every step by scanning previous `loadSkill` calls — see [Skills](../skills/disclosure.md) |
-| `stopWhen`    | `stepCountIs(15)` — hard cap on tool calls per delegation                                                           |
-| Telemetry     | `experimental_telemetry: { isEnabled: true, functionId: "subagent.<name>", metadata: { role, subagent } }`          |
+| Field         | Value                                                                                                                                                 |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Model         | `SUBAGENT_MODEL` in `src/lib/ai/constants.ts`, currently `openai/gpt-5.4-mini`; a domain can override via `DOMAIN_SPEC_OVERRIDES` (see below)         |
+| Instructions  | `SUBAGENT_PREAMBLE` + the domain's `SKILL.md` body, with `{{SKILL_MENU}}` substituted                                                                 |
+| Tools         | All domain tools + `loadSkill`, then run through `filterAdmin(allTools)` when role is not admin, then `wrapApprovalTools` for any `approval()`-marked |
+| `activeTools` | Initially `[...spec.baseToolNames, "loadSkill"]` — discovery tools plus the always-present `loadSkill`                                                |
+| `prepareStep` | Re-computes `activeTools` every step by scanning previous `loadSkill` calls — see [Skills](../skills/disclosure.md)                                   |
+| `stopWhen`    | `stepCountIs(spec.stopSteps ?? 15)` — hard cap on tool calls per delegation, overridable per domain                                                   |
+| Telemetry     | `experimental_telemetry: { isEnabled: true, functionId: "subagent.<name>", metadata: { role, subagent } }`                                            |
 
 ## SubagentSpec
 
@@ -45,6 +45,18 @@ At call time, `buildDelegationTools` layers on:
 - `name` — the domain key (e.g. `"linear"`).
 - `description` — from the domain's top-level `SKILL.md`, shown to the orchestrator on the delegation tool.
 - `systemPrompt` — the same `SKILL.md` body, used as the subagent's instructions.
+
+## Per-domain overrides (`DOMAIN_SPEC_OVERRIDES`)
+
+Most subagents use the defaults. `delegates.ts` also exports a `DOMAIN_SPEC_OVERRIDES` map — a `Partial<Record<domain, Partial<SubagentSpec>>>` — for domains that need non-default wiring. The overridable fields are:
+
+- `model` — swap the subagent model (e.g. a stronger one for harder tasks).
+- `stopSteps` — raise or lower the per-delegation step cap.
+- `inputSchema` — replace the default `{ task: string }` with a domain-specific Zod schema; the orchestrator sees the richer shape on the delegation tool.
+- `buildExperimentalContext` — a function that runs before the subagent starts. Whatever it returns is threaded into the agent's `experimental_context` and is visible to tools via `tool.execute`'s second argument. Use this to provision external state (a sandbox, a DB session, etc.).
+- `postFinish` — an async generator that runs after the subagent emits its final message. It can yield more `UIMessage`s that stream back as the subagent's apparent last output (used, for example, to append a PR URL).
+
+Today only `code` has overrides. Its entry sets `model: "anthropic/claude-opus-4.7"`, `stopSteps: 60`, a repo-constrained `inputSchema` (`{ repo: "purduehackers/<name>", task: string }`), a `buildCodeExperimentalContext` that provisions a Vercel Sandbox session, and a `codePostFinish` that commits, pushes, and opens (or reuses) a PR. The full flow is documented in [Code sandbox](./code-sandbox.md).
 
 ## Fire-and-forget semantics
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,7 @@ Three things are happening at once:
   │  tools                                      │
   │   · current_time                            │
   │   · documentation                           │
+  │   · resolve_organizer                       │
   │   · schedule_task                           │
   │   · list_scheduled_tasks                    │
   │   · cancel_task                             │
@@ -89,7 +90,8 @@ Three things are happening at once:
                          ▼
   ┌─────────────────────────────────────────────┐
   │  Subagent                                   │
-  │  Claude Haiku 4.5 (default) · AI Gateway    │
+  │  GPT-5.4 mini (default) · AI Gateway        │
+  │  some domains override (code → Opus 4.7)    │
   │                                             │
   │  tools                                      │
   │   · loadSkill <progressively unlocks>       │
@@ -132,34 +134,38 @@ See [Agents](./agents/README.md) for the full breakdown.
 
 ## Storage and platform
 
-| Service            | Purpose                                                                                                                            |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| AI Gateway         | `anthropic/claude-sonnet-4.6` (orchestrator) and `anthropic/claude-haiku-4.5` (subagents); routing, observability, model fallbacks |
-| Upstash Redis      | `ConversationStore`, dedup keys, per-channel locks, task registry                                                                  |
-| Turso (libSQL)     | Privacy preferences, ship submissions                                                                                              |
-| Cloudflare R2      | Ship uploads                                                                                                                       |
-| Payload CMS        | Hack night photo archive, curated site content (events, hack-night-sessions, ugrants, shelter projects)                            |
-| Vercel Edge Config | Hack night `version` key (used by the `/init-hn` command)                                                                          |
-| Vercel Queues      | `discord-events` (gateway → consumer), `tasks` (scheduling)                                                                        |
+| Service            | Purpose                                                                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AI Gateway         | `anthropic/claude-sonnet-4.6` (orchestrator), `openai/gpt-5.4-mini` (subagents), `anthropic/claude-opus-4.7` (`delegate_code`); routing, observability, model fallbacks |
+| Upstash Redis      | `ConversationStore`, dedup keys, per-channel locks, task registry, approval state, sandbox session registry                                                             |
+| Turso (libSQL)     | Privacy preferences, ship submissions                                                                                                                                   |
+| Cloudflare R2      | Ship uploads                                                                                                                                                            |
+| Payload CMS        | Hack night photo archive, curated site content (events, hack-night-sessions, ugrants, shelter projects)                                                                 |
+| Vercel Edge Config | Organizer roster (read by `resolve_organizer`), hack night `version` key (used by `/init-hn`)                                                                           |
+| Vercel Queues      | `discord-events` (gateway → consumer), `tasks` (scheduling)                                                                                                             |
+| Vercel Sandbox     | Ephemeral Firecracker microVM per `delegate_code` run, pre-seeded with `ripgrep` + `gh` via optional base snapshot                                                      |
 
 ## Where things live
 
 ```
 src/
-  app/          Next.js routes (Hono catch-all + queue consumers)
+  app/          Next.js routes (Hono catch-all + queue consumers + webhooks)
   server/       Hono app + process-event dispatcher (gateway, interactions, crons)
-  workflows/    Workflow DevKit definitions (chat, task)
-  bot/          EventRouter, handlers, commands, components, crons
+  workflows/    Workflow DevKit definitions (chat, task, sandbox-lifecycle)
+  bot/          EventRouter, handlers, commands, components, crons, integrations
   lib/
     ai/
       orchestrator.ts   top-level agent
       subagent.ts       focused per-domain agent
-      delegates.ts      role-filtered delegation tools
+      delegates.ts      role-filtered delegation tools + DOMAIN_SPEC_OVERRIDES
+      approvals/        approval() wrapper, runtime, store, Discord button flow
       skills/           per-domain SKILL.md trees + registry
       tools/            per-domain tool implementations
+    sandbox/    Vercel Sandbox wrapper + credential brokering for delegate_code
     tasks/      scheduled task registry
     protocol/   Packet types, codec, interaction verify
+      organizers/ Edge Config organizer roster (resolve_organizer / /identity)
 
-scripts/        compile-skills, register-commands
+scripts/        compile-skills, register-commands, create-sandbox-snapshot
 vercel.ts       framework, crons, per-function config
 ```

--- a/docs/deployment/env.md
+++ b/docs/deployment/env.md
@@ -6,12 +6,14 @@
 
 The full list changes often; the canonical source is always [`src/env.ts`](../../src/env.ts). Today it covers:
 
-- **Discord** — bot token, client ID, public key, guild ID.
+- **Discord** — `DISCORD_BOT_TOKEN`, `DISCORD_BOT_CLIENT_ID`, `DISCORD_BOT_PUBLIC_KEY`. The guild ID is a hard-coded constant in `src/lib/constants.ts`, not an env var.
 - **Cron auth** — `CRON_SECRET` (bearer token for `/api/crons/*`).
-- **Integrations** — Linear, Notion, GitHub App credentials (org-installed), Groq, ask.purduehackers.com API key, dashboard URL, Phonebell open URL.
-- **Storage** — Upstash Redis (KV REST), Cloudflare R2 (account ID + access keys + ship bucket), Payload CMS (API key for hack-night media + curated content), Turso libSQL (privacy DB and ship DB).
-- **Vercel** — API token, Edge Config ID. The `vercel()` preset auto-loads `VERCEL_*` deployment vars.
-- **Optional** — Sentry DSN.
+- **AI** — `GROQ_API_KEY` (used by one specialized tool). The AI SDK Gateway authenticates via the standard `VERCEL_*` OIDC vars loaded by the `vercel()` preset.
+- **Integrations — engineering** — Linear (`LINEAR_API_KEY`), Notion (`NOTION_TOKEN`), GitHub App (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_ORG`), Figma (`FIGMA_ACCESS_TOKEN`, `FIGMA_TEAM_ID`), Sentry (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`).
+- **Integrations — ops & platform** — Vercel (`VERCEL_API_TOKEN`, `VERCEL_EDGE_CONFIG_ID`, `EDGE_CONFIG`), Hack Club Bank (`HCB_ORG_SLUG`), SerpAPI for `delegate_shopping` (`SERPAPI_API_KEY`).
+- **Integrations — sales & CMS** — Resend (`RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`), Hunter.io (`HUNTER_API_KEY`), Payload CMS (`PAYLOAD_CMS_API_KEY`), ask.purduehackers.com (`PHACK_ASK_API_KEY`), Phack API (`PHACK_API_TOKEN`), `PHONEBELL_OPEN_URL`, `DASHBOARD_URL`.
+- **Storage** — Upstash Redis (`KV_REST_API_URL`, `KV_REST_API_TOKEN`), Turso main (`TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`), Turso ship (`SHIP_DATABASE_TURSO_DATABASE_URL`, `SHIP_DATABASE_TURSO_AUTH_TOKEN`), Cloudflare R2 (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `SHIP_R2_BUCKET_NAME`), privacy DB (`PRIVACY_DB_URL`, `PRIVACY_DB_API_KEY`).
+- **Optional** — `SENTRY_DSN` (client-side error reporting), `SANDBOX_BASE_SNAPSHOT_ID` (preseeded Vercel Sandbox snapshot with `ripgrep` + `gh`; speeds up `delegate_code` cold starts by ~20-30s — create one via `scripts/create-sandbox-snapshot.ts`).
 
 ## Adding a new env var
 

--- a/docs/deployment/vercel-config.md
+++ b/docs/deployment/vercel-config.md
@@ -5,10 +5,11 @@
 ```ts
 import { type VercelConfig } from "@vercel/config/v1";
 
+import { buildCronRoutes } from "@/bot/crons/config";
+
 export const config: VercelConfig = {
   framework: "nextjs",
-  bunVersion: "1.x",
-  crons: [{ path: "/api/discord/gateway", schedule: "*/9 * * * *" }],
+  crons: [{ path: "/api/discord/gateway", schedule: "*/9 * * * *" }, ...buildCronRoutes()],
   functions: {
     "src/app/api/tasks/route.ts": {
       maxDuration: 600,
@@ -31,7 +32,10 @@ export const config: VercelConfig = {
 
 ## Cron
 
-`*/9 * * * *` → `/api/discord/gateway`. This is the gateway leader cron — it makes sure something is always trying to be the active discord.js client. The cadence overlaps with the listener's 10-minute hold, so there's always a leader. See [Discord § gateway leader election](../discord/gateway.md).
+Two sources:
+
+1. **Gateway leader cron** — `*/9 * * * *` → `/api/discord/gateway`. Hand-registered because it lives outside the handler registry. Keeps something always trying to be the active discord.js client; the cadence overlaps with the listener's 10-minute hold so there's always a leader. See [Discord § gateway leader election](../discord/gateway.md).
+2. **Handler-derived crons** — `buildCronRoutes()` (from `@/bot/crons/config`) walks `src/bot/handlers/crons/` and emits one `{ path: "/api/crons/<name>", schedule }` entry per `defineCron` handler. At time of writing that's `heartbeat`, `hack-night-create`, and `hack-night-cleanup`. Add a new cron by dropping a `defineCron` handler in that directory; no `vercel.ts` edit required. See [Discord § writing handlers](../discord/handlers.md).
 
 ## Queue triggers
 
@@ -48,7 +52,3 @@ Scoping is critical. Next.js compiles each route file into its own `.func` direc
 
 - `600` (10 minutes) on both queue consumers — long enough for an agent run with subagent delegation.
 - `"max"` on the catch-all Hono function — Fluid Compute's plan maximum, since that's where streaming chat turns and long-running interactions live.
-
-## Bun version
-
-`bunVersion: "1.x"` pins the Bun runtime to the 1.x line. Update this when moving to 2.x.

--- a/docs/discord/handlers.md
+++ b/docs/discord/handlers.md
@@ -77,6 +77,21 @@ export const someJob = defineCron({
 });
 ```
 
-Crons are reached by hitting `GET /api/crons/:name` with `Authorization: Bearer ${CRON_SECRET}`. The route looks the cron up by `name` and calls `cron.handle(discord)` — the cron's `schedule` field is metadata only, not actually wired to Vercel's scheduler.
+Crons are reached by hitting `GET /api/crons/:name` with `Authorization: Bearer ${CRON_SECRET}`. The route looks the cron up by `name` and calls `cron.handle(discord)`.
 
-To make Vercel actually fire the cron, add `{ path: "/api/crons/<name>", schedule: "..." }` to the `crons` array in `vercel.ts`. As of writing only the gateway cron is registered there.
+Any cron created via `defineCron` is automatically picked up by `buildCronRoutes()` in [`vercel.ts`](../deployment/vercel-config.md) — you do not edit the `crons` array by hand. The gateway cron is the one exception because it lives outside `src/bot/handlers/crons/`. To add a new cron, drop a handler file under `src/bot/handlers/crons/<name>/` and re-export it from the barrel; the next deploy will register it.
+
+## Shipped commands
+
+One directory per handler under `src/bot/handlers/commands/`. Barrel-exported from `commands/index.ts`; `register-commands.ts` reads the exports when you run `bun run build`.
+
+| Command                     | Kind                | Purpose                                                                                   |
+| --------------------------- | ------------------- | ----------------------------------------------------------------------------------------- |
+| `/ping`                     | slash               | Health check.                                                                             |
+| `/door-opener`              | slash               | Triggers the Phonebell open URL.                                                          |
+| `/privacy`                  | slash               | Manage the user's privacy preferences in the privacy DB.                                  |
+| `/delete-ship`              | slash               | Admin — delete a Ship submission by ID (R2 asset + Turso row).                            |
+| `/restart-bot`              | slash               | Admin — nuke the discord.js gateway leader so the next cron picks it up cleanly.          |
+| `/init-hn`                  | slash               | Organizer — bootstrap a hack night: creates the thread, bumps the Edge Config version.    |
+| `/identity`                 | slash (opens modal) | Organizer — write your Linear/Notion/Sentry/GitHub/Figma IDs to the Edge Config roster.   |
+| `Inspect Context` (message) | context menu        | Organizer — right-click a bot message to see the conversation's context-budget breakdown. |


### PR DESCRIPTION
## Summary
Documentation was several features behind the code — README listed 5 delegate domains when `src/lib/ai/delegates.ts` now registers 12, and the docs referenced the old Haiku subagent model plus an env-var layout that no longer matches `src/env.ts`. This PR re-syncs the top-level README and everything under `docs/` with the current state, adds new pages for two areas that weren't documented at all (`delegate_code` + Vercel Sandbox, and the `approval()` wrapper), and refreshes env/vercel/handlers docs so they match today's `vercel.ts` and `src/bot/handlers/commands/`.

## Test plan
- [x] `bun format`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test` — 937 tests pass
- [x] `bun test:coverage` — 99.58% statements
- [x] `bun knip` — clean
- [x] Stale-term sweep returns no hits in `docs/` for `Claude Haiku 4.5`, `haiku-4.5`, `bunVersion`, or "only the gateway cron is registered"

🤖 Generated with [Claude Code](https://claude.com/claude-code)