### PR TITLE
fix(restart-bot): align gateway fetch timeout with gateway startup budget

### DIFF
--- a/src/bot/handlers/commands/restart-bot/index.ts
+++ b/src/bot/handlers/commands/restart-bot/index.ts
@@ -4,9 +4,10 @@ import { log } from "evlog";
 import { defineCommand } from "@/bot/commands/define";
 import { isOrganizer, respond } from "@/bot/commands/helpers";
 import { env } from "@/env";
+import { HANDOFF_WAIT_MS, READY_TIMEOUT_MS } from "@/server/routes/gateway/constants";
 
 const FAILURE_MSG = "Failed to restart the bot. Try again later.";
-const GATEWAY_TIMEOUT_MS = 10_000;
+const GATEWAY_TIMEOUT_MS = HANDOFF_WAIT_MS + READY_TIMEOUT_MS + 5_000;
 
 function gatewayUrl(): string {
   const host = env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL;

--- a/src/server/routes/gateway/constants.ts
+++ b/src/server/routes/gateway/constants.ts
@@ -1,0 +1,2 @@
+export const HANDOFF_WAIT_MS = 8_000;
+export const READY_TIMEOUT_MS = 30_000;

--- a/src/server/routes/gateway/index.ts
+++ b/src/server/routes/gateway/index.ts
@@ -18,12 +18,12 @@ import { isTextChannel } from "@/lib/protocol/utils";
 import { send } from "@/lib/tasks/queue/client";
 import { DISCORD_EVENT_TOPIC } from "@/lib/tasks/queue/constants";
 
+import { HANDOFF_WAIT_MS, READY_TIMEOUT_MS } from "./constants";
+
 const HOLD_MS = 10 * 60 * 1000;
 const LEADER_KEY = "gateway:leader";
 const LEASE_TTL_MS = 15_000;
 const POLL_INTERVAL_MS = 5_000;
-const HANDOFF_WAIT_MS = 8_000;
-const READY_TIMEOUT_MS = 30_000;
 
 // Atomic compare-and-delete: only removes the lease if we still own it.
 // Without this, a get-then-del race could delete a new leader's key after


### PR DESCRIPTION
## Summary
- `/restart-bot` was reliably failing: its 10s fetch timeout against `/api/discord/gateway` was shorter than the gateway route's own startup budget (8s Redis handoff + 30s `ClientReady` wait from #81), producing a `TimeoutError` and a follow-on `DiscordAPIError[10015] Unknown Webhook` on the deferred interaction's `editReply`.
- Exported `HANDOFF_WAIT_MS` and `READY_TIMEOUT_MS` into `src/server/routes/gateway/constants.ts` (gateway.ts is now `gateway/index.ts`) and derive `GATEWAY_TIMEOUT_MS = HANDOFF_WAIT_MS + READY_TIMEOUT_MS + 5_000` in the command, so the two budgets can't drift apart again.

## Test plan
- [ ] `bun format && bun lint && bun typecheck && bun run test && bun test:coverage && bun knip` all pass locally.
- [ ] Trigger `/restart-bot` in Discord as an organizer and confirm "Bot restart triggered." reply (no `TimeoutError` / `Unknown Webhook` in logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)