### PR TITLE
feat(skills): add deslop and unit-test-quality project skills

### DIFF
--- a/.claude/skills/deslop/SKILL.md
+++ b/.claude/skills/deslop/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: deslop
+description: Simplify recently modified code while preserving behavior. Use when the user says "deslop", "clean up code", "simplify", "remove indirection", or after making changes that could benefit from refinement. Flags one-line wrapper functions, pass-through abstractions, factory helpers like `createXxx()` that only initialize a class, and unnecessary env-var getters. Keeps code explicit and readable — no nested ternaries, no dense one-liners, no cleverness that hurts debuggability.
+license: MIT
+metadata:
+  author: ray
+  version: "1.0.0"
+---
+
+# Deslop
+
+You are a code simplification specialist. Refine recently modified code for clarity and consistency **without changing behavior**. Prefer explicit, readable code over compact code. Be conservative: a refinement you are not certain is safe is not a refinement.
+
+## Goal
+
+Take the code that was just written or modified and make it easier to read and maintain while keeping every observable behavior identical.
+
+## Rule 1 — Preserve functionality
+
+Behavior, outputs, side effects, error messages, and public shapes must stay identical. If a change could alter any of these, do not make it. If in doubt, leave it.
+
+## Rule 2 — Apply project standards
+
+Read `CLAUDE.md`, `AGENTS.md`, `tsconfig.json`, `biome.json` / `.oxlintrc.json` / `eslint.config.*`, and `package.json` scripts to learn what the project already enforces. Align with:
+
+- ES modules with sorted, typed imports
+- Explicit return types on exported functions
+- Explicit `Props` types for components
+- Error handling patterns already in use (don't wrap in try/catch if the project propagates errors)
+- Naming conventions from nearby code
+
+Do not introduce patterns the project does not already use.
+
+## Rule 3 — Enhance clarity
+
+Simplify structure:
+
+- Flatten unnecessary nesting
+- Remove redundant variables, wrappers, and layers
+- Rename local variables that lie about what they hold
+- Delete comments that only restate the code (keep comments that explain _why_ or call out non-obvious constraints)
+- Use early returns over deeply nested conditionals
+- Replace nested ternaries with `switch` statements or `if` / `else if` chains
+- Replace dense one-liners with a few named steps when the one-liner is harder to read
+
+**Clarity beats brevity.** Fewer lines is not a goal.
+
+## Rule 4 — Remove indirection
+
+This is the core of deslop. Indirection is code that adds a name or a layer without adding meaning. It makes the reader follow an extra hop for no payoff. Flag and remove it.
+
+### Patterns to remove
+
+**Factory functions that only `new` a class.** If the function does nothing but call a constructor, inline the constructor.
+
+```ts
+// before
+function createUserStore() {
+  return new UserStore();
+}
+const store = createUserStore();
+
+// after
+const store = new UserStore();
+```
+
+**One-line wrappers around a single expression (not arithmetic/logic).** If a function's body is a single property access, env read, or forward to another function with the same signature, inline it.
+
+```ts
+// before
+function hcbOrgSlug(): string {
+  return env.HCB_ORG_SLUG;
+}
+fetch(`/api/${hcbOrgSlug()}/...`);
+
+// after
+fetch(`/api/${env.HCB_ORG_SLUG}/...`);
+```
+
+**Pass-through wrappers.** A function that takes args and forwards them unchanged to another function is dead weight.
+
+```ts
+// before
+function fetchUser(id: string) {
+  return userRepo.getById(id);
+}
+
+// after — call userRepo.getById(id) directly
+```
+
+**Single-constructor "builders" used at one call site.** If `buildFoo()` runs once and just chains two constructors, inline the chain.
+
+```ts
+// before
+function buildDiscord() {
+  return new API(new REST().setToken(env.TOKEN));
+}
+const discord = buildDiscord();
+
+// after
+const discord = new API(new REST().setToken(env.TOKEN));
+```
+
+**Trivial re-exports.** `export const doThing = realDoThing` adds a rename with no transformation. Import `realDoThing` directly unless the rename is part of a stable public API.
+
+### Patterns to keep
+
+Not every short function is indirection. Keep:
+
+- Functions with memoization or lazy initialization (`const get = () => cache ??= init()`)
+- Named domain operations — `isBusinessHours(t)` is better than inlining the expression at every call site, even if the body is one line
+- Wrappers that normalize or narrow a sprawling third-party API to the shape the project actually uses
+- Helpers called from more than a few places where inlining would duplicate non-trivial logic or hurt readability
+- Dependency-injection seams — optional factory/provider params on production code that tests use to swap in fakes. The seam has a real purpose.
+
+The test is: **does removing this function make the caller harder to read, or does it make it easier?** If easier, remove it.
+
+## Rule 5 — Maintain balance
+
+Avoid over-simplification. Do not:
+
+- Combine unrelated concerns into one function
+- Collapse a readable five-line function into one dense line
+- Remove a helper just because it is short
+- Introduce cleverness (bitwise tricks, fluent chains, implicit coercion) to save lines
+- Restructure code in ways that make a future diff harder to review
+
+If a change trades readability for brevity, revert it.
+
+## Rule 6 — Scope
+
+Only refine code that was modified in the current session or in recent commits on this branch, unless the user explicitly asks for a wider sweep. Do not open unrelated files. Use `git diff` against the branch's merge base to bound the scope.
+
+## Process
+
+1. List the files changed in this session (`git diff --name-only <merge-base>..HEAD` plus uncommitted changes).
+2. For each file, read the changed hunks and the functions they touch.
+3. Walk the Rule 4 patterns and flag candidates. Prefer removing indirection before any other simplification — it is usually the biggest win.
+4. Apply the simplest safe change first. Re-run type checks and the relevant tests after each meaningful change, not at the end.
+5. Leave a one-line note only for changes that are not self-explanatory. Do not narrate whitespace, renames, or inlined wrappers.
+
+## Verification
+
+After refinement, run the project's full check suite (format, lint, typecheck, tests, coverage, dead-code checks like knip). Every status must stay green. If a test fails, the refinement changed behavior — revert that change.

--- a/.claude/skills/unit-test-quality/SKILL.md
+++ b/.claude/skills/unit-test-quality/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: unit-test-quality
+description: Write and review unit tests with strict quality standards. Use when writing new unit tests, reviewing tests in a PR, refactoring a test file, fixing flaky tests, or deciding how to structure test doubles. Enforces — never mock internal modules (use dependency injection instead); only mock third-party SDKs at the package boundary; colocate shared fixtures and fakes under one directory like src/lib/test/ and never duplicate them; test observable behavior, not implementation; no shortcuts (no `as any`, no skipped or todo'd tests, no assertions that only check "did not throw").
+license: MIT
+metadata:
+  author: ray
+  version: "1.0.0"
+---
+
+# Unit Test Quality
+
+Write unit tests that actually protect the code. A unit test verifies the observable behavior of one module against its contract. Tests that mock their way around the code they claim to cover are worse than no test — they pass when production is broken.
+
+## Principles
+
+- A unit test exercises real code. Use real implementations of internal collaborators whenever they are cheap and deterministic.
+- Fakes go at the system boundary (network, disk, time, third-party SDKs), not between your own modules.
+- A test failure should point to a specific contract that was broken. If a test can only fail when you update the mocks, it is not testing behavior.
+- Shared fixtures live in one place and are imported. Never copy.
+
+## Rule 1 — Only mock third-party SDKs
+
+Mock packages owned by someone else: database clients, API SDKs, message brokers, email senders, HTTP clients. Mock them **at the package boundary** so the production code path under test is untouched.
+
+```ts
+// good — mock the SDK package
+import { vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  pagesRetrieve: vi.fn(),
+  pagesUpdate: vi.fn(),
+}));
+
+vi.mock("@notionhq/client", () => ({
+  Client: notionClientClass({
+    pagesRetrieve: mocks.pagesRetrieve,
+    pagesUpdate: mocks.pagesUpdate,
+  }),
+}));
+```
+
+`vi.hoisted()` is required because `vi.mock()` is hoisted above imports — the mock references must exist before the mocked package is loaded.
+
+## Rule 2 — Never mock internal modules
+
+No `vi.mock("@/lib/...")`, no `vi.mock("./sibling")`, no `vi.mock("../services/foo")`. Mocking your own code is how tests pass while production breaks: the mock drifts from the real module, silently.
+
+If you feel the need to mock an internal module, the module you are testing needs a **dependency injection seam**: an optional parameter with a sensible default. Production calls it with no argument and gets the real dependency; tests pass a fake.
+
+```ts
+// production code — default parameter is the seam
+export function buildContextSnapshot(args: {
+  userId: string;
+  getTools?: typeof getOrchestratorTools; // seam
+}): ContextSnapshot {
+  const { getTools = getOrchestratorTools } = args;
+  const tools = getTools();
+  // ...
+}
+
+// test — pass a fake, no mocking
+test("includes tool names", () => {
+  const snapshot = buildContextSnapshot({
+    userId: "u1",
+    getTools: () => ({ currentTime: tool(...), documentation: tool(...) }),
+  });
+  expect(snapshot.tools).toContain("currentTime");
+});
+```
+
+If adding a seam is awkward, the design likely needs it anyway — collaborators should be injectable.
+
+## Rule 3 — Shared fixtures in one place
+
+Put reusable fakes, builders, and fixtures under a single directory. In this repo that is `src/lib/test/`:
+
+```
+src/lib/test/
+  constants.ts       // shared test constants
+  types.ts           // fake/mock type definitions
+  fixtures/
+    sdks.ts          // class builders for third-party SDKs
+    redis.ts         // in-memory Redis with real-semantic get/set/del/sadd
+    discord.ts       // message/command context helpers
+    ai.ts            // agent/model fakes
+    http.ts          // fetch mock
+    sandbox.ts       // in-memory sandbox provider
+  index.ts           // barrel export
+```
+
+Import test utilities from the barrel. Exclude the directory from coverage.
+
+## Rule 4 — No duplication
+
+If two tests need the same fake setup, fake HTTP response, or builder, **extract it to `src/lib/test/`**. Do not copy a mock implementation between files. Do not keep two variants of the same fixture that drift apart.
+
+Before writing a new helper in a test file, grep `src/lib/test/` for an existing one.
+
+## Rule 5 — Colocation and naming
+
+- Unit tests live next to the file they test: `foo.ts` → `foo.test.ts`
+- Integration tests use `foo.integration.test.ts` and run in a separate suite
+- One `describe` block per public function is usually right; one `test` / `it` per behavior
+- `beforeEach(() => vi.clearAllMocks())` when hoisted mocks are used, to prevent cross-test leakage
+
+## Rule 6 — Test behavior, not implementation
+
+Assert on what a caller can observe: return values, thrown errors, state that is later queryable through a public API, calls that went out through mocked boundaries.
+
+Do not assert on private fields, call counts of internal methods, or the order of internal steps unless order is part of the contract.
+
+If the only way to assert what you want is to reach into internals, the module is missing an observable surface — add one (return more structured data, expose a query method) before writing the test.
+
+## Rule 7 — No shortcuts
+
+Each of these is a red flag. Fix the underlying issue instead:
+
+- `as any`, `as unknown as X`, or `@ts-expect-error` to silence type errors — make the types correct
+- `.skip`, `.todo`, `.only` committed to main — land green or don't land
+- `expect(() => fn()).not.toThrow()` as the only assertion — assert the actual result
+- Tests that pass with the implementation commented out — they are testing mocks, not code
+- Copy-pasted mock setups — extract to `src/lib/test/`
+- `eslint-disable` on test files — the lint rule exists for a reason in tests too
+
+## Review checklist
+
+When writing or reviewing a test file, walk this list:
+
+- [ ] Every `vi.mock(...)` points at a third-party package, not a `@/` or relative path
+- [ ] No internal module is mocked; collaborators are injected via seams
+- [ ] Shared fakes/fixtures come from `src/lib/test/`, not defined inline or duplicated
+- [ ] Each test asserts observable behavior, not implementation details
+- [ ] No `as any`, no `.skip` / `.todo`, no `eslint-disable`
+- [ ] `beforeEach` clears mock state when hoisted mocks are used
+- [ ] Test name reads as a sentence about what the code does
+- [ ] Test would fail if the implementation it covers were broken
+
+## When to deviate
+
+Rules above cover unit tests. Integration tests are run through a separate suite and may mock fewer boundaries (real DB, real Redis via a container). End-to-end tests mock even less. The discipline — fakes at the boundary, no internal mocks, shared fixtures in one place — still applies; the boundary just moves.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/deslop/SKILL.md` — simplifies recently modified code while preserving behavior, with a dedicated "Remove indirection" rule targeting factory wrappers, one-line expression wrappers, pass-through forwarders, and single-use constructor builders; includes a "Patterns to keep" section so DI seams and named domain helpers survive.
- Adds `.claude/skills/unit-test-quality/SKILL.md` — enforces mocking only third-party SDKs at the package boundary via `vi.hoisted()` + `vi.mock("package")`, dependency-injection seams instead of internal mocks, shared fixtures in `src/lib/test/` with no duplication, and a no-shortcuts rule (no `as any`, no `.skip`/`.todo`, no `eslint-disable`).
- Includes a review checklist in `unit-test-quality` to walk test files against.

## Test plan

- [x] `bun format`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test` (937 passed)
- [x] `bun test:coverage` (99.58% statements)
- [x] `bun knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)