### PR TITLE
refactor: rename phoenix-agent identifiers to wack-hacker

### DIFF
--- a/docs/agents/code-sandbox.md
+++ b/docs/agents/code-sandbox.md
@@ -55,7 +55,7 @@ Unlike the other delegates, `delegate_code` doesn't just call APIs. It provision
 2. Mints a fresh GitHub App installation access token via Octokit (`octokit.auth({ type: "installation" })`).
 3. Calls `getOrCreateSession({ threadKey, repo, githubToken, gitUser, baseSnapshotId })`:
    - If Redis has a live session for this thread, it's reused. The subagent picks up the same feature branch from the previous turn.
-   - Otherwise a new `VercelSandbox` is created, the repo is cloned, and a feature branch (`phoenix-agent/<slug>-<suffix>`) is checked out.
+   - Otherwise a new `VercelSandbox` is created, the repo is cloned, and a feature branch (`wack-hacker/<slug>-<suffix>`) is checked out.
 4. Returns `{ sandbox, repo, branch, repoDir, threadKey }` — this object is wired into every coding tool's `execute(input, runtime)` via `runtime.experimental_context`.
 
 The `Sandbox` interface in `src/lib/sandbox/types.ts` is the contract the coding tools code against. Today the only implementation is `VercelSandbox`, but the abstraction exists so tests can swap in an in-memory fake.

--- a/src/lib/ai/skills/code/SKILL.md
+++ b/src/lib/ai/skills/code/SKILL.md
@@ -7,7 +7,7 @@ minRole: admin
 mode: delegate
 ---
 
-You are Phoenix's coding agent. You run in an isolated Vercel Sandbox that has the target repository cloned on a fresh feature branch. Your job is to fully complete the delegated task and leave the branch in a state where committing and opening a PR produces a valid, verified change.
+You are the coding agent. You run in an isolated Vercel Sandbox that has the target repository cloned on a fresh feature branch. Your job is to fully complete the delegated task and leave the branch in a state where committing and opening a PR produces a valid, verified change.
 
 **The sandbox handles git automatically.** After your turn ends, the system commits your changes, pushes the branch, and opens (or updates) a pull request — using your final summary to generate the commit message. You do **not** run `git commit`, `git push`, or `gh pr create` yourself.
 

