### PR TITLE
refactor(env): rename VERCEL_EDGE_CONFIG_ID to DASHBOARD_EDGE_CONFIG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,7 @@ KV_REST_API_TOKEN=
 
 # Vercel
 VERCEL_API_TOKEN=
-VERCEL_EDGE_CONFIG_ID=
+DASHBOARD_EDGE_CONFIG=
 
 # SerpAPI (Amazon product search via the shopping subagent)
 SERPAPI_API_KEY=

--- a/docs/deployment/env.md
+++ b/docs/deployment/env.md
@@ -10,7 +10,7 @@ The full list changes often; the canonical source is always [`src/env.ts`](../..
 - **Cron auth** — `CRON_SECRET` (bearer token for `/api/crons/*`).
 - **AI** — `GROQ_API_KEY` (used by one specialized tool). The AI SDK Gateway authenticates via the standard `VERCEL_*` OIDC vars loaded by the `vercel()` preset.
 - **Integrations — engineering** — Linear (`LINEAR_API_KEY`), Notion (`NOTION_TOKEN`), GitHub App (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_ORG`), Figma (`FIGMA_ACCESS_TOKEN`, `FIGMA_TEAM_ID`), Sentry (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`).
-- **Integrations — ops & platform** — Vercel (`VERCEL_API_TOKEN`, `VERCEL_EDGE_CONFIG_ID`, `EDGE_CONFIG`), Hack Club Bank (`HCB_ORG_SLUG`), SerpAPI for `delegate_shopping` (`SERPAPI_API_KEY`).
+- **Integrations — ops & platform** — Vercel (`VERCEL_API_TOKEN`, `DASHBOARD_EDGE_CONFIG`, `EDGE_CONFIG`), Hack Club Bank (`HCB_ORG_SLUG`), SerpAPI for `delegate_shopping` (`SERPAPI_API_KEY`).
 - **Integrations — sales & CMS** — Resend (`RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`), Hunter.io (`HUNTER_API_KEY`), Payload CMS (`PAYLOAD_CMS_API_KEY`), ask.purduehackers.com (`PHACK_ASK_API_KEY`), Phack API (`PHACK_API_TOKEN`).
 - **Integrations — ships** — external gallery service at ships.purduehackers.com (`SHIP_API_KEY`; base URL is a hardcoded constant in `src/bot/integrations/ships/client.ts`). The bot no longer touches the ship DB or R2 directly.
 - **Storage** — Upstash Redis (`KV_REST_API_URL`, `KV_REST_API_TOKEN`), Turso main (`TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`), privacy DB (`PRIVACY_DB_API_KEY`).

--- a/src/bot/handlers/commands/hack-night/index.ts
+++ b/src/bot/handlers/commands/hack-night/index.ts
@@ -6,6 +6,7 @@ import { defineCommand } from "@/bot/commands/define";
 import { isOrganizer, respond } from "@/bot/commands/helpers";
 import { env } from "@/env";
 import { DISCORD_IDS } from "@/lib/protocol/constants";
+import { getDashboardEdgeConfigId } from "@/lib/protocol/organizers/edge-config";
 
 const DEFAULT_EMOJI = "\u{1F319}";
 
@@ -16,7 +17,7 @@ function stripLeadingEmoji(name: string): string {
 async function updateEdgeConfig(version: string): Promise<void> {
   const vercel = new Vercel({ bearerToken: env.VERCEL_API_TOKEN });
   await vercel.edgeConfig.patchEdgeConfigItems({
-    edgeConfigId: env.VERCEL_EDGE_CONFIG_ID,
+    edgeConfigId: getDashboardEdgeConfigId(),
     requestBody: {
       items: [{ operation: "upsert", key: "version", value: version }],
     },

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,7 +26,7 @@ export const env = createEnv({
     KV_REST_API_URL: z.string(),
     KV_REST_API_TOKEN: z.string(),
     VERCEL_API_TOKEN: z.string(),
-    VERCEL_EDGE_CONFIG_ID: z.string(),
+    DASHBOARD_EDGE_CONFIG: z.string(),
     EDGE_CONFIG: z.string(),
     SENTRY_AUTH_TOKEN: z.string(),
     SENTRY_ORG: z.string(),

--- a/src/lib/protocol/organizers/edge-config.test.ts
+++ b/src/lib/protocol/organizers/edge-config.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { parseSpy } = vi.hoisted(() => ({ parseSpy: vi.fn() }));
+
+vi.mock("@vercel/edge-config", () => ({
+  parseConnectionString: parseSpy,
+}));
+
+import { getDashboardEdgeConfigId } from "./edge-config.ts";
+
+beforeEach(() => {
+  parseSpy.mockReset();
+});
+
+describe("getDashboardEdgeConfigId", () => {
+  it("returns the parsed id when the connection string is valid", () => {
+    parseSpy.mockReturnValue({
+      baseUrl: "https://edge-config.vercel.com",
+      id: "ecfg_abc",
+      token: "tkn",
+      version: "1",
+      type: "vercel",
+    });
+    expect(getDashboardEdgeConfigId()).toBe("ecfg_abc");
+  });
+
+  it("throws when the connection string cannot be parsed", () => {
+    parseSpy.mockReturnValue(null);
+    expect(() => getDashboardEdgeConfigId()).toThrow(
+      /DASHBOARD_EDGE_CONFIG is not a valid Edge Config connection string/,
+    );
+  });
+});

--- a/src/lib/protocol/organizers/edge-config.ts
+++ b/src/lib/protocol/organizers/edge-config.ts
@@ -1,0 +1,11 @@
+import { parseConnectionString } from "@vercel/edge-config";
+
+import { env } from "@/env";
+
+export function getDashboardEdgeConfigId(): string {
+  const connection = parseConnectionString(env.DASHBOARD_EDGE_CONFIG);
+  if (!connection) {
+    throw new Error("DASHBOARD_EDGE_CONFIG is not a valid Edge Config connection string");
+  }
+  return connection.id;
+}

--- a/src/lib/protocol/organizers/writer.test.ts
+++ b/src/lib/protocol/organizers/writer.test.ts
@@ -7,6 +7,13 @@ const { mockGet, patchSpy } = vi.hoisted(() => ({
 
 vi.mock("@vercel/edge-config", () => ({
   createClient: () => ({ get: mockGet }),
+  parseConnectionString: () => ({
+    baseUrl: "https://edge-config.vercel.com",
+    id: "ecfg_test",
+    token: "test-token",
+    version: "1",
+    type: "vercel",
+  }),
 }));
 
 vi.mock("@vercel/sdk", () => ({

--- a/src/lib/protocol/organizers/writer.ts
+++ b/src/lib/protocol/organizers/writer.ts
@@ -5,6 +5,7 @@ import { env } from "@/env";
 import type { Organizer, OrganizerPatch, UpsertResult } from "./types.ts";
 
 import { EDITABLE_PLATFORMS, ORGANIZER_KEY_PREFIX } from "./constants.ts";
+import { getDashboardEdgeConfigId } from "./edge-config.ts";
 import { getOrganizer } from "./reader.ts";
 
 /**
@@ -44,7 +45,7 @@ export async function upsertOrganizer(
 
   const vercel = new Vercel({ bearerToken: env.VERCEL_API_TOKEN });
   await vercel.edgeConfig.patchEdgeConfigItems({
-    edgeConfigId: env.VERCEL_EDGE_CONFIG_ID,
+    edgeConfigId: getDashboardEdgeConfigId(),
     requestBody: {
       items: [{ operation: "upsert", key: `${ORGANIZER_KEY_PREFIX}${discordId}`, value: next }],
     },


### PR DESCRIPTION
## Summary

- Renamed `VERCEL_EDGE_CONFIG_ID` → `DASHBOARD_EDGE_CONFIG`. The value always held a full Edge Config connection string (the Hack Night dashboard's store), so the "ID" suffix was misleading.
- Extracted the actual edge config id at write call sites via a new helper `getDashboardEdgeConfigId()` in `src/lib/protocol/organizers/edge-config.ts`, which uses `parseConnectionString` from `@vercel/edge-config`.
- Updated `.env.example`, `docs/deployment/env.md`, both write sites (`hack-night/index.ts`, `organizers/writer.ts`), and the writer test mock to expose `parseConnectionString`.

## Deployment follow-up

Before this merges (or immediately after), add `DASHBOARD_EDGE_CONFIG` with the same connection-string value across Vercel's development / preview / production environments and remove `VERCEL_EDGE_CONFIG_ID`. Skipping this step fails the next deploy at boot with a Zod validation error.

## Test plan

- [x] `bun format`, `bun lint`, `bun typecheck`
- [x] `bun run test` (943/943)
- [x] `bun test:coverage`
- [x] `bun knip`
- [x] Grep for `VERCEL_EDGE_CONFIG_ID` returns zero matches outside `node_modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)