### PR TITLE
feat(observability): OTEL spans, wide-event logs, expanded metrics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@noble/hashes": "^2.2.0",
         "@notionhq/client": "^5.18.0",
         "@octokit/auth-app": "^8.2.0",
+        "@opentelemetry/api": "^1.9.1",
         "@payloadcms/sdk": "^3.83.0",
         "@purduehackers/discord-markdown-utils": "^0.0.4",
         "@sentry/api": "^0.113.0",
@@ -542,13 +543,15 @@
 
     "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.6.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ=="],
 
     "@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.215.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/otlp-exporter-base": "0.215.0", "@opentelemetry/otlp-transformer": "0.215.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/sdk-trace-base": "2.7.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w=="],
 
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
 
@@ -594,9 +597,17 @@
 
     "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.24.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ=="],
 
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.215.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/otlp-transformer": "0.215.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.215.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.215.0", "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/sdk-logs": "0.215.0", "@opentelemetry/sdk-metrics": "2.7.0", "@opentelemetry/sdk-trace-base": "2.7.0", "protobufjs": "^8.0.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng=="],
+
     "@opentelemetry/redis-common": ["@opentelemetry/redis-common@0.38.2", "", {}, "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.215.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.215.0", "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w=="],
 
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw=="],
 
@@ -781,6 +792,26 @@
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@prisma/instrumentation": ["@prisma/instrumentation@7.6.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@purduehackers/discord-markdown-utils": ["@purduehackers/discord-markdown-utils@0.0.4", "", { "dependencies": { "mdast-util-gfm-autolink-literal": "^2.0.1", "micromark-extension-gfm-autolink-literal": "^2.1.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "remark-parse": "^11.0.0", "typescript": "^5", "unified": "^11.0.0" } }, "sha512-f/yWwsx+QYeHr131GaossW/K6o0d/g2d/gJrujEgxdVpprvQmompwaNyMM4dEjzIaa/MmvAXD9iLDy9fdgy7Og=="],
 
@@ -2148,6 +2179,8 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
@@ -2423,6 +2456,8 @@
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -2920,7 +2955,31 @@
 
     "@oclif/core/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.215.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.215.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
@@ -2929,12 +2988,6 @@
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "@sentry/nextjs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@sentry/node/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@sentry/vercel-edge/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@swc/cli/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -3009,6 +3062,8 @@
     "@xhmikosr/downloader/defaults": ["defaults@2.0.2", "", {}, "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA=="],
 
     "@xhmikosr/downloader/file-type": ["file-type@20.5.0", "", { "dependencies": { "@tokenizer/inflate": "^0.2.6", "strtok3": "^10.2.0", "token-types": "^6.0.0", "uint8array-extras": "^1.4.0" } }, "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg=="],