--- a/src/lib/ai/tools/code/bash.test.ts
+++ b/src/lib/ai/tools/code/bash.test.ts
@@ -15,7 +15,7 @@ function makeCtx(
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
     ...overrides,

--- a/src/lib/ai/tools/code/delegation.ts
+++ b/src/lib/ai/tools/code/delegation.ts
@@ -43,7 +43,7 @@ function escapeRegExp(value: string): string {
 export type { CodeDelegationInput } from "./types.ts";
 
 const GIT_USER = {
-  name: "phoenix-bot",
+  name: "wack-hacker[bot]",
   email: "bot@purduehackers.com",
 };
 

--- a/src/lib/ai/tools/code/edit.test.ts
+++ b/src/lib/ai/tools/code/edit.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/glob.test.ts
+++ b/src/lib/ai/tools/code/glob.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/grep.test.ts
+++ b/src/lib/ai/tools/code/grep.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/list_dir.test.ts
+++ b/src/lib/ai/tools/code/list_dir.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/read.test.ts
+++ b/src/lib/ai/tools/code/read.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/run_checks.test.ts
+++ b/src/lib/ai/tools/code/run_checks.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/ai/tools/code/utils.test.ts
+++ b/src/lib/ai/tools/code/utils.test.ts
@@ -10,7 +10,7 @@ describe("getSandboxContext", () => {
     const ctx = {
       sandbox,
       repo: "purduehackers/x",
-      branch: "phoenix-agent/a",
+      branch: "wack-hacker/a",
       repoDir: "/vercel/sandbox",
       threadKey: "T1",
     };

--- a/src/lib/ai/tools/code/write.test.ts
+++ b/src/lib/ai/tools/code/write.test.ts
@@ -10,7 +10,7 @@ function makeCtx(sandbox: InMemorySandbox): CodingSandboxContext {
   return {
     sandbox,
     repo: "purduehackers/x",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     threadKey: "T1",
   };

--- a/src/lib/sandbox/hibernate.test.ts
+++ b/src/lib/sandbox/hibernate.test.ts
@@ -10,7 +10,7 @@ function seedMetadata(expiresIn = 10 * 60 * 1000): SandboxSessionMetadata {
   return {
     sandboxId: "sb-1",
     repo: "purduehackers/agent-sandbox-test",
-    branch: "phoenix-agent/a",
+    branch: "wack-hacker/a",
     repoDir: "/vercel/sandbox",
     expiresAt: Date.now() + expiresIn,
   };

--- a/src/lib/sandbox/hooks.test.ts
+++ b/src/lib/sandbox/hooks.test.ts
@@ -26,8 +26,8 @@ function recordingSandbox(
 
 const BASE_CONFIG = {
   repo: "purduehackers/agent-sandbox-test",
-  branch: "phoenix-agent/test",
-  gitUser: { name: "Phoenix Bot", email: "bot@example.com" },
+  branch: "wack-hacker/test",
+  gitUser: { name: "wack-hacker[bot]", email: "bot@example.com" },
 };
 
 describe("buildSandboxHooks — skipCloneAndBranch", () => {

--- a/src/lib/sandbox/session.test.ts
+++ b/src/lib/sandbox/session.test.ts
@@ -15,7 +15,7 @@ import {
 // `@upstash/redis` is a third-party client we only need to stub for the
 // "default options" branch tests below (where we call session functions
 // without passing `redis`). Mocking an external library is OK; this
-// deliberately avoids mocking any Phoenix module. Hoisted so the mock is
+// deliberately avoids mocking any internal module. Hoisted so the mock is
 // installed before `session.ts` imports `@upstash/redis`.
 const envRedisStore = vi.hoisted(() => ({
   redis: null as ReturnType<typeof createMemoryRedis> | null,
@@ -33,7 +33,7 @@ const baseParams = {
   threadKey: "T1",
   repo: "purduehackers/agent-sandbox-test",
   githubToken: "ghs_token",
-  gitUser: { name: "Phoenix Bot", email: "bot@example.com" },
+  gitUser: { name: "wack-hacker[bot]", email: "bot@example.com" },
 };
 
 function redisKey(threadKey = baseParams.threadKey): string {
@@ -44,7 +44,7 @@ function sessionMetadata(overrides: Partial<SandboxSessionMetadata> = {}): Sandb
   return {
     sandboxId: "sb-existing",
     repo: baseParams.repo,
-    branch: "phoenix-agent/existing",
+    branch: "wack-hacker/existing",
     repoDir: "/vercel/sandbox",
     expiresAt: Date.now() + 10 * 60 * 1000,
     ...overrides,
@@ -70,7 +70,7 @@ describe("getOrCreateSession — fresh provisioning", () => {
     expect(createCalls).toHaveLength(1);
     expect(createCalls[0]!.repo).toBe(baseParams.repo);
     expect(createCalls[0]!.skipCloneAndBranch).toBeFalsy();
-    expect(session.metadata.branch).toMatch(/^phoenix-agent\/agent-sandbox-test-/);
+    expect(session.metadata.branch).toMatch(/^wack-hacker\/agent-sandbox-test-/);
     expect(session.metadata.sandboxId).toBe("sb-0");
     expect(provisionedCount).toBe(1);
   });
@@ -267,7 +267,7 @@ describe("getOrCreateSession — resume from hibernation", () => {
     expect(session.fresh).toBe(true);
     expect(pv.createCalls[0]!.baseSnapshotId).toBe("snap-1");
     expect(pv.createCalls[0]!.skipCloneAndBranch).toBe(true);
-    expect(session.metadata.branch).toBe("phoenix-agent/existing");
+    expect(session.metadata.branch).toBe("wack-hacker/existing");
   });
 });
 
@@ -360,7 +360,7 @@ describe("generateBranchName (via provisionFreshSession)", () => {
       provider,
       onProvisioned: async () => {},
     });
-    expect(session.metadata.branch).toMatch(/^phoenix-agent\/repo-[a-z0-9]+$/);
+    expect(session.metadata.branch).toMatch(/^wack-hacker\/repo-[a-z0-9]+$/);
   });
 });
 

--- a/src/lib/sandbox/session.ts
+++ b/src/lib/sandbox/session.ts
@@ -36,7 +36,7 @@ function generateBranchName(repo: string): string {
   const [, name] = repo.split("/");
   const slug = (name ?? "repo").toLowerCase().replace(/[^a-z0-9-]/g, "-");
   const suffix = Math.random().toString(36).slice(2, 8);
-  return `phoenix-agent/${slug}-${suffix}`;
+  return `wack-hacker/${slug}-${suffix}`;
 }
 
 /** Exposed so the lifecycle workflow can fetch the current metadata. */

--- a/src/lib/test/fixtures/sandbox.ts
+++ b/src/lib/test/fixtures/sandbox.ts
@@ -191,7 +191,7 @@ const defaultExecHandler: ExecHandler = async () => ({
 /**
  * Build a `SandboxProvider` backed by `InMemorySandbox` for unit tests. The
  * returned state object exposes call logs + helpers so tests can drive and
- * assert on provider behaviour without mocking any Phoenix modules.
+ * assert on provider behaviour without mocking any internal modules.
  *
  * - `create` spawns a new `InMemorySandbox` for each call, wraps its `stop`
  *   to record the id in `stoppedIds`, and caches the sandbox for subsequent


### PR DESCRIPTION
## Summary

- Sweeps the remaining `phoenix` / `phoenix-agent` / `phoenix-bot` / `Phoenix Bot` identifiers left over from the project rename to wack-hacker.
- Coding-subagent branches now use the `wack-hacker/<slug>-<suffix>` prefix (`src/lib/sandbox/session.ts`); bot commits are authored by `wack-hacker[bot]` (`src/lib/ai/tools/code/delegation.ts`); the SKILL.md preamble drops the project name in favor of "You are the coding agent."
- Test fixtures, regex matchers, and two stale comments are updated to match; the auto-generated `src/lib/ai/skills/generated/manifest.ts` is gitignored and regenerated at build.

## Test plan

- [x] `bun format`
- [x] `bun lint` — 0 warnings / 0 errors
- [x] `bun typecheck` — clean
- [x] `bun run test` — 937/937 passing
- [x] `bun test:coverage` — 99.58% stmt coverage
- [x] `bun knip` — clean
- [x] `rg -i phoenix` across the repo (outside node_modules) returns zero hits