+
+    "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -3607,10 +3662,6 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
-    "@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@swc/cli/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
+  // Bump the per-attribute length cap before Sentry's OTEL SDK reads env. The
+  // AI SDK stores full prompt messages and tool-call args/results as span
+  // attributes, which routinely exceed the 1024 default. 64 KB keeps the full
+  // conversation history on `ai.prompt.messages` and tool inputs/outputs so
+  // traces in Sentry show the whole agent interaction.
+  if (!process.env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT) {
+    process.env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT = "65536";
+  }
+
   try {
     const { register } = await import("./src/lib/evlog");
     register();

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@noble/hashes": "^2.2.0",
     "@notionhq/client": "^5.18.0",
     "@octokit/auth-app": "^8.2.0",
+    "@opentelemetry/api": "^1.9.1",
     "@payloadcms/sdk": "^3.83.0",
     "@purduehackers/discord-markdown-utils": "^0.0.4",
     "@sentry/api": "^0.113.0",

--- a/src/app/api/discord/events/route.ts
+++ b/src/app/api/discord/events/route.ts
@@ -1,6 +1,7 @@
-import { log } from "evlog";
-
 import { ConversationStore } from "@/bot/store";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { PacketCodec } from "@/lib/protocol/packets";
 import { handleCallback } from "@/lib/tasks/queue/client";
 import { processEvent } from "@/server/process-event";
@@ -10,10 +11,36 @@ const MAX_RETRIES = 3;
 export const POST = handleCallback<string>(
   async (encoded, metadata) => {
     const packet = PacketCodec.decode(encoded);
-    log.info("events", `Received ${packet.type} (attempt ${metadata.deliveryCount})`);
-
-    const store = new ConversationStore();
-    await processEvent(packet, store);
+    return withSpan(
+      "discord.event",
+      {
+        "packet.type": packet.type,
+        "delivery.count": metadata.deliveryCount,
+      },
+      async () => {
+        const logger = createWideLogger({
+          op: "discord.event.callback",
+          event: { type: packet.type },
+          queue: { delivery_count: metadata.deliveryCount, message_id: metadata.messageId },
+        });
+        const startTime = Date.now();
+        countMetric("discord.event.callback_received", { type: packet.type });
+        try {
+          const store = new ConversationStore();
+          await processEvent(packet, store);
+          logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+        } catch (err) {
+          countMetric("discord.event.callback_error", { type: packet.type });
+          logger.error(err as Error);
+          logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+          throw err;
+        } finally {
+          recordDuration("discord.event.callback_duration", Date.now() - startTime, {
+            type: packet.type,
+          });
+        }
+      },
+    );
   },
   {
     retry: (_error, metadata) => {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,11 +1,13 @@
 import { API } from "@discordjs/core/http-only";
 import { REST } from "@discordjs/rest";
-import { log } from "evlog";
 
 import type { TaskEnvelope, TaskHandler } from "@/lib/tasks/queue/types";
 
 import { ConversationStore } from "@/bot/store";
 import { env } from "@/env";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { handleCallback, send } from "@/lib/tasks/queue/client";
 import { TASK_TOPIC } from "@/lib/tasks/queue/constants";
 import { InvalidTaskPayloadError, UnknownTaskError } from "@/lib/tasks/queue/errors";
@@ -17,49 +19,94 @@ const MAX_RETRIES = 3;
 
 export const POST = handleCallback<TaskEnvelope>(
   async (envelope, metadata) => {
-    const store = new ConversationStore();
+    return withSpan(
+      "task.callback",
+      {
+        "task.name": envelope.task,
+        "task.delivery_count": metadata.deliveryCount,
+        "queue.message_id": metadata.messageId,
+      },
+      async () => {
+        const logger = createWideLogger({
+          op: "task.callback",
+          task: { name: envelope.task },
+          queue: { message_id: metadata.messageId, delivery_count: metadata.deliveryCount },
+        });
+        const startTime = Date.now();
+        countMetric("task.received", { name: envelope.task });
+        try {
+          const store = new ConversationStore();
 
-    if (!(await store.dedup(`task:${metadata.messageId}`))) {
-      log.info("tasks", `Dedup hit for ${envelope.task}, skipping`);
-      return;
-    }
+          if (!(await store.dedup(`task:${metadata.messageId}`))) {
+            countMetric("task.dedup_hit", { name: envelope.task });
+            logger.emit({ outcome: "dedup_hit", duration_ms: Date.now() - startTime });
+            return;
+          }
 
-    const handler = taskMap.get(envelope.task);
-    if (!handler) {
-      throw new UnknownTaskError(envelope.task);
-    }
+          const handler = taskMap.get(envelope.task);
+          if (!handler) {
+            countMetric("task.unknown", { name: envelope.task });
+            const err = new UnknownTaskError(envelope.task);
+            logger.error(err);
+            logger.emit({ outcome: "unknown_task", duration_ms: Date.now() - startTime });
+            throw err;
+          }
 
-    const parsed = handler.schema.safeParse(envelope.payload);
-    if (!parsed.success) {
-      throw new InvalidTaskPayloadError(envelope.task, parsed.error);
-    }
+          const parsed = handler.schema.safeParse(envelope.payload);
+          if (!parsed.success) {
+            countMetric("task.invalid_payload", { name: envelope.task });
+            const err = new InvalidTaskPayloadError(envelope.task, parsed.error);
+            logger.error(err);
+            logger.emit({ outcome: "invalid_payload", duration_ms: Date.now() - startTime });
+            throw err;
+          }
 
-    log.info("tasks", `Running ${envelope.task} (attempt ${metadata.deliveryCount})`);
+          const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
+          await handler.handle(parsed.data, discord);
 
-    const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
-    await handler.handle(parsed.data, discord);
+          if (envelope.recurring) {
+            const { delaySeconds, maxRepetitions, repetitionCount = 0 } = envelope.recurring;
+            const next = repetitionCount + 1;
 
-    if (envelope.recurring) {
-      const { delaySeconds, maxRepetitions, repetitionCount = 0 } = envelope.recurring;
-      const next = repetitionCount + 1;
+            if (maxRepetitions === undefined || next < maxRepetitions) {
+              await send(
+                TASK_TOPIC,
+                {
+                  ...envelope,
+                  recurring: { ...envelope.recurring, repetitionCount: next },
+                },
+                { delaySeconds },
+              );
+              countMetric("task.recurring_enqueued", { name: envelope.task });
+              logger.set({
+                recurring: {
+                  next_iteration: next,
+                  max_repetitions: maxRepetitions,
+                  delay_seconds: delaySeconds,
+                },
+              });
+            } else {
+              countMetric("task.recurring_complete", { name: envelope.task });
+              logger.set({
+                recurring: { completed: true, max_repetitions: maxRepetitions },
+              });
+            }
+          }
 
-      if (maxRepetitions === undefined || next < maxRepetitions) {
-        await send(
-          TASK_TOPIC,
-          {
-            ...envelope,
-            recurring: { ...envelope.recurring, repetitionCount: next },
-          },
-          { delaySeconds },
-        );
-        log.info(
-          "tasks",
-          `Re-enqueued ${envelope.task} (${next}/${maxRepetitions ?? "∞"}) in ${delaySeconds}s`,
-        );
-      } else {
-        log.info("tasks", `${envelope.task} completed all ${maxRepetitions} repetitions`);
-      }
-    }
+          countMetric("task.completed", { name: envelope.task });
+          logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+        } catch (err) {
+          countMetric("task.error", { name: envelope.task });
+          if (!(err instanceof UnknownTaskError) && !(err instanceof InvalidTaskPayloadError)) {
+            logger.error(err as Error);
+            logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+          }
+          throw err;
+        } finally {
+          recordDuration("task.duration", Date.now() - startTime, { name: envelope.task });
+        }
+      },
+    );
   },
   {
     retry: (_error, metadata) => {

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,52 +1,71 @@
-import { log } from "evlog";
 import { Webhook, WebhookVerificationError } from "svix";
 
 import { ConversationStore } from "@/bot/store";
 import { env } from "@/env";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { applyResendEvent } from "@/lib/sales/resend-webhook";
 
 export async function POST(req: Request): Promise<Response> {
-  const body = await req.text();
-  const headers = {
-    "svix-id": req.headers.get("svix-id") ?? "",
-    "svix-timestamp": req.headers.get("svix-timestamp") ?? "",
-    "svix-signature": req.headers.get("svix-signature") ?? "",
-  };
+  return withSpan("webhook.resend", { "http.route": "/api/webhooks/resend" }, async () => {
+    const logger = createWideLogger({
+      op: "webhook.resend",
+      http: { method: "POST", route: "/api/webhooks/resend" },
+    });
+    const startTime = Date.now();
+    countMetric("webhook.resend.received");
+    try {
+      const body = await req.text();
+      const headers = {
+        "svix-id": req.headers.get("svix-id") ?? "",
+        "svix-timestamp": req.headers.get("svix-timestamp") ?? "",
+        "svix-signature": req.headers.get("svix-signature") ?? "",
+      };
+      if (headers["svix-id"]) logger.set({ resend: { svix_id: headers["svix-id"] } });
 
-  let event: unknown;
-  try {
-    event = new Webhook(env.RESEND_WEBHOOK_SECRET).verify(body, headers);
-  } catch (err) {
-    if (err instanceof WebhookVerificationError) {
-      log.warn("resend", `Signature verification failed: ${err.message}`);
-      return new Response("invalid signature", { status: 401 });
+      let event: unknown;
+      try {
+        event = new Webhook(env.RESEND_WEBHOOK_SECRET).verify(body, headers);
+      } catch (err) {
+        if (err instanceof WebhookVerificationError) {
+          countMetric("webhook.resend.unauthorized");
+          logger.warn("signature verification failed", { reason: err.message });
+          logger.emit({ outcome: "unauthorized", duration_ms: Date.now() - startTime });
+          return new Response("invalid signature", { status: 401 });
+        }
+        throw err;
+      }
+
+      const svixId = headers["svix-id"];
+      const store = svixId ? new ConversationStore() : null;
+      const dedupKey = svixId ? `resend:${svixId}` : null;
+
+      // Claim the dedup slot. If the claim is already held, a prior delivery of
+      // this event was successfully applied and we short-circuit. The claim is
+      // only retained when processing succeeds — failures release it so Resend's
+      // retry can attempt processing again.
+      if (store && dedupKey && !(await store.dedup(dedupKey))) {
+        countMetric("webhook.resend.dedup_hit");
+        logger.emit({ outcome: "dedup_hit", duration_ms: Date.now() - startTime });
+        return new Response("ok", { status: 200 });
+      }
+
+      try {
+        await applyResendEvent(event);
+      } catch (err) {
+        countMetric("webhook.resend.error");
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        if (store && dedupKey) await store.releaseDedup(dedupKey);
+        return new Response("failed to apply event", { status: 500 });
+      }
+
+      countMetric("webhook.resend.processed");
+      logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+      return new Response("ok", { status: 200 });
+    } finally {
+      recordDuration("webhook.resend.duration", Date.now() - startTime);
     }
-    throw err;
-  }
-
-  const svixId = headers["svix-id"];
-  const store = svixId ? new ConversationStore() : null;
-  const dedupKey = svixId ? `resend:${svixId}` : null;
-
-  // Claim the dedup slot. If the claim is already held, a prior delivery of
-  // this event was successfully applied and we short-circuit. The claim is
-  // only retained when processing succeeds — failures release it so Resend's
-  // retry can attempt processing again.
-  if (store && dedupKey && !(await store.dedup(dedupKey))) {
-    log.info("resend", `Dedup hit for ${svixId}, skipping`);
-    return new Response("ok", { status: 200 });
-  }
-
-  try {
-    await applyResendEvent(event);
-  } catch (err) {
-    log.error(
-      "resend",
-      `Failed to apply event: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    if (store && dedupKey) await store.releaseDedup(dedupKey);
-    return new Response("failed to apply event", { status: 500 });
-  }
-
-  return new Response("ok", { status: 200 });
+  });
 }

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -1,6 +1,5 @@
 import type { API } from "@discordjs/core/http-only";
 
-import { log } from "evlog";
 import { start, resumeHook } from "workflow/api";
 
 import type { HandlerContext } from "@/bot/types";
@@ -11,9 +10,13 @@ import type { ChatHookEvent } from "@/workflows/chat";
 import { stripBotMention } from "@/bot/mention";
 import { fetchRecentMessages, fetchReferencedMessageContext } from "@/bot/recent-messages";
 import { AgentContext } from "@/lib/ai/context";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric } from "@/lib/metrics";
+import { setActiveSpanAttributes, withSpan } from "@/lib/otel/tracing";
 import { chatWorkflow } from "@/workflows/chat";
 
 type MessageData = MessageCreatePacketType["data"];
+type WideLogger = ReturnType<typeof createWideLogger>;
 
 async function fetchLeadInMessages(
   discord: API,
@@ -37,71 +40,173 @@ async function fetchLeadInMessages(
   return { recentMessages, referencedContext };
 }
 
-export async function handleMention(
-  packet: MessageCreatePacketType,
-  ctx: HandlerContext,
-): Promise<void> {
+interface MentionRouting {
+  sourceChannelId: string;
+  lookupThreadId: string | undefined;
+  alreadyInThread: boolean;
+}
+
+/**
+ * Try to resume an existing chat workflow by replaying the mention as a hook
+ * event. Returns `true` on success so the caller can short-circuit. Returns
+ * `false` when the workflow has expired; the caller should start fresh.
+ */
+async function tryResumeExistingWorkflow(args: {
+  packet: MessageCreatePacketType;
+  ctx: HandlerContext;
+  existing: { workflowRunId: string };
+  content: string;
+  routing: MentionRouting;
+  logger: WideLogger;
+}): Promise<boolean> {
+  const { packet, ctx, existing, content, routing, logger } = args;
+  setActiveSpanAttributes({ "chat.id": existing.workflowRunId });
+  logger.set({ chat: { id: existing.workflowRunId } });
+  try {
+    // No recentMessages fetch on resume: the lead-in context was pinned at
+    // workflow start; turn-to-turn conversation memory comes from the
+    // workflow's accumulated messages array instead.
+    const turnContext = AgentContext.fromPacket(packet).toJSON();
+    const event: ChatHookEvent = { type: "message", content, context: turnContext };
+    await resumeHook(existing.workflowRunId, event);
+    await ctx.store.touch(routing.sourceChannelId, routing.lookupThreadId);
+    countMetric("chat.workflow.resumed");
+    return true;
+  } catch (err) {
+    countMetric("chat.workflow.resume_expired");
+    logger.warn("resume failed, starting fresh", { reason: String(err) });
+    await ctx.store.delete(routing.sourceChannelId, routing.lookupThreadId);
+    return false;
+  }
+}
+
+/**
+ * Ensure the conversation has a dedicated thread. If the mention is already
+ * inside a thread we reuse it; otherwise we try to open one. A failure to open
+ * the thread is non-fatal — the conversation falls back to the source channel.
+ */
+async function ensureConversationThread(args: {
+  ctx: HandlerContext;
+  packet: MessageCreatePacketType;
+  routing: MentionRouting;
+  content: string;
+  logger: WideLogger;
+}): Promise<{
+  conversationChannelId: string;
+  conversationThreadId: string | undefined;
+  createdThread: { id: string; name: string } | undefined;
+}> {
+  const { ctx, packet, routing, content, logger } = args;
   const { data } = packet;
-  const sourceChannelId = data.channel.id;
-  const alreadyInThread = Boolean(data.thread);
-  const lookupThreadId = alreadyInThread ? sourceChannelId : undefined;
-
-  const content = stripBotMention(data.content, ctx.botUserId);
-
-  if (!content) {
-    await ctx.discord.channels.createMessage(sourceChannelId, {
-      content: "Hey! What can I help you with?",
-    });
-    return;
-  }
-
-  const existing = await ctx.store.get(sourceChannelId, lookupThreadId);
-
-  if (existing) {
-    log.info("mention", `Resuming workflow ${existing.workflowRunId} for ${data.author.username}`);
-    try {
-      // No recentMessages fetch on resume: the lead-in context was pinned at
-      // workflow start; turn-to-turn conversation memory comes from the
-      // workflow's accumulated messages array instead.
-      const turnContext = AgentContext.fromPacket(packet).toJSON();
-      const event: ChatHookEvent = { type: "message", content, context: turnContext };
-      await resumeHook(existing.workflowRunId, event);
-      await ctx.store.touch(sourceChannelId, lookupThreadId);
-      return;
-    } catch (err) {
-      log.info(
-        "mention",
-        `Workflow ${existing.workflowRunId} expired, starting fresh: ${String(err)}`,
-      );
-      await ctx.store.delete(sourceChannelId, lookupThreadId);
-    }
-  }
-
-  let conversationChannelId = sourceChannelId;
-  let conversationThreadId = lookupThreadId;
+  let conversationChannelId = routing.sourceChannelId;
+  let conversationThreadId = routing.lookupThreadId;
   let createdThread: { id: string; name: string } | undefined;
 
-  if (!alreadyInThread) {
+  if (!routing.alreadyInThread) {
     try {
       const threadName =
         `${data.author.nickname ?? data.author.username} — ${content.slice(0, 54)}`.trim();
       const thread = await ctx.discord.channels.createThread(
-        sourceChannelId,
+        routing.sourceChannelId,
         { name: threadName, auto_archive_duration: 60 },
         data.id,
       );
       conversationChannelId = thread.id;
       conversationThreadId = thread.id;
       createdThread = { id: thread.id, name: thread.name };
-      log.info("mention", `Created thread ${thread.id} for ${data.author.username}`);
+      countMetric("chat.thread.created");
+      logger.set({ chat: { thread_id: thread.id } });
     } catch (err) {
-      log.warn("mention", `Failed to create thread, replying in channel: ${String(err)}`);
+      countMetric("chat.thread.create_failed");
+      logger.warn("thread create failed", { reason: String(err) });
     }
   }
 
+  return { conversationChannelId, conversationThreadId, createdThread };
+}
+
+export async function handleMention(
+  packet: MessageCreatePacketType,
+  ctx: HandlerContext,
+): Promise<void> {
+  const { data } = packet;
+  const sourceChannelId = data.channel.id;
+
+  return withSpan(
+    "chat.mention",
+    {
+      "chat.channel_id": sourceChannelId,
+      "chat.user_id": data.author.id,
+      "chat.already_in_thread": Boolean(data.thread),
+    },
+    async () => {
+      const alreadyInThread = Boolean(data.thread);
+      const lookupThreadId = alreadyInThread ? sourceChannelId : undefined;
+      const logger = createWideLogger({
+        op: "chat.mention",
+        chat: {
+          channel_id: sourceChannelId,
+          user_id: data.author.id,
+          already_in_thread: alreadyInThread,
+        },
+      });
+      const startTime = Date.now();
+
+      const content = stripBotMention(data.content, ctx.botUserId);
+
+      if (!content) {
+        countMetric("chat.mention.empty");
+        await ctx.discord.channels.createMessage(sourceChannelId, {
+          content: "Hey! What can I help you with?",
+        });
+        logger.emit({ outcome: "empty", duration_ms: Date.now() - startTime });
+        return;
+      }
+
+      const existing = await ctx.store.get(sourceChannelId, lookupThreadId);
+      const routing: MentionRouting = { sourceChannelId, lookupThreadId, alreadyInThread };
+
+      if (existing) {
+        const resumed = await tryResumeExistingWorkflow({
+          packet,
+          ctx,
+          existing,
+          content,
+          routing,
+          logger,
+        });
+        if (resumed) {
+          logger.emit({ outcome: "resumed", duration_ms: Date.now() - startTime });
+          return;
+        }
+      }
+
+      await startFreshWorkflow({ packet, ctx, content, routing, logger, startTime });
+    },
+  );
+}
+
+/**
+ * Start a fresh chat workflow for a mention that didn't have a live resume
+ * target. Creates a thread (best-effort), fetches lead-in context, kicks off
+ * `chatWorkflow`, and emits the final wide event.
+ */
+async function startFreshWorkflow(args: {
+  packet: MessageCreatePacketType;
+  ctx: HandlerContext;
+  content: string;
+  routing: MentionRouting;
+  logger: WideLogger;
+  startTime: number;
+}): Promise<void> {
+  const { packet, ctx, content, routing, logger, startTime } = args;
+  const { data } = packet;
+  const { conversationChannelId, conversationThreadId, createdThread } =
+    await ensureConversationThread({ ctx, packet, routing, content, logger });
+
   const { recentMessages, referencedContext } = await fetchLeadInMessages(
     ctx.discord,
-    sourceChannelId,
+    routing.sourceChannelId,
     data,
   );
 
@@ -110,8 +215,6 @@ export async function handleMention(
     recentMessages,
     referencedContext,
   }).toJSON();
-
-  log.info("mention", `Starting workflow for ${data.author.username} in ${data.channel.name}`);
 
   const run = await start(chatWorkflow, [
     {
@@ -122,12 +225,24 @@ export async function handleMention(
     },
   ]);
 
-  log.info("mention", `Workflow ${run.runId} started`);
+  setActiveSpanAttributes({ "chat.id": run.runId });
+  countMetric("chat.workflow.started");
 
   await ctx.store.set({
     workflowRunId: run.runId,
-    channelId: sourceChannelId,
+    channelId: routing.sourceChannelId,
     threadId: conversationThreadId,
     startedAt: new Date().toISOString(),
+  });
+
+  logger.emit({
+    outcome: "started",
+    duration_ms: Date.now() - startTime,
+    chat: {
+      id: run.runId,
+      workflow_run_id: run.runId,
+      lead_in_count: recentMessages?.length ?? 0,
+      referenced_count: referencedContext?.length ?? 0,
+    },
   });
 }

--- a/src/bot/store.ts
+++ b/src/bot/store.ts
@@ -1,5 +1,7 @@
 import { Redis } from "@upstash/redis";
 
+import { withSpan } from "@/lib/otel/tracing";
+
 import type { ConversationState, RedisLike } from "./types";
 
 export type { ConversationState, RedisLike } from "./types";
@@ -27,41 +29,57 @@ export class ConversationStore {
   }
 
   async get(channelId: string, threadId?: string): Promise<ConversationState | null> {
-    return this.redis.get<ConversationState>(this.key(channelId, threadId));
+    return withSpan("redis.conversation.get", { "redis.key_pattern": "conversation" }, () =>
+      this.redis.get<ConversationState>(this.key(channelId, threadId)),
+    );
   }
 
   async set(state: ConversationState): Promise<void> {
-    await this.redis.set(this.key(state.channelId, state.threadId), state, { ex: TTL });
+    await withSpan("redis.conversation.set", { "redis.key_pattern": "conversation" }, () =>
+      this.redis.set(this.key(state.channelId, state.threadId), state, { ex: TTL }),
+    );
   }
 
   async delete(channelId: string, threadId?: string): Promise<void> {
-    await this.redis.del(this.key(channelId, threadId));
+    await withSpan("redis.conversation.delete", { "redis.key_pattern": "conversation" }, () =>
+      this.redis.del(this.key(channelId, threadId)),
+    );
   }
 
   async touch(channelId: string, threadId?: string): Promise<void> {
-    await this.redis.expire(this.key(channelId, threadId), TTL);
+    await withSpan("redis.conversation.touch", { "redis.key_pattern": "conversation" }, () =>
+      this.redis.expire(this.key(channelId, threadId), TTL),
+    );
   }
 
   /** Atomic dedup — returns true if this key hasn't been seen in the TTL window. */
   async dedup(key: string, ttlMs = DEDUP_TTL_MS): Promise<boolean> {
-    const result = await this.redis.set(`dedup:${key}`, 1, { nx: true, px: ttlMs });
-    return result !== null;
+    return withSpan("redis.dedup.claim", { "redis.key_pattern": "dedup" }, async () => {
+      const result = await this.redis.set(`dedup:${key}`, 1, { nx: true, px: ttlMs });
+      return result !== null;
+    });
   }
 
   /** Release a dedup claim so a retry can re-run the guarded work. */
   async releaseDedup(key: string): Promise<void> {
-    await this.redis.del(`dedup:${key}`);
+    await withSpan("redis.dedup.release", { "redis.key_pattern": "dedup" }, () =>
+      this.redis.del(`dedup:${key}`),
+    );
   }
 
   /** Atomic lock — returns a token if acquired, null if already held. */
   async acquireLock(key: string, ttlMs = LOCK_TTL_MS): Promise<string | null> {
-    const token = crypto.randomUUID();
-    const result = await this.redis.set(`lock:${key}`, token, { nx: true, px: ttlMs });
-    return result !== null ? token : null;
+    return withSpan("redis.lock.acquire", { "redis.key_pattern": "lock" }, async () => {
+      const token = crypto.randomUUID();
+      const result = await this.redis.set(`lock:${key}`, token, { nx: true, px: ttlMs });
+      return result !== null ? token : null;
+    });
   }
 
   /** Release a lock only if the token matches (Lua script, atomic). */
   async releaseLock(key: string, token: string): Promise<void> {
-    await this.redis.eval(RELEASE_LOCK_SCRIPT, [`lock:${key}`], [token]);
+    await withSpan("redis.lock.release", { "redis.key_pattern": "lock" }, () =>
+      this.redis.eval(RELEASE_LOCK_SCRIPT, [`lock:${key}`], [token]),
+    );
   }
 }

--- a/src/lib/ai/delegates.ts
+++ b/src/lib/ai/delegates.ts
@@ -2,7 +2,7 @@ import type { ToolSet } from "ai";
 
 import type { AgentContext } from "./context.ts";
 import type { TurnUsageTracker } from "./turn-usage.ts";
-import type { SubagentSpec } from "./types.ts";
+import type { SubagentSpec, TelemetryMetadata } from "./types.ts";
 
 import { SKILL_MANIFEST as CMS_SUBSKILLS } from "./skills/generated/domains/cms.ts";
 import { SKILL_MANIFEST as CODE_SUBSKILLS } from "./skills/generated/domains/code.ts";
@@ -159,7 +159,11 @@ const DOMAIN_SPEC_OVERRIDES: Partial<Record<keyof typeof DOMAINS, Partial<Subage
 const registry = new SkillRegistry(SKILL_MANIFEST);
 
 /** Build delegation tools for every delegate-mode skill the role can access. */
-export function buildDelegationTools(context: AgentContext, tracker: TurnUsageTracker): ToolSet {
+export function buildDelegationTools(
+  context: AgentContext,
+  tracker: TurnUsageTracker,
+  extraMetadata?: TelemetryMetadata,
+): ToolSet {
   const tools: ToolSet = {};
   for (const [name, config] of Object.entries(DOMAINS)) {
     const skill = registry.loadSkill(name, context.role);
@@ -175,6 +179,7 @@ export function buildDelegationTools(context: AgentContext, tracker: TurnUsageTr
       },
       context,
       tracker,
+      extraMetadata,
     );
   }
   return tools;

--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -50,7 +50,7 @@ describe("MessageRenderer.formatFooter", () => {
     ).toBe("-# 0.5s");
   });
 
-  it("appends the trace id when provided", () => {
+  it("puts the trace id first when provided", () => {
     expect(
       MessageRenderer.formatFooter({
         elapsedMs: 500,
@@ -59,7 +59,7 @@ describe("MessageRenderer.formatFooter", () => {
         stepCount: 1,
         traceId: "abc123def456",
       }),
-    ).toBe("-# 0.5s · 100 tokens · Trace: `abc123def456`");
+    ).toBe("-# `abc123def456` · 0.5s · 100 tokens");
   });
 });
 

--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -6,7 +6,7 @@ import { createMockAPI, asAPI } from "../test/fixtures/index.ts";
 import { MessageRenderer } from "./message-renderer.ts";
 
 describe("MessageRenderer.formatFooter", () => {
-  it("shows all metadata when present", () => {
+  it("shows elapsed, tokens, and tool calls", () => {
     expect(
       MessageRenderer.formatFooter({
         elapsedMs: 3200,
@@ -14,7 +14,7 @@ describe("MessageRenderer.formatFooter", () => {
         toolCallCount: 4,
         stepCount: 3,
       }),
-    ).toBe("-# 3.2s · 1,423 tokens · 4 tool calls · 3 steps");
+    ).toBe("-# 3.2s · 1,423 tokens · 4 tool calls");
   });
 
   it("omits tool calls when zero", () => {
@@ -28,17 +28,6 @@ describe("MessageRenderer.formatFooter", () => {
     ).toBe("-# 1.0s · 500 tokens");
   });
 
-  it("omits steps when only 1", () => {
-    expect(
-      MessageRenderer.formatFooter({
-        elapsedMs: 2500,
-        totalTokens: 800,
-        toolCallCount: 2,
-        stepCount: 1,
-      }),
-    ).toBe("-# 2.5s · 800 tokens · 2 tool calls");
-  });
-
   it("uses singular for 1 tool call", () => {
     expect(
       MessageRenderer.formatFooter({
@@ -47,7 +36,7 @@ describe("MessageRenderer.formatFooter", () => {
         toolCallCount: 1,
         stepCount: 2,
       }),
-    ).toBe("-# 1.0s · 100 tokens · 1 tool call · 2 steps");
+    ).toBe("-# 1.0s · 100 tokens · 1 tool call");
   });
 
   it("omits tokens when undefined", () => {
@@ -59,6 +48,18 @@ describe("MessageRenderer.formatFooter", () => {
         stepCount: 1,
       }),
     ).toBe("-# 0.5s");
+  });
+
+  it("appends the trace id when provided", () => {
+    expect(
+      MessageRenderer.formatFooter({
+        elapsedMs: 500,
+        totalTokens: 100,
+        toolCallCount: 0,
+        stepCount: 1,
+        traceId: "abc123def456",
+      }),
+    ).toBe("-# 0.5s · 100 tokens · Trace: `abc123def456`");
   });
 });
 

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -95,19 +95,12 @@ export class MessageRenderer {
   // Static utilities
   // ---------------------------------------------------------------------------
 
-  static formatFooter({
-    elapsedMs,
-    totalTokens,
-    toolCallCount,
-    stepCount,
-    traceId,
-  }: FooterMeta): string {
+  static formatFooter({ elapsedMs, totalTokens, toolCallCount, traceId }: FooterMeta): string {
     const parts = [`${(elapsedMs / 1000).toFixed(1)}s`];
 
     if (totalTokens != null) parts.push(`${totalTokens.toLocaleString("en-US")} tokens`);
     if (toolCallCount === 1) parts.push("1 tool call");
     else if (toolCallCount > 1) parts.push(`${toolCallCount} tool calls`);
-    if (stepCount > 1) parts.push(`${stepCount} steps`);
     if (traceId) parts.push(`Trace: \`${traceId}\``);
 
     return `-# ${parts.join(" · ")}`;

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -95,13 +95,20 @@ export class MessageRenderer {
   // Static utilities
   // ---------------------------------------------------------------------------
 
-  static formatFooter({ elapsedMs, totalTokens, toolCallCount, stepCount }: FooterMeta): string {
+  static formatFooter({
+    elapsedMs,
+    totalTokens,
+    toolCallCount,
+    stepCount,
+    traceId,
+  }: FooterMeta): string {
     const parts = [`${(elapsedMs / 1000).toFixed(1)}s`];
 
     if (totalTokens != null) parts.push(`${totalTokens.toLocaleString("en-US")} tokens`);
     if (toolCallCount === 1) parts.push("1 tool call");
     else if (toolCallCount > 1) parts.push(`${toolCallCount} tool calls`);
     if (stepCount > 1) parts.push(`${stepCount} steps`);
+    if (traceId) parts.push(`Trace: \`${traceId}\``);
 
     return `-# ${parts.join(" · ")}`;
   }

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -96,12 +96,13 @@ export class MessageRenderer {
   // ---------------------------------------------------------------------------
 
   static formatFooter({ elapsedMs, totalTokens, toolCallCount, traceId }: FooterMeta): string {
-    const parts = [`${(elapsedMs / 1000).toFixed(1)}s`];
+    const parts: string[] = [];
 
+    if (traceId) parts.push(`\`${traceId}\``);
+    parts.push(`${(elapsedMs / 1000).toFixed(1)}s`);
     if (totalTokens != null) parts.push(`${totalTokens.toLocaleString("en-US")} tokens`);
     if (toolCallCount === 1) parts.push("1 tool call");
     else if (toolCallCount > 1) parts.push(`${toolCallCount} tool calls`);
-    if (traceId) parts.push(`Trace: \`${traceId}\``);
 
     return `-# ${parts.join(" · ")}`;
   }

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,6 +1,7 @@
 import { ToolLoopAgent, type ToolSet } from "ai";
 
 import type { TurnUsageTracker } from "./turn-usage.ts";
+import type { TelemetryMetadata } from "./types.ts";
 
 import { wrapApprovalTools } from "./approvals/index.ts";
 import { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
@@ -19,8 +20,15 @@ export { ORCHESTRATOR_MODEL, SYSTEM_PROMPT } from "./constants.ts";
  * orchestrator runs with. Takes the full `AgentContext` because role-aware
  * tools (delegates, schedule_task) need both the resolved role and the
  * scheduler's `memberRoles` for propagation into persisted task meta.
+ *
+ * `extraMetadata` flows through to every delegation subagent so the whole
+ * chat trace shares `chat.*` attributes without baggage plumbing.
  */
-export function getOrchestratorTools(context: AgentContext, tracker: TurnUsageTracker): ToolSet {
+export function getOrchestratorTools(
+  context: AgentContext,
+  tracker: TurnUsageTracker,
+  extraMetadata?: TelemetryMetadata,
+): ToolSet {
   const tools: ToolSet = {
     current_time,
     documentation,
@@ -28,14 +36,18 @@ export function getOrchestratorTools(context: AgentContext, tracker: TurnUsageTr
     schedule_task: createScheduleTask(context),
     list_scheduled_tasks,
     cancel_task,
-    ...buildDelegationTools(context, tracker),
+    ...buildDelegationTools(context, tracker, extraMetadata),
   };
   return wrapApprovalTools(tools, { context });
 }
 
-export function createOrchestrator(context: AgentContext, tracker: TurnUsageTracker) {
+export function createOrchestrator(
+  context: AgentContext,
+  tracker: TurnUsageTracker,
+  extraMetadata?: TelemetryMetadata,
+) {
   const instructions = context.buildInstructions(SYSTEM_PROMPT);
-  const tools = getOrchestratorTools(context, tracker);
+  const tools = getOrchestratorTools(context, tracker, extraMetadata);
 
   return new ToolLoopAgent({
     model: ORCHESTRATOR_MODEL,
@@ -46,6 +58,7 @@ export function createOrchestrator(context: AgentContext, tracker: TurnUsageTrac
       functionId: "orchestrator",
       metadata: {
         role: context.role,
+        ...extraMetadata,
       },
     },
   });

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -1,9 +1,11 @@
 import type { API } from "@discordjs/core/http-only";
 
 import { isTextUIPart, type UIMessage } from "ai";
-import { log } from "evlog";
 
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
+import { buildChatAttributes } from "@/lib/otel/chat-attributes";
+import { withSpan } from "@/lib/otel/tracing";
 
 import type {
   Attachment,
@@ -76,18 +78,55 @@ export async function streamTurn(
   serializedContext: SerializedAgentContext,
   options: StreamTurnOptions = {},
 ): Promise<{ text: string; usage: TurnUsage }> {
-  const { taskId, createAgent = createOrchestrator } = options;
+  const { taskId, workflowRunId, turnIndex } = options;
+  const chatAttrs = workflowRunId
+    ? buildChatAttributes({ workflowRunId, context: serializedContext, turnIndex })
+    : undefined;
+  return withSpan(
+    "chat.turn",
+    {
+      ...chatAttrs,
+      "chat.channel_id": serializedContext.channel.id,
+      "chat.user_id": serializedContext.userId,
+      "chat.message_count": messages.length,
+      ...(taskId ? { "task.id": taskId } : {}),
+    },
+    () => runStreamTurn({ discord, channelId, messages, serializedContext, options, chatAttrs }),
+  );
+}
+
+async function runStreamTurn(args: {
+  discord: API;
+  channelId: string;
+  messages: ChatMessage[];
+  serializedContext: SerializedAgentContext;
+  options: StreamTurnOptions;
+  chatAttrs: ReturnType<typeof buildChatAttributes> | undefined;
+}): Promise<{ text: string; usage: TurnUsage }> {
+  const { discord, channelId, messages, serializedContext, options, chatAttrs } = args;
+  const { taskId, createAgent = createOrchestrator, workflowRunId, turnIndex } = options;
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const tracker = new TurnUsageTracker();
   // The `OrchestratorFactory` return type is a structural subset of the real
   // ToolLoopAgent, so we cast back to the concrete agent type here to keep the
   // stream-event discriminated union typed.
-  const agent = createAgent(agentCtx, tracker) as ReturnType<typeof createOrchestrator>;
+  const agent = createAgent(agentCtx, tracker, chatAttrs) as ReturnType<typeof createOrchestrator>;
   const renderer = new MessageRenderer(discord, channelId, { taskId });
 
-  await renderer.init();
+  const logger = createWideLogger({
+    op: "ai.turn",
+    chat: {
+      id: workflowRunId,
+      channel_id: channelId,
+      thread_id: serializedContext.thread?.id,
+      user_id: serializedContext.userId,
+      turn_index: turnIndex,
+      message_count: messages.length,
+    },
+    ...(taskId ? { task: { id: taskId } } : {}),
+  });
 
-  log.info("streaming", `Turn started in ${channelId}`);
+  await renderer.init();
 
   const priorMessages = messages.slice(0, -1).map((m) => ({ role: m.role, content: m.content }));
   const current = messages[messages.length - 1];
@@ -96,19 +135,52 @@ export async function streamTurn(
   const startTime = Date.now();
   const result = await agent.stream({ messages: [...priorMessages, currentMessage] });
 
-  let lastTextId: string | undefined;
+  await renderStream(result.fullStream, renderer);
 
-  for await (const event of result.fullStream) {
+  const elapsedMs = Date.now() - startTime;
+  const metadataError = await finalizeTurn({ result, tracker, renderer, elapsedMs, logger });
+
+  countMetric("ai.turn.completed");
+  recordDuration("ai.turn.duration", elapsedMs);
+
+  logger.emit({
+    outcome: metadataError ? "partial" : "ok",
+    duration_ms: elapsedMs,
+    text_length: renderer.content.length,
+    tokens: tracker.totalTokens,
+    tool_calls: tracker.totalToolCalls,
+    steps: tracker.totalSteps,
+  });
+
+  return { text: renderer.content, usage: tracker.toTurnUsage() };
+}
+
+async function renderStream(
+  fullStream: AsyncIterable<unknown>,
+  renderer: MessageRenderer,
+): Promise<void> {
+  let lastTextId: string | undefined;
+  for await (const raw of fullStream) {
+    const event = raw as {
+      type: string;
+      id?: string;
+      text?: string;
+      toolName?: string;
+      preliminary?: boolean;
+      output?: unknown;
+    };
     switch (event.type) {
       case "text-delta": {
         const delta =
-          lastTextId !== undefined && event.id !== lastTextId ? "\n\n" + event.text : event.text;
+          lastTextId !== undefined && event.id !== lastTextId
+            ? "\n\n" + (event.text ?? "")
+            : (event.text ?? "");
         lastTextId = event.id;
         await renderer.appendText(delta);
         break;
       }
       case "tool-input-start":
-        await renderer.showToolCall(event.toolName);
+        if (event.toolName) await renderer.showToolCall(event.toolName);
         break;
       case "tool-result":
         if (event.preliminary && event.output && typeof event.output === "object") {
@@ -122,11 +194,22 @@ export async function streamTurn(
         break;
     }
   }
+}
 
-  const elapsedMs = Date.now() - startTime;
+async function finalizeTurn(args: {
+  result: { totalUsage: PromiseLike<unknown>; steps: PromiseLike<unknown> };
+  tracker: TurnUsageTracker;
+  renderer: MessageRenderer;
+  elapsedMs: number;
+  logger: ReturnType<typeof createWideLogger>;
+}): Promise<unknown> {
+  const { result, tracker, renderer, elapsedMs, logger } = args;
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
-    tracker.recordOrchestrator({ usage: totalUsage, steps });
+    tracker.recordOrchestrator({
+      usage: totalUsage as { inputTokens?: number; outputTokens?: number; totalTokens?: number },
+      steps: steps as readonly { toolCalls: readonly unknown[] }[],
+    });
 
     await renderer.finalize({
       elapsedMs,
@@ -138,21 +221,16 @@ export async function streamTurn(
     recordDistribution("ai.turn.tokens", tracker.totalTokens);
     recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls);
     recordDistribution("ai.turn.steps", tracker.totalSteps);
+    return undefined;
   } catch (err) {
-    log.warn("streaming", `Failed to collect metadata: ${String(err)}`);
     countMetric("ai.turn.metadata_error");
+    logger.warn("metadata collection failed", { reason: String(err) });
     await renderer.finalize({
       elapsedMs,
       totalTokens: undefined,
       toolCallCount: 0,
       stepCount: 0,
     });
+    return err;
   }
-
-  countMetric("ai.turn.completed");
-  recordDuration("ai.turn.duration", elapsedMs);
-
-  log.info("streaming", `Turn complete, ${renderer.content.length} chars, ${elapsedMs}ms`);
-
-  return { text: renderer.content, usage: tracker.toTurnUsage() };
 }

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -1,5 +1,6 @@
 import type { API } from "@discordjs/core/http-only";
 
+import { trace } from "@opentelemetry/api";
 import { isTextUIPart, type UIMessage } from "ai";
 
 import { createWideLogger } from "@/lib/logging/wide";
@@ -138,7 +139,15 @@ async function runStreamTurn(args: {
   await renderStream(result.fullStream, renderer);
 
   const elapsedMs = Date.now() - startTime;
-  const metadataError = await finalizeTurn({ result, tracker, renderer, elapsedMs, logger });
+  const traceId = trace.getActiveSpan()?.spanContext().traceId;
+  const metadataError = await finalizeTurn({
+    result,
+    tracker,
+    renderer,
+    elapsedMs,
+    logger,
+    traceId,
+  });
 
   countMetric("ai.turn.completed");
   recordDuration("ai.turn.duration", elapsedMs);
@@ -202,8 +211,9 @@ async function finalizeTurn(args: {
   renderer: MessageRenderer;
   elapsedMs: number;
   logger: ReturnType<typeof createWideLogger>;
+  traceId: string | undefined;
 }): Promise<unknown> {
-  const { result, tracker, renderer, elapsedMs, logger } = args;
+  const { result, tracker, renderer, elapsedMs, logger, traceId } = args;
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
     tracker.recordOrchestrator({
@@ -216,6 +226,7 @@ async function finalizeTurn(args: {
       totalTokens: tracker.totalTokens,
       toolCallCount: tracker.totalToolCalls,
       stepCount: tracker.totalSteps,
+      traceId,
     });
 
     recordDistribution("ai.turn.tokens", tracker.totalTokens);
@@ -230,6 +241,7 @@ async function finalizeTurn(args: {
       totalTokens: undefined,
       toolCallCount: 0,
       stepCount: 0,
+      traceId,
     });
     return err;
   }

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -11,10 +11,11 @@ import {
 } from "ai";
 import { z } from "zod";
 
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution } from "@/lib/metrics";
 
 import type { AgentContext } from "./context.ts";
-import type { SubagentSpec } from "./types.ts";
+import type { SubagentSpec, TelemetryMetadata } from "./types.ts";
 
 import { wrapApprovalTools } from "./approvals/index.ts";
 import { addCacheControl } from "./cache-control.ts";
@@ -63,6 +64,15 @@ export function recordSubagentMetrics(
   countMetric("ai.subagent.completed", { domain: spec.name });
   recordDistribution("ai.subagent.tokens", tokens, { domain: spec.name });
   recordDistribution("ai.subagent.tool_calls", toolCalls, { domain: spec.name });
+  createWideLogger({
+    op: "ai.subagent",
+    subagent: { domain: spec.name },
+  }).emit({
+    outcome: "ok",
+    tokens,
+    tool_calls: toolCalls,
+    steps: steps.length,
+  });
 }
 
 /**
@@ -92,6 +102,7 @@ export function createDelegationTool(
   spec: SubagentSpec,
   context: AgentContext,
   tracker: TurnUsageTracker,
+  extraMetadata?: TelemetryMetadata,
 ) {
   const role = context.role;
   const inputSchema = spec.inputSchema ?? DEFAULT_TASK_INPUT_SCHEMA;
@@ -136,7 +147,7 @@ export function createDelegationTool(
         experimental_telemetry: {
           isEnabled: true,
           functionId: `subagent.${spec.name}`,
-          metadata: { role, subagent: spec.name },
+          metadata: { role, subagent: spec.name, ...extraMetadata },
         },
       });
 

--- a/src/lib/ai/tools/code/delegation.ts
+++ b/src/lib/ai/tools/code/delegation.ts
@@ -1,10 +1,10 @@
 import type { UIMessage } from "ai";
 
-import { log } from "evlog";
 import { z } from "zod";
 
 import type { Sandbox } from "@/lib/sandbox/types";
 
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric } from "@/lib/metrics";
 import { getOrCreateSession } from "@/lib/sandbox/session";
 
@@ -88,20 +88,29 @@ export async function* codePostFinish(args: {
 }): AsyncGenerator<UIMessage, void, void> {
   const ctx = args.experimentalContext as CodingSandboxContext | undefined;
   if (!ctx) {
-    log.warn("code-delegation", "postFinish invoked without experimental context — skipping");
+    createWideLogger({ op: "ai.code_delegate.post_finish" }).emit({
+      outcome: "skipped",
+      reason: "no_experimental_context",
+    });
     return;
   }
   const authorUsername = (args.agentContext as AgentContext | undefined)?.username;
   const { sandbox, repo, branch } = ctx;
+  const logger = createWideLogger({
+    op: "ai.code_delegate.post_finish",
+    code_delegate: { repo, branch, thread_key: ctx.threadKey },
+  });
 
   const status = await sandbox.exec("git status --porcelain", { cwd: ctx.repoDir });
   if (status.exitCode !== 0) {
+    logger.emit({ outcome: "aborted", reason: "git_status_failed", exit_code: status.exitCode });
     yield statusMessage(
       `Post-finish aborted: \`git status\` exited ${status.exitCode}. stderr: ${truncate(status.stderr)}`,
     );
     return;
   }
   if (!status.stdout.trim()) {
+    logger.emit({ outcome: "no_changes" });
     yield statusMessage("No changes to commit. Nothing pushed; no PR opened.");
     return;
   }
@@ -110,6 +119,7 @@ export async function* codePostFinish(args: {
 
   const addResult = await sandbox.exec("git add -A", { cwd: ctx.repoDir });
   if (addResult.exitCode !== 0) {
+    logger.emit({ outcome: "staging_failed", exit_code: addResult.exitCode });
     yield statusMessage(
       `Staging failed (exit ${addResult.exitCode}). stderr: ${truncate(addResult.stderr || addResult.stdout)}`,
     );
@@ -120,6 +130,7 @@ export async function* codePostFinish(args: {
     cwd: ctx.repoDir,
   });
   if (commitResult.exitCode !== 0) {
+    logger.emit({ outcome: "commit_failed", exit_code: commitResult.exitCode });
     yield statusMessage(
       `Commit failed (exit ${commitResult.exitCode}). stderr: ${truncate(commitResult.stderr || commitResult.stdout)}`,
     );
@@ -131,6 +142,7 @@ export async function* codePostFinish(args: {
     timeoutMs: 3 * 60 * 1000,
   });
   if (push.exitCode !== 0) {
+    logger.emit({ outcome: "push_failed", exit_code: push.exitCode });
     yield statusMessage(
       `Push failed (exit ${push.exitCode}). stderr: ${truncate(push.stderr || push.stdout)}`,
     );
@@ -148,6 +160,8 @@ export async function* codePostFinish(args: {
       repoDir: ctx.repoDir,
     });
   } catch (err) {
+    logger.error(err as Error);
+    logger.emit({ outcome: "pr_open_failed" });
     yield statusMessage(
       `Branch \`${branch}\` pushed but opening the PR failed: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -155,6 +169,7 @@ export async function* codePostFinish(args: {
   }
 
   countMetric("ai.code_delegate.pr_opened");
+  logger.emit({ outcome: "pr_opened", pr_url: prUrl });
   yield statusMessage(`${args.lastAssistantText.trim()}\n\n**PR**: ${prUrl}`.trim());
 }
 

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -201,12 +201,23 @@ export interface OrchestratorAgent {
 }
 
 /**
+ * Telemetry metadata passed through to every AI SDK `experimental_telemetry.metadata`
+ * call in an orchestrator + its subagents. Flat key/value pairs; the AI SDK
+ * flattens these into `ai.telemetry.metadata.<key>` span attributes so Axiom
+ * can query by `chat.id` across the whole conversation. Undefined values are
+ * tolerated so callers can build metadata from optional fields without first
+ * filtering them out.
+ */
+export type TelemetryMetadata = Record<string, string | number | undefined>;
+
+/**
  * Factory signature for `createOrchestrator`. Exported so tests can inject a
  * fake through `streamTurn`'s options bag without mocking our own modules.
  */
 export type OrchestratorFactory = (
   ctx: AgentContext,
   tracker: TurnUsageTracker,
+  extraMetadata?: TelemetryMetadata,
 ) => OrchestratorAgent;
 
 /**
@@ -218,4 +229,12 @@ export interface StreamTurnOptions {
   taskId?: string;
   /** Dependency-injected orchestrator factory; defaults to `createOrchestrator`. */
   createAgent?: OrchestratorFactory;
+  /**
+   * Workflow run id for the containing chat workflow. Used to populate
+   * `chat.*` attributes on the turn span + every AI SDK span so a whole
+   * conversation is one Axiom query (`chat.id == <workflowRunId>`).
+   */
+  workflowRunId?: string;
+  /** Turn number within the conversation (1 = first turn). */
+  turnIndex?: number;
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -68,6 +68,12 @@ export interface FooterMeta {
   totalTokens: number | undefined;
   toolCallCount: number;
   stepCount: number;
+  /**
+   * Full OTEL trace id for the turn (32-char hex). Rendered into the footer as
+   * `Trace: <id>` so operators can paste it into Sentry to pull up the full
+   * agent trace for a specific Discord reply.
+   */
+  traceId?: string;
 }
 
 /**

--- a/src/lib/logging/wide.test.ts
+++ b/src/lib/logging/wide.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { baseEmit, traceId } = vi.hoisted(() => ({
+  baseEmit: vi.fn((overrides: Record<string, unknown>) => ({ emitted: overrides })),
+  traceId: { current: undefined as string | undefined },
+}));
+
+vi.mock("evlog", () => ({
+  createLogger: vi.fn((context: Record<string, unknown>) => ({
+    set: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    emit: baseEmit,
+    getContext: () => context,
+  })),
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: {
+    getActiveSpan: () =>
+      traceId.current ? { spanContext: () => ({ traceId: traceId.current }) } : undefined,
+  },
+}));
+
+import { createWideLogger } from "./wide";
+
+describe("createWideLogger", () => {
+  it("injects the current OTEL trace id on emit when available", () => {
+    traceId.current = "abc123";
+    baseEmit.mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    logger.emit({ outcome: "ok" });
+    expect(baseEmit).toHaveBeenCalledWith({ trace: { id: "abc123" }, outcome: "ok" });
+  });
+
+  it("omits trace id when no active span exists", () => {
+    traceId.current = undefined;
+    baseEmit.mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    logger.emit({ outcome: "ok" });
+    expect(baseEmit).toHaveBeenCalledWith({ outcome: "ok" });
+  });
+
+  it("defaults overrides to an empty object when caller omits them", () => {
+    traceId.current = undefined;
+    baseEmit.mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    logger.emit();
+    expect(baseEmit).toHaveBeenCalledWith({});
+  });
+});

--- a/src/lib/logging/wide.ts
+++ b/src/lib/logging/wide.ts
@@ -1,0 +1,46 @@
+import { trace } from "@opentelemetry/api";
+import { createLogger, type RequestLogger } from "evlog";
+
+type WideContext = Record<string, unknown>;
+
+/**
+ * Create a scoped wide-event logger for one unit of work. Wraps `evlog`'s
+ * `createLogger` so:
+ *   - The emitted event automatically includes the current OTEL trace id
+ *     (`trace.id`), which Sentry uses to join a log line to a trace.
+ *   - Base context (op, chat, user, workflow ids, …) is set once up front and
+ *     flows through `.set()`, `.info()`, `.warn()`, `.error()`, and `.emit()`.
+ *
+ * Follow the wide-event pattern: create one logger per unit of work, accumulate
+ * attributes as the work progresses (`.set({...})`), and call `.emit({status, duration_ms, ...})`
+ * exactly once at the end. Errors should be captured with `.error(err)` before
+ * the final emit; the wide event will carry both the accumulated context and
+ * the parsed error fields.
+ *
+ * @example
+ *   const logger = createWideLogger({ op: "chat.run_turn", chat: { id, channel_id } });
+ *   logger.set({ turn_index: 2 });
+ *   try {
+ *     const turn = await streamTurn(...);
+ *     logger.emit({ status: "ok", tokens: turn.usage.totalTokens });
+ *   } catch (err) {
+ *     logger.error(err as Error);
+ *     logger.emit({ status: "error" });
+ *     throw err;
+ *   }
+ */
+export function createWideLogger(context: WideContext = {}): RequestLogger {
+  const logger = createLogger(context);
+  const originalEmit = logger.emit.bind(logger);
+  // Re-assign emit via Object.assign so we preserve the RequestLogger shape
+  // without casting; evlog's RequestLogger.emit accepts a plain object of
+  // overrides, which matches what we splat in here.
+  logger.emit = (overrides = {}) => {
+    const traceId = trace.getActiveSpan()?.spanContext().traceId;
+    return originalEmit({
+      ...(traceId ? { trace: { id: traceId } } : {}),
+      ...overrides,
+    });
+  };
+  return logger;
+}

--- a/src/lib/otel/chat-attributes.test.ts
+++ b/src/lib/otel/chat-attributes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import type { SerializedAgentContext } from "@/lib/ai/types";
+
+import { buildChatAttributes } from "./chat-attributes";
+
+const baseContext: SerializedAgentContext = {
+  userId: "u1",
+  username: "alice",
+  nickname: "Alice",
+  channel: { id: "c1", name: "general" },
+  date: "Jan 1, 2026",
+};
+
+describe("buildChatAttributes", () => {
+  it("builds required keys from workflowRunId + context", () => {
+    const attrs = buildChatAttributes({ workflowRunId: "run-1", context: baseContext });
+    expect(attrs).toEqual({
+      "chat.id": "run-1",
+      "chat.channel_id": "c1",
+      "chat.user_id": "u1",
+      "chat.workflow_run_id": "run-1",
+    });
+  });
+
+  it("includes chat.thread_id when the context has a thread", () => {
+    const attrs = buildChatAttributes({
+      workflowRunId: "run-1",
+      context: {
+        ...baseContext,
+        thread: { id: "t1", name: "thread", parentChannel: baseContext.channel },
+      },
+    });
+    expect(attrs["chat.thread_id"]).toBe("t1");
+  });
+
+  it("includes chat.turn_index when provided", () => {
+    const attrs = buildChatAttributes({
+      workflowRunId: "run-1",
+      context: baseContext,
+      turnIndex: 3,
+    });
+    expect(attrs["chat.turn_index"]).toBe(3);
+  });
+
+  it("omits username (PII)", () => {
+    const attrs = buildChatAttributes({ workflowRunId: "run-1", context: baseContext });
+    expect(attrs).not.toHaveProperty("chat.username");
+  });
+});

--- a/src/lib/otel/chat-attributes.ts
+++ b/src/lib/otel/chat-attributes.ts
@@ -1,0 +1,25 @@
+import type { SerializedAgentContext } from "@/lib/ai/types";
+
+import type { ChatAttributes } from "./types.ts";
+
+export type { ChatAttributes } from "./types.ts";
+
+/**
+ * Build chat attributes from a serialized context + the workflow run id. The
+ * run id doubles as `chat.id` so a conversation maps to one Axiom query.
+ */
+export function buildChatAttributes(args: {
+  workflowRunId: string;
+  context: SerializedAgentContext;
+  turnIndex?: number;
+}): ChatAttributes {
+  const { workflowRunId, context, turnIndex } = args;
+  return {
+    "chat.id": workflowRunId,
+    "chat.channel_id": context.channel.id,
+    ...(context.thread?.id ? { "chat.thread_id": context.thread.id } : {}),
+    "chat.user_id": context.userId,
+    ...(turnIndex !== undefined ? { "chat.turn_index": turnIndex } : {}),
+    "chat.workflow_run_id": workflowRunId,
+  };
+}

--- a/src/lib/otel/constants.ts
+++ b/src/lib/otel/constants.ts
@@ -1,0 +1,1 @@
+export const TRACER_NAME = "wack-hacker";

--- a/src/lib/otel/tracing.test.ts
+++ b/src/lib/otel/tracing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { startActiveSpan, span } = vi.hoisted(() => {
+  const span = {
+    end: vi.fn(),
+    setAttributes: vi.fn(),
+    setAttribute: vi.fn(),
+    setStatus: vi.fn(),
+    recordException: vi.fn(),
+  };
+  return {
+    span,
+    startActiveSpan: vi.fn((_name: string, _opts: unknown, fn: (s: typeof span) => unknown) =>
+      fn(span),
+    ),
+  };
+});
+
+vi.mock("@opentelemetry/api", () => ({
+  SpanStatusCode: { ERROR: 2 },
+  trace: {
+    getTracer: vi.fn(() => ({ startActiveSpan })),
+    getActiveSpan: vi.fn(() => span),
+  },
+}));
+
+import { setActiveSpanAttributes, withSpan } from "./tracing";
+
+describe("withSpan", () => {
+  it("runs fn inside a span and ends it on success", async () => {
+    const result = await withSpan("test.span", { foo: "bar" }, async () => "ok");
+    expect(result).toBe("ok");
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      "test.span",
+      { attributes: { foo: "bar" } },
+      expect.any(Function),
+    );
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("records exceptions, sets error status, rethrows, and still ends", async () => {
+    const err = new Error("boom");
+    await expect(withSpan("failing.span", {}, async () => Promise.reject(err))).rejects.toBe(err);
+    expect(span.recordException).toHaveBeenCalledWith(err);
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2, message: "boom" });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("stringifies non-Error throws for the status message", async () => {
+    await expect(
+      withSpan("throw-string", {}, async () => {
+        throw "nope";
+      }),
+    ).rejects.toBe("nope");
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2, message: "nope" });
+  });
+});
+
+describe("setActiveSpanAttributes", () => {
+  it("forwards attributes to the active span", () => {
+    setActiveSpanAttributes({ foo: "bar" });
+    expect(span.setAttributes).toHaveBeenCalledWith({ foo: "bar" });
+  });
+});

--- a/src/lib/otel/tracing.ts
+++ b/src/lib/otel/tracing.ts
@@ -1,0 +1,39 @@
+import { SpanStatusCode, trace, type Attributes, type Span } from "@opentelemetry/api";
+
+import { TRACER_NAME } from "./constants.ts";
+
+export const tracer = trace.getTracer(TRACER_NAME);
+
+/**
+ * Run `fn` inside a span. Exceptions are recorded on the span, and the span
+ * ends in the finally. Returns whatever `fn` returns.
+ *
+ * Mirrors the minimal pattern used across the codebase: open span, do work,
+ * close span — no bespoke wrapper semantics.
+ */
+export async function withSpan<T>(
+  name: string,
+  attributes: Attributes,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return tracer.startActiveSpan(name, { attributes }, async (span) => {
+    try {
+      const result = await fn(span);
+      return result;
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/** Set attributes on whatever span is currently active. No-op if none. */
+export function setActiveSpanAttributes(attributes: Attributes): void {
+  trace.getActiveSpan()?.setAttributes(attributes);
+}

--- a/src/lib/otel/types.ts
+++ b/src/lib/otel/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Attributes we stamp onto every span emitted inside a chat workflow or any
+ * handler that can be correlated to a chat. Deliberately excludes username
+ * (PII); user_id is sufficient for joining back to a person off-trace.
+ *
+ * Axiom-queryable: `chat.id == "<workflowRunId>"` returns every span in the
+ * conversation, across workflow-step invocation boundaries.
+ *
+ * Index signature is present so `ChatAttributes` is structurally assignable
+ * to `TelemetryMetadata` (an alias for `Record<string, string | number>`),
+ * letting the same object flow into AI SDK telemetry metadata and OTEL span
+ * attributes without re-keying.
+ */
+export interface ChatAttributes {
+  "chat.id": string;
+  "chat.channel_id": string;
+  "chat.thread_id"?: string;
+  "chat.user_id": string;
+  "chat.turn_index"?: number;
+  "chat.workflow_run_id": string;
+  [key: string]: string | number | undefined;
+}

--- a/src/lib/sales/resend-webhook.ts
+++ b/src/lib/sales/resend-webhook.ts
@@ -1,9 +1,9 @@
 import type { UpdatePageParameters } from "@notionhq/client/build/src/api-endpoints";
 
-import { log } from "evlog";
-
 import { notion } from "@/lib/ai/tools/sales/client";
 import { COMPANIES_DATA_SOURCE_ID, CONTACTS_DATA_SOURCE_ID } from "@/lib/ai/tools/sales/constants";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
 
 /**
  * Resend sends Svix-style payloads: `{ type: "email.delivered", created_at, data: { email_id, ... } }`.
@@ -88,49 +88,67 @@ function currentEventAt(properties: Record<string, unknown>): string | null {
 }
 
 export async function applyResendEvent(raw: unknown): Promise<void> {
-  if (!isResendEvent(raw)) {
-    log.warn("resend", `Discarded event — shape does not match ResendEvent`);
-    return;
-  }
-  if (!(raw.type in STATUS_BY_EVENT)) {
-    log.info("resend", `Ignoring unsupported event type ${raw.type}`);
-    return;
-  }
+  const logger = createWideLogger({ op: "resend.event.apply" });
+  const startTime = Date.now();
+  try {
+    if (!isResendEvent(raw)) {
+      countMetric("resend.event.discarded", { reason: "shape_mismatch" });
+      logger.emit({ outcome: "discarded", reason: "shape_mismatch" });
+      return;
+    }
+    if (!(raw.type in STATUS_BY_EVENT)) {
+      countMetric("resend.event.unsupported", { type: raw.type });
+      logger.emit({ outcome: "unsupported", type: raw.type });
+      return;
+    }
 
-  const eventType = raw.type as ResendEventType;
-  const nextStatus = STATUS_BY_EVENT[eventType];
-  const emailId = raw.data.email_id;
+    const eventType = raw.type as ResendEventType;
+    const nextStatus = STATUS_BY_EVENT[eventType];
+    const emailId = raw.data.email_id;
+    logger.set({ resend: { event_type: eventType, email_id: emailId } });
 
-  const page =
-    (await findPageByEmailId(COMPANIES_DATA_SOURCE_ID, emailId)) ??
-    (await findPageByEmailId(CONTACTS_DATA_SOURCE_ID, emailId));
-  if (!page) {
-    log.info("resend", `No Notion row matches email_id ${emailId} (${eventType})`);
-    return;
+    const page =
+      (await findPageByEmailId(COMPANIES_DATA_SOURCE_ID, emailId)) ??
+      (await findPageByEmailId(CONTACTS_DATA_SOURCE_ID, emailId));
+    if (!page) {
+      countMetric("resend.event.no_match", { type: eventType });
+      logger.emit({ outcome: "no_match" });
+      return;
+    }
+
+    const currentRank = STATUS_RANK[currentStatus(page.properties) ?? "Sent"];
+    const applyStatus = STATUS_RANK[nextStatus] >= currentRank;
+    const shouldBlock = eventType === "email.bounced" || eventType === "email.complained";
+
+    const existingEventAt = currentEventAt(page.properties);
+    const applyEventAt = !existingEventAt || raw.created_at > existingEventAt;
+
+    const properties: Record<string, unknown> = {};
+    if (applyEventAt) {
+      properties["Outreach Last Event At"] = { date: { start: raw.created_at } };
+    }
+    if (applyStatus) {
+      properties["Outreach Status"] = { select: { name: nextStatus } };
+    }
+    if (shouldBlock) {
+      properties["Do Not Contact"] = { checkbox: true };
+    }
+
+    if (Object.keys(properties).length === 0) {
+      countMetric("resend.event.noop", { type: eventType });
+      logger.emit({ outcome: "noop" });
+      return;
+    }
+
+    await notion.pages.update({ page_id: page.id, properties } as UpdatePageParameters);
+    countMetric("resend.event.applied", { type: eventType, status: nextStatus });
+    logger.emit({
+      outcome: "applied",
+      next_status: nextStatus,
+      blocked: shouldBlock,
+      duration_ms: Date.now() - startTime,
+    });
+  } finally {
+    recordDuration("resend.event.apply_duration", Date.now() - startTime);
   }
-
-  const currentRank = STATUS_RANK[currentStatus(page.properties) ?? "Sent"];
-  const applyStatus = STATUS_RANK[nextStatus] >= currentRank;
-  const shouldBlock = eventType === "email.bounced" || eventType === "email.complained";
-
-  const existingEventAt = currentEventAt(page.properties);
-  const applyEventAt = !existingEventAt || raw.created_at > existingEventAt;
-
-  const properties: Record<string, unknown> = {};
-  if (applyEventAt) {
-    properties["Outreach Last Event At"] = { date: { start: raw.created_at } };
-  }
-  if (applyStatus) {
-    properties["Outreach Status"] = { select: { name: nextStatus } };
-  }
-  if (shouldBlock) {
-    properties["Do Not Contact"] = { checkbox: true };
-  }
-
-  if (Object.keys(properties).length === 0) {
-    log.info("resend", `No-op for ${emailId} (${eventType}) — already newer state`);
-    return;
-  }
-
-  await notion.pages.update({ page_id: page.id, properties } as UpdatePageParameters);
 }

--- a/src/lib/sandbox/session.ts
+++ b/src/lib/sandbox/session.ts
@@ -1,5 +1,3 @@
-import { log } from "evlog";
-
 import type { RedisLike } from "@/bot/types";
 
 import type {
@@ -11,6 +9,9 @@ import type {
   SandboxSessionMetadata,
 } from "./types.ts";
 
+import { createWideLogger } from "../logging/wide.ts";
+import { countMetric, recordDuration } from "../metrics.ts";
+import { withSpan } from "../otel/tracing.ts";
 import { resolveOnProvisioned, resolveProvider, resolveRedis } from "./session-deps.ts";
 
 export type {
@@ -72,18 +73,58 @@ export async function writeSession(
 export async function getOrCreateSession(
   params: GetOrCreateSessionParams,
 ): Promise<SandboxSession> {
-  const redis = resolveRedis(params.redis);
-  const provider = resolveProvider(params.provider);
-  const cached = await redis.get<SandboxSessionMetadata>(redisKey(params.threadKey));
+  return withSpan(
+    "sandbox.session.get_or_create",
+    { "sandbox.thread_key": params.threadKey, "sandbox.repo": params.repo },
+    async (span) => {
+      const logger = createWideLogger({
+        op: "sandbox.session.get_or_create",
+        sandbox: { thread_key: params.threadKey, repo: params.repo },
+      });
+      const startTime = Date.now();
+      try {
+        const redis = resolveRedis(params.redis);
+        const provider = resolveProvider(params.provider);
+        const cached = await redis.get<SandboxSessionMetadata>(redisKey(params.threadKey));
 
-  const liveReuse = await tryLiveReuse(cached, params, redis, provider);
-  if (liveReuse) return liveReuse;
+        const liveReuse = await tryLiveReuse(cached, params, redis, provider);
+        if (liveReuse) {
+          countMetric("sandbox.session.reused");
+          span.setAttribute("sandbox.outcome", "reused");
+          logger.emit({
+            outcome: "reused",
+            duration_ms: Date.now() - startTime,
+            sandbox_id: liveReuse.metadata.sandboxId,
+          });
+          return liveReuse;
+        }
 
-  if (cached && cached.repo !== params.repo) {
-    await discardStaleSession(cached, params, redis, provider);
-  }
+        if (cached && cached.repo !== params.repo) {
+          await discardStaleSession(cached, params, redis, provider);
+          countMetric("sandbox.session.discarded_stale");
+          logger.set({ discarded: { prior_repo: cached.repo } });
+        }
 
-  return provisionFreshSession(params, redis, provider);
+        const result = await provisionFreshSession(params, redis, provider);
+        const outcome = result.metadata.sandboxId && cached?.hibernated ? "resumed" : "provisioned";
+        countMetric("sandbox.session.provisioned", { outcome });
+        span.setAttribute("sandbox.outcome", outcome);
+        logger.emit({
+          outcome,
+          duration_ms: Date.now() - startTime,
+          sandbox_id: result.metadata.sandboxId,
+          branch: result.metadata.branch,
+        });
+        return result;
+      } catch (err) {
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        throw err;
+      } finally {
+        recordDuration("sandbox.session.get_or_create_duration", Date.now() - startTime);
+      }
+    },
+  );
 }
 
 async function tryLiveReuse(
@@ -109,13 +150,13 @@ async function tryLiveReuse(
       lastUsedAt: Date.now(),
     };
     await writeSession(params.threadKey, metadata, redis);
-    log.info("sandbox", `Reused sandbox ${cached.sandboxId} for thread ${params.threadKey}`);
     return { sandbox, metadata, fresh: false };
   } catch (err) {
-    log.warn(
-      "sandbox",
-      `Reconnect failed for sandbox ${cached.sandboxId}: ${String(err)}. Provisioning fresh.`,
-    );
+    countMetric("sandbox.session.reconnect_failed");
+    createWideLogger({
+      op: "sandbox.session.reconnect",
+      sandbox: { thread_key: params.threadKey, sandbox_id: cached.sandboxId },
+    }).emit({ outcome: "failed", reason: String(err) });
     await redis.del(redisKey(params.threadKey));
     return null;
   }
@@ -127,19 +168,28 @@ async function discardStaleSession(
   redis: RedisLike,
   provider: SandboxProvider,
 ): Promise<void> {
-  log.warn(
-    "sandbox",
-    `Repo changed for thread ${params.threadKey} (${cached.repo} → ${params.repo}); discarding old session`,
-  );
+  const logger = createWideLogger({
+    op: "sandbox.session.discard_stale",
+    sandbox: {
+      thread_key: params.threadKey,
+      sandbox_id: cached.sandboxId,
+      prior_repo: cached.repo,
+      new_repo: params.repo,
+    },
+  });
   if (!cached.hibernated) {
     try {
       const old = await provider.reconnect(cached.sandboxId, {
         githubToken: params.githubToken,
       });
       await old.stop();
+      logger.emit({ outcome: "stopped" });
     } catch (err) {
-      log.warn("sandbox", `Failed to stop stale sandbox ${cached.sandboxId}: ${String(err)}`);
+      logger.warn("failed to stop stale sandbox", { reason: String(err) });
+      logger.emit({ outcome: "stop_failed" });
     }
+  } else {
+    logger.emit({ outcome: "hibernated_discarded" });
   }
   await redis.del(redisKey(params.threadKey));
 }
@@ -179,10 +229,6 @@ async function provisionFreshSession(
   };
 
   await writeSession(params.threadKey, metadata, redis);
-  log.info(
-    "sandbox",
-    `${isResume ? "Resumed" : "Provisioned"} sandbox ${sandbox.name} for thread ${params.threadKey}`,
-  );
 
   const onProvisioned = resolveOnProvisioned(params.onProvisioned);
   await onProvisioned(params.threadKey);
@@ -199,27 +245,42 @@ export async function releaseSession(
   threadKey: string,
   options: ReleaseSessionOptions = {},
 ): Promise<void> {
-  const redis = resolveRedis(options.redis);
-  const provider = resolveProvider(options.provider);
-  const key = redisKey(threadKey);
-  const metadata = await redis.get<SandboxSessionMetadata>(key);
-  if (!metadata) return;
-
-  if (!metadata.hibernated) {
-    try {
-      const sandbox = await provider.reconnect(metadata.sandboxId, {
-        githubToken: options.githubToken,
-      });
-      await sandbox.stop();
-    } catch (err) {
-      log.warn(
-        "sandbox",
-        `Release failed for sandbox ${metadata.sandboxId} (${threadKey}): ${String(err)}`,
-      );
+  return withSpan("sandbox.session.release", { "sandbox.thread_key": threadKey }, async () => {
+    const logger = createWideLogger({
+      op: "sandbox.session.release",
+      sandbox: { thread_key: threadKey },
+    });
+    const redis = resolveRedis(options.redis);
+    const provider = resolveProvider(options.provider);
+    const key = redisKey(threadKey);
+    const metadata = await redis.get<SandboxSessionMetadata>(key);
+    if (!metadata) {
+      logger.emit({ outcome: "no-session" });
+      return;
     }
-  }
 
-  await redis.del(key);
+    logger.set({ sandbox: { sandbox_id: metadata.sandboxId, hibernated: metadata.hibernated } });
+
+    if (!metadata.hibernated) {
+      try {
+        const sandbox = await provider.reconnect(metadata.sandboxId, {
+          githubToken: options.githubToken,
+        });
+        await sandbox.stop();
+        countMetric("sandbox.session.released");
+        logger.emit({ outcome: "stopped" });
+      } catch (err) {
+        countMetric("sandbox.session.release_failed");
+        logger.warn("release failed", { reason: String(err) });
+        logger.emit({ outcome: "release_failed" });
+      }
+    } else {
+      countMetric("sandbox.session.released", { hibernated: "true" });
+      logger.emit({ outcome: "released_hibernated" });
+    }
+
+    await redis.del(key);
+  });
 }
 
 /**
@@ -233,45 +294,66 @@ export async function hibernateSession(
   threadKey: string,
   options: HibernateSessionOptions = {},
 ): Promise<"hibernated" | "skipped-missing" | "skipped-already"> {
-  const redis = resolveRedis(options.redis);
-  const provider = resolveProvider(options.provider);
-  const metadata = await redis.get<SandboxSessionMetadata>(redisKey(threadKey));
-  if (!metadata) return "skipped-missing";
-  if (metadata.hibernated) return "skipped-already";
+  return withSpan(
+    "sandbox.session.hibernate",
+    { "sandbox.thread_key": threadKey },
+    async (span) => {
+      const logger = createWideLogger({
+        op: "sandbox.session.hibernate",
+        sandbox: { thread_key: threadKey },
+      });
+      const redis = resolveRedis(options.redis);
+      const provider = resolveProvider(options.provider);
+      const metadata = await redis.get<SandboxSessionMetadata>(redisKey(threadKey));
+      if (!metadata) {
+        span.setAttribute("sandbox.outcome", "skipped-missing");
+        logger.emit({ outcome: "skipped-missing" });
+        return "skipped-missing";
+      }
+      if (metadata.hibernated) {
+        span.setAttribute("sandbox.outcome", "skipped-already");
+        logger.emit({ outcome: "skipped-already", sandbox_id: metadata.sandboxId });
+        return "skipped-already";
+      }
 
-  try {
-    const sandbox = await provider.reconnect(metadata.sandboxId, {
-      githubToken: options.githubToken,
-      expiresAt: metadata.expiresAt,
-    });
+      logger.set({ sandbox: { sandbox_id: metadata.sandboxId } });
 
-    // Best-effort commit of uncommitted WIP so resume starts from a clean tree.
-    try {
-      await sandbox.exec(
-        "git add -A && git diff --cached --quiet || git commit -m 'wip: hibernation checkpoint'",
-        {
-          cwd: metadata.repoDir,
-          timeoutMs: 30_000,
-        },
-      );
-    } catch (err) {
-      log.warn("sandbox", `WIP commit before hibernation failed (${threadKey}): ${String(err)}`);
-    }
+      try {
+        const sandbox = await provider.reconnect(metadata.sandboxId, {
+          githubToken: options.githubToken,
+          expiresAt: metadata.expiresAt,
+        });
 
-    const snap = await sandbox.snapshot();
-    const next: SandboxSessionMetadata = {
-      ...metadata,
-      hibernated: true,
-      snapshotId: snap.snapshotId,
-    };
-    await writeSession(threadKey, next, redis);
-    log.info(
-      "sandbox",
-      `Hibernated ${metadata.sandboxId} → snapshot ${snap.snapshotId} (${threadKey})`,
-    );
-    return "hibernated";
-  } catch (err) {
-    log.warn("sandbox", `Hibernate failed for ${threadKey}: ${String(err)}`);
-    return "skipped-missing";
-  }
+        // Best-effort commit of uncommitted WIP so resume starts from a clean tree.
+        try {
+          await sandbox.exec(
+            "git add -A && git diff --cached --quiet || git commit -m 'wip: hibernation checkpoint'",
+            {
+              cwd: metadata.repoDir,
+              timeoutMs: 30_000,
+            },
+          );
+        } catch (err) {
+          logger.warn("wip commit before hibernation failed", { reason: String(err) });
+        }
+
+        const snap = await sandbox.snapshot();
+        const next: SandboxSessionMetadata = {
+          ...metadata,
+          hibernated: true,
+          snapshotId: snap.snapshotId,
+        };
+        await writeSession(threadKey, next, redis);
+        span.setAttribute("sandbox.outcome", "hibernated");
+        logger.emit({ outcome: "hibernated", snapshot_id: snap.snapshotId });
+        return "hibernated";
+      } catch (err) {
+        countMetric("sandbox.session.hibernate_failed");
+        span.setAttribute("sandbox.outcome", "hibernate-failed");
+        logger.error(err as Error);
+        logger.emit({ outcome: "hibernate_failed" });
+        return "skipped-missing";
+      }
+    },
+  );
 }

--- a/src/lib/sandbox/vercel-sandbox.ts
+++ b/src/lib/sandbox/vercel-sandbox.ts
@@ -13,7 +13,26 @@ import type {
   VercelSandboxReconnectOptions,
 } from "./types.ts";
 
+import { countMetric, recordDuration } from "../metrics.ts";
+import { withSpan } from "../otel/tracing.ts";
 import { buildGitHubCredentialBrokeringPolicy } from "./credential-brokering.ts";
+
+/**
+ * Categorize a shell command into a low-cardinality bucket so we can tag
+ * sandbox.exec spans without leaking raw command text. `git` and common file
+ * utilities get dedicated labels; everything else falls to `bash`.
+ */
+function cmdCategory(command: string): string {
+  const first = command.trim().split(/\s+/)[0] ?? "";
+  if (first === "git" || first.startsWith("git")) return "git";
+  if (
+    /^(cat|ls|rm|mv|cp|mkdir|touch|stat|find|head|tail|echo|pwd|which|tree|diff|grep|sed|awk|wc|sort|uniq)$/.test(
+      first,
+    )
+  )
+    return "file";
+  return "bash";
+}
 
 export type { VercelSandboxCreateOptions, VercelSandboxReconnectOptions } from "./types.ts";
 
@@ -219,69 +238,99 @@ export class VercelSandbox implements Sandbox {
   }
 
   async exec(command: string, options: ExecOptions = {}): Promise<ExecResult> {
-    const cwd = options.cwd ?? this.workingDirectory;
-    const timeoutMs = options.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
+    const category = cmdCategory(command);
+    return withSpan(
+      "sandbox.exec",
+      { "sandbox.id": this.name, "cmd.category": category },
+      async (span) => {
+        const startTime = Date.now();
+        const cwd = options.cwd ?? this.workingDirectory;
+        const timeoutMs = options.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
 
-    const timeoutSignal = AbortSignal.timeout(timeoutMs);
-    const signal = options.signal
-      ? AbortSignal.any([timeoutSignal, options.signal])
-      : timeoutSignal;
+        const timeoutSignal = AbortSignal.timeout(timeoutMs);
+        const signal = options.signal
+          ? AbortSignal.any([timeoutSignal, options.signal])
+          : timeoutSignal;
 
-    try {
-      const result = await this.sdk.runCommand({
-        cmd: "bash",
-        args: ["-c", command],
-        cwd,
-        env: this.mergedEnv(options.env),
-        signal,
-      });
+        try {
+          const result = await this.sdk.runCommand({
+            cmd: "bash",
+            args: ["-c", command],
+            cwd,
+            env: this.mergedEnv(options.env),
+            signal,
+          });
 
-      const [stdoutRaw, stderrRaw] = await Promise.all([result.stdout(), result.stderr()]);
+          const [stdoutRaw, stderrRaw] = await Promise.all([result.stdout(), result.stderr()]);
 
-      let stdout = stdoutRaw;
-      let truncated = false;
-      if (stdout.length > MAX_OUTPUT_LENGTH) {
-        stdout = stdout.slice(0, MAX_OUTPUT_LENGTH);
-        truncated = true;
-      }
+          let stdout = stdoutRaw;
+          let truncated = false;
+          if (stdout.length > MAX_OUTPUT_LENGTH) {
+            stdout = stdout.slice(0, MAX_OUTPUT_LENGTH);
+            truncated = true;
+          }
 
-      let stderr = stderrRaw;
-      if (stderr.length > MAX_OUTPUT_LENGTH) {
-        stderr = stderr.slice(0, MAX_OUTPUT_LENGTH);
-        truncated = true;
-      }
+          let stderr = stderrRaw;
+          if (stderr.length > MAX_OUTPUT_LENGTH) {
+            stderr = stderr.slice(0, MAX_OUTPUT_LENGTH);
+            truncated = true;
+          }
 
-      return { exitCode: result.exitCode, stdout, stderr, truncated };
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        return {
-          exitCode: null,
-          stdout: "",
-          stderr: `Command timed out after ${timeoutMs}ms`,
-          truncated: false,
-        };
-      }
-      if (err instanceof Error && err.name === "AbortError") throw err;
-      return {
-        exitCode: null,
-        stdout: "",
-        stderr: err instanceof Error ? err.message : String(err),
-        truncated: false,
-      };
-    }
+          span.setAttributes({
+            "sandbox.exit_code": result.exitCode ?? -1,
+            "sandbox.truncated": truncated,
+          });
+          countMetric("sandbox.exec.completed", { category });
+          return { exitCode: result.exitCode, stdout, stderr, truncated };
+        } catch (err) {
+          if (err instanceof Error && err.name === "TimeoutError") {
+            countMetric("sandbox.exec.timeout", { category });
+            span.setAttribute("sandbox.timed_out", true);
+            return {
+              exitCode: null,
+              stdout: "",
+              stderr: `Command timed out after ${timeoutMs}ms`,
+              truncated: false,
+            };
+          }
+          if (err instanceof Error && err.name === "AbortError") {
+            countMetric("sandbox.exec.aborted", { category });
+            throw err;
+          }
+          countMetric("sandbox.exec.error", { category });
+          return {
+            exitCode: null,
+            stdout: "",
+            stderr: err instanceof Error ? err.message : String(err),
+            truncated: false,
+          };
+        } finally {
+          recordDuration("sandbox.exec.duration", Date.now() - startTime, { category });
+        }
+      },
+    );
   }
 
   async extendTimeout(additionalMs: number): Promise<{ expiresAt: number }> {
-    await this.sdk.extendTimeout(additionalMs);
-    // Extension is relative to the existing deadline, not to now — matches the
-    // Sandbox contract (and InMemorySandbox's semantics). session.ts then
-    // persists the new value to Redis.
-    this._expiresAt += additionalMs;
-    this.scheduleTimeoutHook();
-    return { expiresAt: this._expiresAt };
+    return withSpan(
+      "sandbox.extend_timeout",
+      { "sandbox.id": this.name, "sandbox.extend_ms": additionalMs },
+      async () => {
+        await this.sdk.extendTimeout(additionalMs);
+        // Extension is relative to the existing deadline, not to now — matches the
+        // Sandbox contract (and InMemorySandbox's semantics). session.ts then
+        // persists the new value to Redis.
+        this._expiresAt += additionalMs;
+        this.scheduleTimeoutHook();
+        countMetric("sandbox.extend_timeout");
+        return { expiresAt: this._expiresAt };
+      },
+    );
   }
 
   async *streamExec(command: string, options: ExecOptions = {}): AsyncIterable<StreamExecChunk> {
+    const category = cmdCategory(command);
+    const startTime = Date.now();
     const cwd = options.cwd ?? this.workingDirectory;
     const detached = await this.sdk.runCommand({
       cmd: "bash",
@@ -306,6 +355,8 @@ export class VercelSandbox implements Sandbox {
       await detached.wait({ signal: options.signal });
     } finally {
       logs.close();
+      recordDuration("sandbox.stream_exec.duration", Date.now() - startTime, { category });
+      countMetric("sandbox.stream_exec.completed", { category });
     }
   }
 
@@ -314,36 +365,52 @@ export class VercelSandbox implements Sandbox {
   }
 
   async snapshot(): Promise<SnapshotResult> {
-    // The SDK's snapshot call stops the sandbox as a side effect. Clear our
-    // timeout hook so it doesn't fire against a dead VM.
-    if (this.timeoutTimer) {
-      clearTimeout(this.timeoutTimer);
-      this.timeoutTimer = undefined;
-    }
-    const snap = await this.sdk.snapshot();
-    this.stopped = true;
-    return { snapshotId: snap.snapshotId };
+    return withSpan("sandbox.snapshot", { "sandbox.id": this.name }, async () => {
+      const startTime = Date.now();
+      try {
+        // The SDK's snapshot call stops the sandbox as a side effect. Clear our
+        // timeout hook so it doesn't fire against a dead VM.
+        if (this.timeoutTimer) {
+          clearTimeout(this.timeoutTimer);
+          this.timeoutTimer = undefined;
+        }
+        const snap = await this.sdk.snapshot();
+        this.stopped = true;
+        countMetric("sandbox.snapshot.completed");
+        return { snapshotId: snap.snapshotId };
+      } finally {
+        recordDuration("sandbox.snapshot.duration", Date.now() - startTime);
+      }
+    });
   }
 
   async stop(): Promise<void> {
     if (this.stopped) return;
-    this.stopped = true;
-    if (this.timeoutTimer) {
-      clearTimeout(this.timeoutTimer);
-      this.timeoutTimer = undefined;
-    }
-
-    if (this.hooks?.beforeStop) {
+    await withSpan("sandbox.stop", { "sandbox.id": this.name }, async () => {
+      const startTime = Date.now();
       try {
-        await this.hooks.beforeStop(this);
-      } catch (err) {
-        console.error(
-          "[VercelSandbox] beforeStop hook failed:",
-          err instanceof Error ? err.message : err,
-        );
-      }
-    }
+        this.stopped = true;
+        if (this.timeoutTimer) {
+          clearTimeout(this.timeoutTimer);
+          this.timeoutTimer = undefined;
+        }
 
-    await this.sdk.stop();
+        if (this.hooks?.beforeStop) {
+          try {
+            await this.hooks.beforeStop(this);
+          } catch (err) {
+            console.error(
+              "[VercelSandbox] beforeStop hook failed:",
+              err instanceof Error ? err.message : err,
+            );
+          }
+        }
+
+        await this.sdk.stop();
+        countMetric("sandbox.stop.completed");
+      } finally {
+        recordDuration("sandbox.stop.duration", Date.now() - startTime);
+      }
+    });
   }
 }

--- a/src/server/process-event.ts
+++ b/src/server/process-event.ts
@@ -1,11 +1,11 @@
 import { API } from "@discordjs/core/http-only";
 import { REST } from "@discordjs/rest";
-import { log } from "evlog";
 
 import type { Packet } from "@/lib/protocol/types";
 
 import { ConversationStore } from "@/bot/store";
 import { env } from "@/env";
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDuration } from "@/lib/metrics";
 
 import { router } from "./routes/handlers";
@@ -35,9 +35,14 @@ function getMessageChannelId(packet: Packet): string | null {
 }
 
 export async function processEvent(packet: Packet, store: ConversationStore): Promise<void> {
+  const logger = createWideLogger({
+    op: "event.process",
+    event: { type: packet.type },
+  });
+
   if (!(await store.dedup(getDedupKey(packet)))) {
-    log.debug("events", `Dedup hit, skipping ${packet.type}`);
     countMetric("event.dedup_hit", { type: packet.type });
+    logger.emit({ outcome: "dedup_hit" });
     return;
   }
 
@@ -49,12 +54,14 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
 
   const startTime = Date.now();
   const lockChannel = getMessageChannelId(packet);
+  if (lockChannel) logger.set({ lock: { channel_id: lockChannel } });
+
   try {
     if (lockChannel) {
       const token = await store.acquireLock(lockChannel);
       if (!token) {
-        log.warn("events", `Lock held for ${lockChannel}, dropping ${packet.type}`);
         countMetric("event.lock_contention", { type: packet.type });
+        logger.emit({ outcome: "lock_contention", duration_ms: Date.now() - startTime });
         return;
       }
       try {
@@ -66,8 +73,11 @@ export async function processEvent(packet: Packet, store: ConversationStore): Pr
       await router.dispatch(packet, ctx);
     }
     countMetric("event.processed", { type: packet.type });
+    logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
   } catch (err) {
     countMetric("event.error", { type: packet.type });
+    logger.error(err as Error);
+    logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
     throw err;
   } finally {
     recordDuration("event.process_duration", Date.now() - startTime, { type: packet.type });

--- a/src/server/routes/crons.ts
+++ b/src/server/routes/crons.ts
@@ -1,13 +1,14 @@
 import { API } from "@discordjs/core/http-only";
 import { REST } from "@discordjs/rest";
-import { log } from "evlog";
 import { Hono } from "hono";
 
 import type { CronHandler } from "@/bot/crons/types";
 
 import * as crons from "@/bot/handlers/crons";
 import { env } from "@/env";
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 
 const cronMap = new Map((Object.values(crons) as CronHandler[]).map((c) => [c.name, c]));
 
@@ -19,27 +20,35 @@ route.get("/crons/:name", async (c) => {
   // handlers cannot be triggered externally.
   const auth = c.req.header("authorization");
   if (auth !== `Bearer ${env.CRON_SECRET}`) {
+    createWideLogger({ op: "cron.execute" }).emit({ outcome: "unauthorized" });
     return c.json({ error: "Unauthorized" }, 401);
   }
 
   const name = c.req.param("name");
   const cron = cronMap.get(name);
-  if (!cron) return c.json({ error: `Unknown cron: ${name}` }, 404);
-
-  log.info("crons", `Running ${name}`);
-
-  const startTime = Date.now();
-  const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
-  try {
-    await cron.handle(discord);
-    countMetric("cron.completed", { name });
-    return c.json({ ok: true, cron: name });
-  } catch (err) {
-    countMetric("cron.error", { name });
-    throw err;
-  } finally {
-    recordDuration("cron.duration", Date.now() - startTime, { name });
+  if (!cron) {
+    createWideLogger({ op: "cron.execute", cron: { name } }).emit({ outcome: "unknown" });
+    return c.json({ error: `Unknown cron: ${name}` }, 404);
   }
+
+  return withSpan("cron.execute", { "cron.name": name }, async () => {
+    const logger = createWideLogger({ op: "cron.execute", cron: { name } });
+    const startTime = Date.now();
+    const discord = new API(new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN));
+    try {
+      await cron.handle(discord);
+      countMetric("cron.completed", { name });
+      logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+      return c.json({ ok: true, cron: name });
+    } catch (err) {
+      countMetric("cron.error", { name });
+      logger.error(err as Error);
+      logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+      throw err;
+    } finally {
+      recordDuration("cron.duration", Date.now() - startTime, { name });
+    }
+  });
 });
 
 export default route;

--- a/src/server/routes/gateway.ts
+++ b/src/server/routes/gateway.ts
@@ -10,6 +10,9 @@ import { monotonicFactory } from "ulid";
 import type { Packet } from "@/lib/protocol/types";
 
 import { env } from "@/env";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { PacketCodec } from "@/lib/protocol/packets";
 import { isTextChannel } from "@/lib/protocol/utils";
 import { send } from "@/lib/tasks/queue/client";
@@ -35,11 +38,22 @@ end`;
 const ulid = monotonicFactory();
 
 async function relay(packet: Packet, oidcToken: string): Promise<void> {
-  try {
-    await send(DISCORD_EVENT_TOPIC, PacketCodec.encode(packet), { oidcToken });
-  } catch (err) {
-    log.error("gateway", `Failed to publish packet: ${String(err)}`);
-  }
+  return withSpan("gateway.relay", { "packet.type": packet.type }, async () => {
+    const logger = createWideLogger({
+      op: "gateway.relay",
+      event: { type: packet.type },
+    });
+    const startTime = Date.now();
+    try {
+      await send(DISCORD_EVENT_TOPIC, PacketCodec.encode(packet), { oidcToken });
+      countMetric("gateway.packet.relayed", { type: packet.type });
+      logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+    } catch (err) {
+      countMetric("gateway.packet.relay_failed", { type: packet.type });
+      logger.error(err as Error);
+      logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+    }
+  });
 }
 
 type Publish = (packet: Packet) => Promise<void>;
@@ -52,9 +66,11 @@ async function releaseLease(redis: Redis, listenerId: string): Promise<void> {
       [listenerId],
     );
     if (released === 1) {
+      countMetric("gateway.lease.released");
       log.info("gateway", `released lease for ${listenerId}`);
     }
   } catch (err) {
+    countMetric("gateway.lease.release_failed");
     log.error("gateway", `lease release failed: ${String(err)}`);
   }
 }
@@ -76,17 +92,22 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
   const redis = Redis.fromEnv();
   const listenerId = `gw_${ulid()}`;
   const abort = new AbortController();
+  const logger = createWideLogger({
+    op: "gateway.listener",
+    gateway: { listener_id: listenerId },
+  });
 
-  log.info("gateway", `listener ${listenerId} starting`);
+  countMetric("gateway.listener.started");
+  logger.info("listener starting");
 
   const existing = await redis.get<string>(LEADER_KEY).catch(() => null);
   await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
 
   if (existing && existing !== listenerId) {
-    log.info(
-      "gateway",
-      `prior leader ${existing} detected, waiting ${HANDOFF_WAIT_MS}ms for handoff`,
-    );
+    logger.info("prior leader detected, waiting for handoff", {
+      prior_leader: existing,
+      handoff_wait_ms: HANDOFF_WAIT_MS,
+    });
     await new Promise((r) => setTimeout(r, HANDOFF_WAIT_MS));
   }
 
@@ -95,16 +116,15 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
     try {
       const current = await redis.get<string>(LEADER_KEY);
       if (current !== listenerId) {
-        log.info(
-          "gateway",
-          `leadership lost (current=${current ?? "null"}), aborting ${listenerId}`,
-        );
+        countMetric("gateway.leader.lost");
+        logger.info("leadership lost", { current_leader: current ?? null });
         abort.abort();
         return;
       }
       await redis.set(LEADER_KEY, listenerId, { px: LEASE_TTL_MS });
     } catch (err) {
-      log.error("gateway", `lease poll failed: ${String(err)}`);
+      countMetric("gateway.lease.poll_failed");
+      logger.warn("lease poll failed", { reason: String(err) });
     }
   }, POLL_INTERVAL_MS);
 
@@ -116,9 +136,12 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
     const ready = once(client, Events.ClientReady, { signal: readySignal });
     await client.login(env.DISCORD_BOT_TOKEN);
     await ready;
-    log.info("gateway", `ready for ${listenerId}`);
+    countMetric("gateway.listener.ready");
+    logger.set({ ready: true });
   } catch (err) {
-    log.error("gateway", `login/ready failed: ${String(err)}`);
+    countMetric("gateway.listener.login_failed");
+    logger.error(err as Error);
+    logger.emit({ outcome: "login_failed" });
     clearInterval(poll);
     await destroyClient(client, listenerId);
     await releaseLease(redis, listenerId);
@@ -126,22 +149,22 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
   }
 
   const hold = (async () => {
+    const holdStart = Date.now();
+    let exitReason: string = "hold_elapsed";
     try {
       // Fast-path: abort fired between ready and hold-executor running.
       // AbortSignal listeners added post-abort never fire, so teardown
       // would otherwise wait out the full HOLD_MS.
       if (abort.signal.aborted) {
-        log.info("gateway", `hold skipped, already aborted for ${listenerId}`);
+        exitReason = "aborted_pre_hold";
         return;
       }
       await new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          log.info("gateway", `hold elapsed for ${listenerId}`);
-          resolve();
-        }, HOLD_MS);
+        const timer = setTimeout(() => resolve(), HOLD_MS);
         abort.signal.addEventListener(
           "abort",
           () => {
+            exitReason = "aborted";
             clearTimeout(timer);
             resolve();
           },
@@ -149,9 +172,15 @@ async function startGatewayListener(client: Client): Promise<{ hold: Promise<voi
         );
       });
     } finally {
+      recordDuration("gateway.listener.hold_duration", Date.now() - holdStart);
       clearInterval(poll);
       await destroyClient(client, listenerId);
       await releaseLease(redis, listenerId);
+      logger.emit({
+        outcome: "ok",
+        exit_reason: exitReason,
+        hold_duration_ms: Date.now() - holdStart,
+      });
     }
   })();
 

--- a/src/server/routes/handlers.ts
+++ b/src/server/routes/handlers.ts
@@ -1,4 +1,3 @@
-import { log } from "evlog";
 import { resumeHook } from "workflow/api";
 
 import type { EventHandler } from "@/bot/events/types";
@@ -9,6 +8,9 @@ import { handleMention } from "@/bot/handlers/events";
 import { isBotMention } from "@/bot/mention";
 import { EventRouter } from "@/bot/router";
 import { AgentContext } from "@/lib/ai/context";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 
 export const router = new EventRouter();
 
@@ -25,21 +27,42 @@ router.onMessage(async (packet, ctx) => {
   const existing = await ctx.store.get(channelId);
   if (!existing) return;
 
-  log.info("handlers", `Forwarding message to workflow ${existing.workflowRunId}`);
-
-  try {
-    const turnContext = AgentContext.fromPacket(packet).toJSON();
-    const event: ChatHookEvent = {
-      type: "message",
-      content: packet.data.content,
-      context: turnContext,
-    };
-    await resumeHook(existing.workflowRunId, event);
-    await ctx.store.touch(channelId);
-  } catch (err) {
-    log.info("handlers", `Conversation ended for ${channelId}: ${String(err)}`);
-    await ctx.store.delete(channelId);
-  }
+  return withSpan(
+    "chat.resume_hook",
+    {
+      "chat.id": existing.workflowRunId,
+      "chat.channel_id": channelId,
+      "chat.workflow_run_id": existing.workflowRunId,
+    },
+    async () => {
+      const logger = createWideLogger({
+        op: "chat.resume_hook",
+        chat: {
+          id: existing.workflowRunId,
+          workflow_run_id: existing.workflowRunId,
+          channel_id: channelId,
+          user_id: packet.data.author.id,
+        },
+      });
+      try {
+        const turnContext = AgentContext.fromPacket(packet).toJSON();
+        const event: ChatHookEvent = {
+          type: "message",
+          content: packet.data.content,
+          context: turnContext,
+        };
+        await resumeHook(existing.workflowRunId, event);
+        await ctx.store.touch(channelId);
+        countMetric("chat.resume_hook.ok");
+        logger.emit({ outcome: "ok" });
+      } catch (err) {
+        countMetric("chat.resume_hook.ended");
+        await ctx.store.delete(channelId);
+        logger.warn("workflow ended", { reason: String(err) });
+        logger.emit({ outcome: "ended" });
+      }
+    },
+  );
 });
 
 for (const h of Object.values(userEvents) as EventHandler[]) {

--- a/src/server/routes/interactions/command.ts
+++ b/src/server/routes/interactions/command.ts
@@ -1,6 +1,5 @@
 import { API } from "@discordjs/core/http-only";
 import { waitUntil } from "@vercel/functions";
-import { log } from "evlog";
 
 import type {
   InteractionResponsePayload,
@@ -11,7 +10,9 @@ import type { DiscordInteraction } from "@/lib/protocol/types";
 
 import { parseOptions } from "@/bot/commands/registry";
 import * as commands from "@/bot/handlers/commands";
-import { countMetric } from "@/lib/metrics";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { InteractionResponseType } from "@/lib/protocol/constants";
 
 import type { DispatcherResult } from "./types.ts";
@@ -35,7 +36,6 @@ export async function handleApplicationCommand(
     };
   }
 
-  log.info("interactions", `Executing /${name}`);
   countMetric("interaction.command", { command: name });
 
   if (command.modal) return runModalCommand(command, interaction);
@@ -50,18 +50,43 @@ async function runModalCommand(
   command: SlashCommand,
   interaction: DiscordInteraction,
 ): Promise<InteractionResponsePayload> {
-  const discord = buildDiscord();
-  try {
-    const response = await command.execute(buildCtx(interaction, discord));
-    if (response) return response;
-    log.error("interactions", `/${command.name} (modal) returned no response`);
-    countMetric("interaction.command_error", { command: command.name });
-    return ephemeralError(`/${command.name} did not produce a response.`);
-  } catch (err) {
-    log.error("interactions", `/${command.name} failed: ${describeError(err)}`);
-    countMetric("interaction.command_error", { command: command.name });
-    return ephemeralError(`Error executing /${command.name}.`);
-  }
+  return withSpan(
+    "interaction.command",
+    { "command.name": command.name, "command.mode": "modal" },
+    async () => {
+      const logger = createWideLogger({
+        op: "interaction.command",
+        command: { name: command.name, mode: "modal" },
+        user: { id: interaction.member?.user?.id ?? interaction.user?.id },
+      });
+      const startTime = Date.now();
+      const discord = buildDiscord();
+      try {
+        const response = await command.execute(buildCtx(interaction, discord));
+        if (response) {
+          logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+          return response;
+        }
+        countMetric("interaction.command_error", { command: command.name });
+        logger.emit({
+          outcome: "error",
+          duration_ms: Date.now() - startTime,
+          reason: "no_response",
+        });
+        return ephemeralError(`/${command.name} did not produce a response.`);
+      } catch (err) {
+        countMetric("interaction.command_error", { command: command.name });
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        return ephemeralError(`Error executing /${command.name}.`);
+      } finally {
+        recordDuration("interaction.command_duration", Date.now() - startTime, {
+          command: command.name,
+          mode: "modal",
+        });
+      }
+    },
+  );
 }
 
 function runDeferredCommand(
@@ -70,17 +95,45 @@ function runDeferredCommand(
 ): InteractionResponsePayload {
   const discord = buildDiscord();
   waitUntil(
-    command.execute(buildCtx(interaction, discord)).catch((err: unknown) => {
-      log.error("interactions", `/${command.name} failed: ${describeError(err)}`);
-      countMetric("interaction.command_error", { command: command.name });
-      discord.interactions
-        .editReply(interaction.application_id, interaction.token, {
-          content: `Error executing /${command.name}.`,
-        })
-        .catch((e: unknown) =>
-          log.error("interactions", `Failed to send error response: ${describeError(e)}`),
-        );
-    }),
+    withSpan(
+      "interaction.command",
+      { "command.name": command.name, "command.mode": "deferred" },
+      async () => {
+        const logger = createWideLogger({
+          op: "interaction.command",
+          command: { name: command.name, mode: "deferred" },
+          user: { id: interaction.member?.user?.id ?? interaction.user?.id },
+        });
+        const startTime = Date.now();
+        try {
+          await command.execute(buildCtx(interaction, discord));
+          logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+        } catch (err) {
+          countMetric("interaction.command_error", { command: command.name });
+          logger.error(err as Error);
+          logger.emit({
+            outcome: "error",
+            duration_ms: Date.now() - startTime,
+            error_summary: describeError(err),
+          });
+          await discord.interactions
+            .editReply(interaction.application_id, interaction.token, {
+              content: `Error executing /${command.name}.`,
+            })
+            .catch((e: unknown) =>
+              createWideLogger({
+                op: "interaction.command.error_reply",
+                command: { name: command.name },
+              }).error(e as Error),
+            );
+        } finally {
+          recordDuration("interaction.command_duration", Date.now() - startTime, {
+            command: command.name,
+            mode: "deferred",
+          });
+        }
+      },
+    ),
   );
   return {
     type: InteractionResponseType.DeferredChannelMessageWithSource,

--- a/src/server/routes/interactions/component.ts
+++ b/src/server/routes/interactions/component.ts
@@ -1,11 +1,12 @@
 import { waitUntil } from "@vercel/functions";
-import { log } from "evlog";
 
 import type { ComponentHandler } from "@/bot/components/types";
 import type { DiscordInteraction } from "@/lib/protocol/types";
 
 import * as components from "@/bot/components";
-import { countMetric } from "@/lib/metrics";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { InteractionResponseType } from "@/lib/protocol/constants";
 
 import type { DispatcherResult } from "./types.ts";
@@ -20,16 +21,34 @@ export function handleMessageComponent(interaction: DiscordInteraction): Dispatc
   const customId = interaction.data?.custom_id;
   if (!customId) return { error: "Missing custom_id", status: 400 };
 
-  const prefix = customId.split(":")[0];
+  const prefix = customId.split(":")[0] ?? "unknown";
   const handler = componentHandlers.find((h) => h.prefix === prefix);
 
   if (handler) {
-    log.info("interactions", `Handling component ${prefix}`);
     countMetric("interaction.component", { prefix });
     const discord = buildDiscord();
     waitUntil(
-      handler.handle({ interaction, discord, customId }).catch((err: unknown) => {
-        log.error("interactions", `Component ${customId} failed: ${describeError(err)}`);
+      withSpan("interaction.component", { "component.prefix": prefix }, async () => {
+        const logger = createWideLogger({
+          op: "interaction.component",
+          component: { prefix, custom_id: customId },
+          user: { id: interaction.member?.user?.id ?? interaction.user?.id },
+        });
+        const startTime = Date.now();
+        try {
+          await handler.handle({ interaction, discord, customId });
+          logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+        } catch (err: unknown) {
+          countMetric("interaction.component_error", { prefix });
+          logger.error(err as Error);
+          logger.emit({
+            outcome: "error",
+            duration_ms: Date.now() - startTime,
+            error_summary: describeError(err),
+          });
+        } finally {
+          recordDuration("interaction.component_duration", Date.now() - startTime, { prefix });
+        }
       }),
     );
   }

--- a/src/server/routes/interactions/index.ts
+++ b/src/server/routes/interactions/index.ts
@@ -3,6 +3,8 @@ import { Hono, type Context } from "hono";
 import type { DiscordInteraction } from "@/lib/protocol/types";
 
 import { env } from "@/env";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { InteractionType, InteractionResponseType } from "@/lib/protocol/constants";
 import { verifyInteraction } from "@/lib/protocol/verify";
 
@@ -15,36 +17,67 @@ import { handleModalSubmit } from "./modal.ts";
 const route = new Hono();
 
 route.post("/interactions", async (c) => {
-  const result = await verifyInteraction(c.req.raw, env.DISCORD_BOT_PUBLIC_KEY);
-  if (!result.valid) return c.json({ error: "Invalid signature" }, 401);
+  return withSpan(
+    "interaction.dispatch",
+    { "http.route": "/api/discord/interactions" },
+    async () => {
+      const startTime = Date.now();
+      try {
+        const result = await verifyInteraction(c.req.raw, env.DISCORD_BOT_PUBLIC_KEY);
+        if (!result.valid) {
+          countMetric("interaction.unauthorized");
+          return c.json({ error: "Invalid signature" }, 401);
+        }
 
-  const interaction = result.body as DiscordInteraction;
+        const interaction = result.body as DiscordInteraction;
+        countMetric("interaction.received", { type: typeLabel(interaction.type) });
 
-  switch (interaction.type) {
-    case InteractionType.Ping:
-      return c.json({ type: InteractionResponseType.Pong });
+        switch (interaction.type) {
+          case InteractionType.Ping:
+            return c.json({ type: InteractionResponseType.Pong });
 
-    case InteractionType.ApplicationCommand:
-      return dispatch(c, await handleApplicationCommand(interaction));
+          case InteractionType.ApplicationCommand:
+            return dispatch(c, await handleApplicationCommand(interaction));
 
-    case InteractionType.MessageComponent:
-      return dispatch(c, handleMessageComponent(interaction));
+          case InteractionType.MessageComponent:
+            return dispatch(c, handleMessageComponent(interaction));
 
-    // No slash commands currently declare autocomplete options; respond with an
-    // empty choice list so Discord doesn't show a stale/broken suggestion popup.
-    case InteractionType.ApplicationCommandAutocomplete:
-      return c.json({
-        type: InteractionResponseType.ApplicationCommandAutocompleteResult,
-        data: { choices: [] },
-      });
+          // No slash commands currently declare autocomplete options; respond with an
+          // empty choice list so Discord doesn't show a stale/broken suggestion popup.
+          case InteractionType.ApplicationCommandAutocomplete:
+            return c.json({
+              type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+              data: { choices: [] },
+            });
 
-    case InteractionType.ModalSubmit:
-      return dispatch(c, await handleModalSubmit(interaction));
+          case InteractionType.ModalSubmit:
+            return dispatch(c, await handleModalSubmit(interaction));
 
-    default:
-      return c.json({ error: "Unhandled interaction type" }, 400);
-  }
+          default:
+            countMetric("interaction.unknown_type");
+            return c.json({ error: "Unhandled interaction type" }, 400);
+        }
+      } finally {
+        recordDuration("interaction.dispatch_duration", Date.now() - startTime);
+      }
+    },
+  );
 });
+
+function typeLabel(type: InteractionType): string {
+  switch (type) {
+    case InteractionType.Ping:
+      return "ping";
+    case InteractionType.ApplicationCommand:
+      return "command";
+    case InteractionType.MessageComponent:
+      return "component";
+    case InteractionType.ApplicationCommandAutocomplete:
+      return "autocomplete";
+    case InteractionType.ModalSubmit:
+      return "modal";
+  }
+}
 
 function dispatch(c: Context, result: DispatcherResult): Response {
   if ("error" in result) return c.json({ error: result.error }, result.status);

--- a/src/server/routes/interactions/modal.ts
+++ b/src/server/routes/interactions/modal.ts
@@ -1,10 +1,10 @@
-import { log } from "evlog";
-
 import type { ModalHandler } from "@/bot/modals/types";
 import type { DiscordInteraction } from "@/lib/protocol/types";
 
 import * as modalHandlers from "@/bot/handlers/modals";
-import { countMetric } from "@/lib/metrics";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 
 import type { DispatcherResult } from "./types.ts";
 
@@ -20,30 +20,48 @@ export async function handleModalSubmit(
   const customId = interaction.data?.custom_id;
   if (!customId) return { error: "Missing custom_id", status: 400 };
 
-  const prefix = customId.split(":")[0];
+  const prefix = customId.split(":")[0] ?? "unknown";
   const handler = modalHandlerList.find((h) => h.prefix === prefix);
 
   if (!handler) {
-    log.warn("interactions", `Unexpected modal submit: ${customId}`);
+    createWideLogger({ op: "interaction.modal", modal: { prefix, custom_id: customId } }).emit({
+      outcome: "unknown",
+    });
     return ephemeralError("This form is no longer supported.");
   }
 
-  log.info("interactions", `Handling modal ${prefix}`);
-  countMetric("interaction.modal", { prefix });
-
-  const discord = buildDiscord();
-  try {
-    return await handler.handle({
-      interaction,
-      discord,
-      customId,
-      fields: extractModalFields(interaction),
+  return withSpan("interaction.modal", { "modal.prefix": prefix }, async () => {
+    const logger = createWideLogger({
+      op: "interaction.modal",
+      modal: { prefix, custom_id: customId },
+      user: { id: interaction.member?.user?.id ?? interaction.user?.id },
     });
-  } catch (err: unknown) {
-    log.error("interactions", `Modal ${customId} failed: ${describeError(err)}`);
-    countMetric("interaction.modal_error", { prefix });
-    return ephemeralError("Something went wrong processing the form.");
-  }
+    const startTime = Date.now();
+    countMetric("interaction.modal", { prefix });
+
+    const discord = buildDiscord();
+    try {
+      const result = await handler.handle({
+        interaction,
+        discord,
+        customId,
+        fields: extractModalFields(interaction),
+      });
+      logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+      return result;
+    } catch (err: unknown) {
+      countMetric("interaction.modal_error", { prefix });
+      logger.error(err as Error);
+      logger.emit({
+        outcome: "error",
+        duration_ms: Date.now() - startTime,
+        error_summary: describeError(err),
+      });
+      return ephemeralError("Something went wrong processing the form.");
+    } finally {
+      recordDuration("interaction.modal_duration", Date.now() - startTime, { prefix });
+    }
+  });
 }
 
 function extractModalFields(interaction: DiscordInteraction): Map<string, string> {

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -1,6 +1,5 @@
 import { API } from "@discordjs/core/http-only";
 import { REST } from "@discordjs/rest";
-import { log } from "evlog";
 import { createHook, getWorkflowMetadata } from "workflow";
 
 import type { ChatMessage, SerializedAgentContext, TurnUsage } from "@/lib/ai/types";
@@ -10,7 +9,9 @@ import { ConversationStore } from "@/bot/store";
 import { buildContextSnapshot } from "@/lib/ai/snapshot";
 import { streamTurn } from "@/lib/ai/streaming";
 import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
-import { countMetric } from "@/lib/metrics";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { releaseSession } from "@/lib/sandbox/session";
 
 import type { ChatHookEvent, ChatPayload } from "./types";
@@ -35,10 +36,57 @@ async function runTurn(
   channelId: string,
   messages: ChatMessage[],
   serializedContext: SerializedAgentContext,
+  workflowRunId: string,
+  turnIndex: number,
 ) {
   "use step";
-  const discord = new API(new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN!));
-  return streamTurn(discord, channelId, messages, serializedContext);
+  return withSpan(
+    "workflow.chat.run_turn",
+    {
+      "chat.id": workflowRunId,
+      "chat.channel_id": channelId,
+      "chat.turn_index": turnIndex,
+      "chat.user_id": serializedContext.userId,
+    },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.chat.run_turn",
+        chat: {
+          id: workflowRunId,
+          channel_id: channelId,
+          thread_id: serializedContext.thread?.id,
+          user_id: serializedContext.userId,
+          turn_index: turnIndex,
+        },
+      });
+      const startTime = Date.now();
+      const discord = new API(new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN!));
+      try {
+        const result = await streamTurn(discord, channelId, messages, serializedContext, {
+          workflowRunId,
+          turnIndex,
+        });
+        logger.emit({
+          outcome: "ok",
+          duration_ms: Date.now() - startTime,
+          turn: turnIndex === 1 ? "first" : "followup",
+          tokens: result.usage.totalTokens,
+          tool_calls: result.usage.toolCallCount,
+          steps: result.usage.stepCount,
+          text_length: result.text.length,
+        });
+        return result;
+      } catch (err) {
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        throw err;
+      } finally {
+        recordDuration("workflow.chat.run_turn_duration", Date.now() - startTime, {
+          turn: turnIndex === 1 ? "first" : "followup",
+        });
+      }
+    },
+  );
 }
 
 async function persistSnapshot(
@@ -52,46 +100,87 @@ async function persistSnapshot(
   },
 ) {
   "use step";
-  // Build the snapshot inside the step. buildContextSnapshot materializes the
-  // full orchestrator tool set (AI SDK `tool()` wrappers, Zod → JSON Schema
-  // conversion), which must not run in the workflow sandbox. Best-effort: a
-  // Redis blip should not abort the chat workflow.
-  try {
-    const snapshot = buildContextSnapshot(args);
-    await new ContextSnapshotStore().set(channelId, threadId, snapshot);
-  } catch (err) {
-    log.warn("workflow", `Snapshot persist failed for ${channelId}: ${String(err)}`);
-    countMetric("workflow.chat.snapshot_error");
-  }
+  return withSpan(
+    "workflow.chat.persist_snapshot",
+    {
+      "chat.channel_id": channelId,
+      ...(threadId ? { "chat.thread_id": threadId } : {}),
+      "chat.turn_count": args.turnCount,
+    },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.chat.persist_snapshot",
+        chat: {
+          channel_id: channelId,
+          thread_id: threadId,
+          turn_count: args.turnCount,
+          total_tokens: args.totalUsage.totalTokens,
+        },
+      });
+      const startTime = Date.now();
+      // Build the snapshot inside the step. buildContextSnapshot materializes the
+      // full orchestrator tool set (AI SDK `tool()` wrappers, Zod → JSON Schema
+      // conversion), which must not run in the workflow sandbox. Best-effort: a
+      // Redis blip should not abort the chat workflow.
+      try {
+        const snapshot = buildContextSnapshot(args);
+        await new ContextSnapshotStore().set(channelId, threadId, snapshot);
+        logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+      } catch (err) {
+        countMetric("workflow.chat.snapshot_error");
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+      } finally {
+        recordDuration("workflow.chat.persist_snapshot_duration", Date.now() - startTime);
+      }
+    },
+  );
 }
 
 async function cleanupConversation(channelId: string, threadId: string | undefined) {
   "use step";
-  const threadKey = threadId ?? channelId;
-  // Snapshot + sandbox release are best-effort; only the ConversationStore
-  // delete is load-bearing for starting a fresh workflow later.
-  const [conversationResult, snapshotResult, sandboxResult] = await Promise.allSettled([
-    new ConversationStore().delete(channelId),
-    new ContextSnapshotStore().delete(channelId, threadId),
-    releaseSession(threadKey),
-  ]);
-  if (snapshotResult.status === "rejected") {
-    log.warn(
-      "workflow",
-      `Snapshot delete failed for ${channelId}: ${String(snapshotResult.reason)}`,
-    );
-    countMetric("workflow.chat.snapshot_cleanup_error");
-  }
-  if (sandboxResult.status === "rejected") {
-    log.warn(
-      "workflow",
-      `Sandbox release failed for ${threadKey}: ${String(sandboxResult.reason)}`,
-    );
-    countMetric("workflow.chat.sandbox_cleanup_error");
-  }
-  if (conversationResult.status === "rejected") {
-    throw conversationResult.reason;
-  }
+  return withSpan(
+    "workflow.chat.cleanup",
+    {
+      "chat.channel_id": channelId,
+      ...(threadId ? { "chat.thread_id": threadId } : {}),
+    },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.chat.cleanup",
+        chat: { channel_id: channelId, thread_id: threadId },
+      });
+      const startTime = Date.now();
+      const threadKey = threadId ?? channelId;
+      // Snapshot + sandbox release are best-effort; only the ConversationStore
+      // delete is load-bearing for starting a fresh workflow later.
+      const [conversationResult, snapshotResult, sandboxResult] = await Promise.allSettled([
+        new ConversationStore().delete(channelId),
+        new ContextSnapshotStore().delete(channelId, threadId),
+        releaseSession(threadKey),
+      ]);
+      const cleanup = {
+        snapshot: snapshotResult.status,
+        sandbox: sandboxResult.status,
+        conversation: conversationResult.status,
+      };
+      if (snapshotResult.status === "rejected") {
+        countMetric("workflow.chat.snapshot_cleanup_error");
+        logger.warn("snapshot delete failed", { reason: String(snapshotResult.reason) });
+      }
+      if (sandboxResult.status === "rejected") {
+        countMetric("workflow.chat.sandbox_cleanup_error");
+        logger.warn("sandbox release failed", { reason: String(sandboxResult.reason) });
+      }
+      recordDuration("workflow.chat.cleanup_duration", Date.now() - startTime);
+      if (conversationResult.status === "rejected") {
+        logger.error(conversationResult.reason as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime, cleanup });
+        throw conversationResult.reason;
+      }
+      logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime, cleanup });
+    },
+  );
 }
 
 export async function chatWorkflow(payload: ChatPayload) {
@@ -100,7 +189,16 @@ export async function chatWorkflow(payload: ChatPayload) {
   const { channelId, threadId, content, context } = payload;
   const { workflowRunId } = getWorkflowMetadata();
 
-  log.info("workflow", `Chat started: ${workflowRunId}`);
+  const workflowLogger = createWideLogger({
+    op: "workflow.chat",
+    chat: {
+      id: workflowRunId,
+      channel_id: channelId,
+      thread_id: threadId,
+      user_id: context.userId,
+    },
+  });
+  workflowLogger.info("chat workflow started");
   countMetric("workflow.chat.started");
 
   // Stable for the lifetime of this workflow — the conversation is pinned to
@@ -111,8 +209,9 @@ export async function chatWorkflow(payload: ChatPayload) {
   const stableRecentMessages = context.recentMessages;
   const stableReferencedContext = context.referencedContext;
 
+  const workflowStart = Date.now();
   const messages: ChatMessage[] = [{ role: "user", content }];
-  const first = await runTurn(channelId, messages, context);
+  const first = await runTurn(channelId, messages, context, workflowRunId, 1);
   messages.push({ role: "assistant", content: first.text });
   capHistory(messages);
 
@@ -122,15 +221,17 @@ export async function chatWorkflow(payload: ChatPayload) {
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
+  let endedByUser = false;
+
   for await (const event of hook) {
+    countMetric("workflow.chat.hook_event", { type: event.type });
     if (event.type === "done") {
-      log.info("workflow", `Chat ended by user: ${workflowRunId}`);
       countMetric("workflow.chat.ended");
+      endedByUser = true;
       break;
     }
     if (!event.content) continue;
 
-    log.info("workflow", `Follow-up from ${event.context.username}: ${workflowRunId}`);
     countMetric("workflow.chat.followup");
 
     // Merge the fresh per-turn identity from the event with the stable
@@ -144,7 +245,7 @@ export async function chatWorkflow(payload: ChatPayload) {
     };
 
     messages.push({ role: "user", content: event.content });
-    const turn = await runTurn(channelId, messages, turnContext);
+    const turn = await runTurn(channelId, messages, turnContext, workflowRunId, turnCount + 1);
     messages.push({ role: "assistant", content: turn.text });
     capHistory(messages);
     turnCount += 1;
@@ -158,5 +259,12 @@ export async function chatWorkflow(payload: ChatPayload) {
   }
 
   await cleanupConversation(channelId, threadId);
-  log.info("workflow", `Chat cleaned up: ${workflowRunId}`);
+  workflowLogger.emit({
+    outcome: "ok",
+    duration_ms: Date.now() - workflowStart,
+    ended_by: endedByUser ? "user" : "hook_close",
+    turn_count: turnCount,
+    total_tokens: totalUsage.totalTokens,
+    tool_calls: totalUsage.toolCallCount,
+  });
 }

--- a/src/workflows/sandbox-lifecycle.ts
+++ b/src/workflows/sandbox-lifecycle.ts
@@ -1,7 +1,8 @@
-import { log } from "evlog";
 import { sleep } from "workflow";
 
+import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { hibernateSession, readSession, writeSession } from "@/lib/sandbox/session";
 
 /**
@@ -27,56 +28,109 @@ interface WakeDecision {
 
 async function decideWake(threadKey: string): Promise<WakeDecision> {
   "use step";
-  const meta = await readSession(threadKey);
-  if (!meta) return { action: "exit", reason: "session-gone" };
-  if (meta.hibernated) return { action: "exit", reason: "already-hibernated" };
+  return withSpan(
+    "sandbox.lifecycle.decide_wake",
+    { "sandbox.thread_key": threadKey },
+    async () => {
+      const logger = createWideLogger({
+        op: "sandbox.lifecycle.decide_wake",
+        sandbox: { thread_key: threadKey },
+      });
+      const meta = await readSession(threadKey);
+      if (!meta) {
+        logger.emit({ action: "exit", reason: "session-gone" });
+        return { action: "exit", reason: "session-gone" };
+      }
+      if (meta.hibernated) {
+        logger.emit({ action: "exit", reason: "already-hibernated" });
+        return { action: "exit", reason: "already-hibernated" };
+      }
 
-  const wakeAt = meta.expiresAt - HIBERNATION_LEAD_MS;
-  const now = Date.now();
-  if (wakeAt <= now) {
-    return { action: "sleep", wakeAt: now + MIN_SLEEP_MS, reason: "imminent" };
-  }
-  return {
-    action: "sleep",
-    wakeAt: Math.min(wakeAt, now + MAX_SLEEP_MS),
-    reason: "scheduled",
-  };
+      const wakeAt = meta.expiresAt - HIBERNATION_LEAD_MS;
+      const now = Date.now();
+      if (wakeAt <= now) {
+        logger.emit({
+          action: "sleep",
+          reason: "imminent",
+          wake_at: new Date(now + MIN_SLEEP_MS).toISOString(),
+        });
+        return { action: "sleep", wakeAt: now + MIN_SLEEP_MS, reason: "imminent" };
+      }
+      const clampedWake = Math.min(wakeAt, now + MAX_SLEEP_MS);
+      logger.emit({
+        action: "sleep",
+        reason: "scheduled",
+        wake_at: new Date(clampedWake).toISOString(),
+        expires_at: new Date(meta.expiresAt).toISOString(),
+      });
+      return { action: "sleep", wakeAt: clampedWake, reason: "scheduled" };
+    },
+  );
 }
 
 async function performHibernation(
   threadKey: string,
 ): Promise<"hibernated" | "missing" | "still-active"> {
   "use step";
-  // Re-read — the expiresAt might have been bumped while we slept.
-  const meta = await readSession(threadKey);
-  if (!meta) return "missing";
-  if (meta.hibernated) return "missing";
+  return withSpan("sandbox.lifecycle.hibernate", { "sandbox.thread_key": threadKey }, async () => {
+    const logger = createWideLogger({
+      op: "sandbox.lifecycle.hibernate",
+      sandbox: { thread_key: threadKey },
+    });
+    // Re-read — the expiresAt might have been bumped while we slept.
+    const meta = await readSession(threadKey);
+    if (!meta) {
+      logger.emit({ outcome: "missing", reason: "no-session" });
+      return "missing";
+    }
+    if (meta.hibernated) {
+      logger.emit({ outcome: "missing", reason: "already-hibernated" });
+      return "missing";
+    }
 
-  // Give the conversation one more buffer: if the deadline moved further out
-  // than the hibernation lead, the user/chat is still engaged and we should
-  // loop back to sleep instead of hibernating.
-  if (meta.expiresAt - Date.now() > HIBERNATION_LEAD_MS * 2) {
-    return "still-active";
-  }
+    // Give the conversation one more buffer: if the deadline moved further out
+    // than the hibernation lead, the user/chat is still engaged and we should
+    // loop back to sleep instead of hibernating.
+    if (meta.expiresAt - Date.now() > HIBERNATION_LEAD_MS * 2) {
+      logger.emit({ outcome: "still-active", expires_at: new Date(meta.expiresAt).toISOString() });
+      return "still-active";
+    }
 
-  const result = await hibernateSession(threadKey);
-  if (result === "hibernated") {
-    countMetric("sandbox.lifecycle.hibernated");
-    return "hibernated";
-  }
-  countMetric("sandbox.lifecycle.hibernate_skipped", { reason: result });
-  return "missing";
+    const result = await hibernateSession(threadKey);
+    if (result === "hibernated") {
+      countMetric("sandbox.lifecycle.hibernated");
+      logger.emit({ outcome: "hibernated", sandbox_id: meta.sandboxId });
+      return "hibernated";
+    }
+    countMetric("sandbox.lifecycle.hibernate_skipped", { reason: result });
+    logger.emit({ outcome: "missing", reason: result });
+    return "missing";
+  });
 }
 
 async function markLifecycleOwned(threadKey: string, runId: string): Promise<boolean> {
   "use step";
-  const meta = await readSession(threadKey);
-  if (!meta) return false;
-  // Mark this workflow as the owner; the session-lifecycle run id lets a new
-  // invocation take over if the previous one was lost.
-  const claimed = { ...meta, lifecycleRunId: runId };
-  await writeSession(threadKey, claimed);
-  return true;
+  return withSpan(
+    "sandbox.lifecycle.mark_owned",
+    { "sandbox.thread_key": threadKey, "sandbox.lifecycle_run_id": runId },
+    async () => {
+      const logger = createWideLogger({
+        op: "sandbox.lifecycle.mark_owned",
+        sandbox: { thread_key: threadKey, lifecycle_run_id: runId },
+      });
+      const meta = await readSession(threadKey);
+      if (!meta) {
+        logger.emit({ outcome: "no-session" });
+        return false;
+      }
+      // Mark this workflow as the owner; the session-lifecycle run id lets a new
+      // invocation take over if the previous one was lost.
+      const claimed = { ...meta, lifecycleRunId: runId };
+      await writeSession(threadKey, claimed);
+      logger.emit({ outcome: "ok", sandbox_id: meta.sandboxId });
+      return true;
+    },
+  );
 }
 
 /**
@@ -90,10 +144,15 @@ async function markLifecycleOwned(threadKey: string, runId: string): Promise<boo
 export async function sandboxLifecycleWorkflow(threadKey: string, runId: string) {
   "use workflow";
 
-  log.info("sandbox-lifecycle", `Started for thread ${threadKey} (run ${runId})`);
+  const workflowLogger = createWideLogger({
+    op: "sandbox.lifecycle",
+    sandbox: { thread_key: threadKey, lifecycle_run_id: runId },
+  });
+  workflowLogger.info("lifecycle started");
+
   const owned = await markLifecycleOwned(threadKey, runId);
   if (!owned) {
-    log.info("sandbox-lifecycle", `No session; exiting (thread ${threadKey})`);
+    workflowLogger.emit({ outcome: "exit", reason: "no-session" });
     return;
   }
 
@@ -102,10 +161,11 @@ export async function sandboxLifecycleWorkflow(threadKey: string, runId: string)
   for (let iteration = 0; iteration < 24; iteration += 1) {
     const decision = await decideWake(threadKey);
     if (decision.action === "exit") {
-      log.info(
-        "sandbox-lifecycle",
-        `Exiting thread=${threadKey} reason=${decision.reason ?? "unknown"}`,
-      );
+      workflowLogger.emit({
+        outcome: "exit",
+        reason: decision.reason ?? "unknown",
+        iterations: iteration,
+      });
       return;
     }
 
@@ -117,11 +177,12 @@ export async function sandboxLifecycleWorkflow(threadKey: string, runId: string)
 
     const result = await performHibernation(threadKey);
     if (result === "hibernated" || result === "missing") {
+      workflowLogger.emit({ outcome: result, iterations: iteration + 1 });
       return;
     }
     // "still-active" — loop back and re-compute wake time against the new deadline.
   }
 
-  log.warn("sandbox-lifecycle", `Max iterations hit for ${threadKey}; exiting`);
   countMetric("sandbox.lifecycle.max_iterations");
+  workflowLogger.emit({ outcome: "exit", reason: "max-iterations" });
 }

--- a/src/workflows/task.ts
+++ b/src/workflows/task.ts
@@ -1,6 +1,5 @@
 import { API } from "@discordjs/core/http-only";
 import { REST } from "@discordjs/rest";
-import { log } from "evlog";
 import { sleep, getWorkflowMetadata } from "workflow";
 
 import type { TaskMeta } from "@/lib/tasks/types";
@@ -8,6 +7,9 @@ import type { TaskMeta } from "@/lib/tasks/types";
 import { AgentContext } from "@/lib/ai/context";
 import { MessageRenderer } from "@/lib/ai/message-renderer";
 import { streamTurn } from "@/lib/ai/streaming";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric, recordDuration } from "@/lib/metrics";
+import { withSpan } from "@/lib/otel/tracing";
 import { nextOccurrence } from "@/lib/tasks/cron";
 import { saveTask, removeTask, getTask } from "@/lib/tasks/registry";
 
@@ -17,66 +19,148 @@ export type { TaskPayload } from "./types";
 
 async function persistTask(meta: TaskMeta) {
   "use step";
-  await saveTask(meta);
-  log.info("task-workflow", `Registered task ${meta.id}: ${meta.description}`);
+  return withSpan(
+    "workflow.task.persist",
+    { "task.id": meta.id, "task.schedule_type": meta.schedule.type },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.task.persist",
+        task: {
+          id: meta.id,
+          description: meta.description,
+          schedule_type: meta.schedule.type,
+          action_type: meta.action.type,
+        },
+      });
+      try {
+        await saveTask(meta);
+        countMetric("workflow.task.persisted", { schedule_type: meta.schedule.type });
+        logger.emit({ outcome: "ok" });
+      } catch (err) {
+        logger.error(err as Error);
+        logger.emit({ outcome: "error" });
+        throw err;
+      }
+    },
+  );
 }
 
 async function computeNextRun(meta: TaskMeta): Promise<Date> {
   "use step";
-  if (meta.schedule.type === "once" && meta.schedule.at) {
-    return new Date(meta.schedule.at);
-  }
-  if (meta.schedule.cron) {
-    return nextOccurrence(meta.schedule.cron, new Date(), meta.schedule.timezone);
-  }
-  throw new Error(`Invalid schedule for task ${meta.id}`);
+  return withSpan(
+    "workflow.task.compute_next_run",
+    { "task.id": meta.id, "task.schedule_type": meta.schedule.type },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.task.compute_next_run",
+        task: { id: meta.id, schedule_type: meta.schedule.type },
+      });
+      try {
+        let next: Date;
+        if (meta.schedule.type === "once" && meta.schedule.at) {
+          next = new Date(meta.schedule.at);
+        } else if (meta.schedule.cron) {
+          next = nextOccurrence(meta.schedule.cron, new Date(), meta.schedule.timezone);
+        } else {
+          throw new Error(`Invalid schedule for task ${meta.id}`);
+        }
+        logger.emit({ outcome: "ok", next_run_at: next.toISOString() });
+        return next;
+      } catch (err) {
+        logger.error(err as Error);
+        logger.emit({ outcome: "error" });
+        throw err;
+      }
+    },
+  );
 }
 
 async function executeAction(meta: TaskMeta) {
   "use step";
-  const discord = new API(new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN!));
+  return withSpan(
+    "workflow.task.execute_action",
+    { "task.id": meta.id, "task.action_type": meta.action.type },
+    async () => {
+      const logger = createWideLogger({
+        op: "workflow.task.execute_action",
+        task: { id: meta.id, action_type: meta.action.type },
+      });
+      const startTime = Date.now();
+      try {
+        const discord = new API(
+          new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN!),
+        );
 
-  const taskFooter = `-# Task: ${meta.id}`;
+        const taskFooter = `-# Task: ${meta.id}`;
 
-  if (meta.action.type === "message") {
-    for (const msg of MessageRenderer.splitWithFooter(meta.action.content, taskFooter)) {
-      await discord.channels.createMessage(meta.action.channelId, { content: msg });
-    }
-    log.info("task-workflow", `Sent message for task ${meta.id}`);
-  } else if (meta.action.type === "agent") {
-    const now = new Date();
-    // `memberRoles` is re-resolved by `AgentContext.role` at execute time, so
-    // a privilege revocation between scheduling and firing is respected. Do
-    // not blank these out — without them the scheduled run loses access to
-    // every `delegate_*` subagent.
-    const context = AgentContext.fromJSON({
-      userId: meta.context.userId,
-      username: "system",
-      nickname: "Scheduled Task",
-      channel: { id: meta.action.channelId, name: "scheduled" },
-      date: now.toLocaleDateString("en-US", {
-        weekday: "long",
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      }),
-      memberRoles: meta.context.memberRoles,
-    });
-    await streamTurn(
-      discord,
-      meta.action.channelId,
-      [{ role: "user", content: meta.action.prompt }],
-      context.toJSON(),
-      { taskId: meta.id },
-    );
-    log.info("task-workflow", `Ran agent for task ${meta.id}`);
-  }
+        if (meta.action.type === "message") {
+          const channelId = meta.action.channelId;
+          logger.set({ task: { channel_id: channelId } });
+          let messages = 0;
+          for (const msg of MessageRenderer.splitWithFooter(meta.action.content, taskFooter)) {
+            await discord.channels.createMessage(channelId, { content: msg });
+            messages += 1;
+          }
+          logger.set({ task: { messages_sent: messages } });
+        } else if (meta.action.type === "agent") {
+          const channelId = meta.action.channelId;
+          logger.set({ task: { channel_id: channelId } });
+          const now = new Date();
+          // `memberRoles` is re-resolved by `AgentContext.role` at execute time, so
+          // a privilege revocation between scheduling and firing is respected. Do
+          // not blank these out — without them the scheduled run loses access to
+          // every `delegate_*` subagent.
+          const context = AgentContext.fromJSON({
+            userId: meta.context.userId,
+            username: "system",
+            nickname: "Scheduled Task",
+            channel: { id: channelId, name: "scheduled" },
+            date: now.toLocaleDateString("en-US", {
+              weekday: "long",
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            }),
+            memberRoles: meta.context.memberRoles,
+          });
+          await streamTurn(
+            discord,
+            channelId,
+            [{ role: "user", content: meta.action.prompt }],
+            context.toJSON(),
+            { taskId: meta.id, workflowRunId: meta.id, turnIndex: 1 },
+          );
+        }
+        countMetric("workflow.task.action_completed", { action_type: meta.action.type });
+        logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
+      } catch (err) {
+        countMetric("workflow.task.action_error", { action_type: meta.action.type });
+        logger.error(err as Error);
+        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        throw err;
+      } finally {
+        recordDuration("workflow.task.action_duration", Date.now() - startTime, {
+          action_type: meta.action.type,
+        });
+      }
+    },
+  );
 }
 
 async function cleanupTask(id: string) {
   "use step";
-  await removeTask(id);
-  log.info("task-workflow", `Removed task ${id}`);
+  return withSpan("workflow.task.cleanup", { "task.id": id }, async () => {
+    const logger = createWideLogger({ op: "workflow.task.cleanup", task: { id } });
+    try {
+      await removeTask(id);
+      countMetric("workflow.task.cleanup_completed");
+      logger.emit({ outcome: "ok" });
+    } catch (err) {
+      logger.error(err as Error);
+      logger.emit({ outcome: "error" });
+      throw err;
+    }
+  });
 }
 
 export async function taskWorkflow(payload: TaskPayload) {
@@ -84,6 +168,11 @@ export async function taskWorkflow(payload: TaskPayload) {
 
   const { workflowRunId } = getWorkflowMetadata();
   const meta: TaskMeta = { ...payload.meta, id: workflowRunId };
+
+  countMetric("workflow.task.started", {
+    schedule_type: meta.schedule.type,
+    action_type: meta.action.type,
+  });
 
   await persistTask(meta);
 
@@ -102,7 +191,10 @@ export async function taskWorkflow(payload: TaskPayload) {
 
     // Check if task was removed (cancelled) while sleeping
     const current = await checkTask(meta.id);
-    if (!current) break;
+    if (!current) {
+      countMetric("workflow.task.cancelled_during_sleep");
+      break;
+    }
 
     await executeAction(meta);
   }
@@ -110,5 +202,5 @@ export async function taskWorkflow(payload: TaskPayload) {
 
 async function checkTask(id: string): Promise<TaskMeta | null> {
   "use step";
-  return getTask(id);
+  return withSpan("workflow.task.check", { "task.id": id }, () => getTask(id));
 }


### PR DESCRIPTION
## Summary
- Adds `@opentelemetry/api` manual spans via a small `withSpan` helper around every unit of work — AI turns, subagents, workflow steps, HTTP entry points, sandbox ops, Redis ops, the gateway listener — so Sentry's embedded OTEL tracer captures them. `chat.*` attributes flow through the AI SDK's `experimental_telemetry.metadata`, turning a whole conversation into one queryable trace. `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=65536` is bumped so full prompts, tool call args, and tool results survive as span attributes.
- Introduces `createWideLogger` on top of evlog: each unit of work emits **one** structured wide event with `outcome`, `duration_ms`, and domain attributes, auto-stamped with the current `trace.id` for log↔trace joining. Replaces chatty per-step `log.info` calls across process-event, chat/task/sandbox-lifecycle workflows, mention + resume-hook handlers, streaming + subagent, crons, all interaction handlers, the resend/tasks/discord webhooks, gateway relay + listener, sandbox session/lifecycle, and the code post-finish step.
- Expands `countMetric`/`recordDuration`/`recordDistribution` coverage across previously untraced paths (webhooks, task callback, discord events, interaction handlers, sandbox lifecycle, sandbox session transitions, resend apply outcomes, gateway packet relay, etc.).

## Test plan
- [x] `bun format` / `bun lint` (0 warnings / 0 errors) / `bun typecheck`
- [x] `bun run test` — 956 tests pass (added `wide.test.ts`, `tracing.test.ts`, `chat-attributes.test.ts`)
- [x] `bun test:coverage` — 99.38% statements / 98.69% branches / 100% functions / 99.31% lines (thresholds: 90/85/90/90)
- [x] `bun knip` — no unused exports
- [ ] Trigger a Discord `@mention` in a dev/preview deploy and verify Sentry shows a single trace with `chat.id` on every span (`chat.turn` → `ai.streamText` → `ai.toolCall` children + subagent children + outbound fetch spans)
- [ ] Confirm wide-event JSON lines in Sentry logs carry `trace.id` so each log links back to its trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)