### PR TITLE
feat(observability): join mention → workflow → steps into one trace

### DIFF
--- a/src/bot/context-snapshot.test.ts
+++ b/src/bot/context-snapshot.test.ts
@@ -32,6 +32,7 @@ const sampleSnapshot: ContextSnapshot = {
     subagentTokens: 0,
     toolCallCount: 1,
     stepCount: 2,
+    toolNames: [],
   },
   turnCount: 1,
   updatedAt: "2026-04-15T12:00:00.000Z",

--- a/src/bot/handlers/commands/inspect-context/render.test.ts
+++ b/src/bot/handlers/commands/inspect-context/render.test.ts
@@ -64,6 +64,7 @@ const baseBreakdown: ContextBreakdown = {
     subagentTokens: 0,
     toolCallCount: 32,
     stepCount: 41,
+    toolNames: [],
   },
   turnCount: 14,
   messageCount: 38,

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -12,7 +12,7 @@ import { fetchRecentMessages, fetchReferencedMessageContext } from "@/bot/recent
 import { AgentContext } from "@/lib/ai/context";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric } from "@/lib/metrics";
-import { setActiveSpanAttributes, withSpan } from "@/lib/otel/tracing";
+import { captureTraceparent, setActiveSpanAttributes, withSpan } from "@/lib/otel/tracing";
 import { chatWorkflow } from "@/workflows/chat";
 
 type MessageData = MessageCreatePacketType["data"];
@@ -67,7 +67,12 @@ async function tryResumeExistingWorkflow(args: {
     // workflow start; turn-to-turn conversation memory comes from the
     // workflow's accumulated messages array instead.
     const turnContext = AgentContext.fromPacket(packet).toJSON();
-    const event: ChatHookEvent = { type: "message", content, context: turnContext };
+    const event: ChatHookEvent = {
+      type: "message",
+      content,
+      context: turnContext,
+      traceparent: captureTraceparent(),
+    };
     await resumeHook(existing.workflowRunId, event);
     await ctx.store.touch(routing.sourceChannelId, routing.lookupThreadId);
     countMetric("chat.workflow.resumed");
@@ -222,6 +227,7 @@ async function startFreshWorkflow(args: {
       threadId: conversationThreadId,
       content,
       context: turnContext,
+      traceparent: captureTraceparent(),
     },
   ]);
 

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -246,7 +246,6 @@ async function startFreshWorkflow(args: {
     duration_ms: Date.now() - startTime,
     chat: {
       id: run.runId,
-      workflow_run_id: run.runId,
       lead_in_count: recentMessages?.length ?? 0,
       referenced_count: referencedContext?.length ?? 0,
     },

--- a/src/lib/ai/inspect-context.test.ts
+++ b/src/lib/ai/inspect-context.test.ts
@@ -43,6 +43,7 @@ const baseSnap: ContextSnapshot = {
     subagentTokens: 0,
     toolCallCount: 1,
     stepCount: 2,
+    toolNames: [],
   },
   turnCount: 1,
   updatedAt: "2026-04-15T12:00:00.000Z",

--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -454,4 +454,16 @@ describe("MessageRenderer: finalize edge cases", () => {
     const lastSend = sends[sends.length - 1];
     expect((lastSend[1] as { content: string }).content).toContain("Hello!");
   });
+
+  it("finalize throws when called before init()", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 0,
+      stepCount: 1,
+    };
+    await expect(renderer.finalize(meta)).rejects.toThrow(/before init/);
+  });
 });

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -73,19 +73,26 @@ export class MessageRenderer {
    * or the fallback new message — plus the ids of any overflow chunks that
    * were sent as additional messages. These surface on the turn's wide event
    * and span so operators can resolve a trace back to the Discord reply.
+   *
+   * Requires `init()` to have completed first; throws otherwise so callers
+   * don't accidentally skip the placeholder message and silently lose the
+   * primary reply id from observability.
    */
-  async finalize(meta: FooterMeta): Promise<{ messageId: string | null; overflowIds: string[] }> {
+  async finalize(meta: FooterMeta): Promise<{ messageId: string; overflowIds: string[] }> {
+    if (this.messageId === null) {
+      throw new Error("MessageRenderer.finalize() called before init()");
+    }
+    let primaryId = this.messageId;
+
     let footer = MessageRenderer.formatFooter(meta);
     if (this.taskId) footer += `\n-# Task: ${this.taskId}`;
 
     const finalText = this.text || "I didn't have anything to say.";
     const chunks = MessageRenderer.splitWithFooter(finalText, footer);
 
-    let primaryId = this.messageId;
-
     // Edit the original message with the first chunk
     try {
-      await this.discord.channels.editMessage(this.channelId, this.messageId!, {
+      await this.discord.channels.editMessage(this.channelId, primaryId, {
         content: chunks[0],
       });
     } catch (err) {

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -67,13 +67,21 @@ export class MessageRenderer {
     this.subagentPreview = "";
   }
 
-  /** Finalize: render footer, split across messages, send. */
-  async finalize(meta: FooterMeta): Promise<void> {
+  /**
+   * Finalize: render footer, split across messages, send. Returns the id of
+   * the primary (first) message the user sees — either the edited placeholder
+   * or the fallback new message — plus the ids of any overflow chunks that
+   * were sent as additional messages. These surface on the turn's wide event
+   * and span so operators can resolve a trace back to the Discord reply.
+   */
+  async finalize(meta: FooterMeta): Promise<{ messageId: string | null; overflowIds: string[] }> {
     let footer = MessageRenderer.formatFooter(meta);
     if (this.taskId) footer += `\n-# Task: ${this.taskId}`;
 
     const finalText = this.text || "I didn't have anything to say.";
     const chunks = MessageRenderer.splitWithFooter(finalText, footer);
+
+    let primaryId = this.messageId;
 
     // Edit the original message with the first chunk
     try {
@@ -82,13 +90,22 @@ export class MessageRenderer {
       });
     } catch (err) {
       log.warn("streaming", `Final edit failed, sending new message: ${String(err)}`);
-      await this.discord.channels.createMessage(this.channelId, { content: chunks[0] });
+      const fallback = await this.discord.channels.createMessage(this.channelId, {
+        content: chunks[0],
+      });
+      primaryId = fallback.id;
     }
 
     // Send additional messages for overflow chunks
+    const overflowIds: string[] = [];
     for (let i = 1; i < chunks.length; i++) {
-      await this.discord.channels.createMessage(this.channelId, { content: chunks[i] });
+      const msg = await this.discord.channels.createMessage(this.channelId, {
+        content: chunks[i],
+      });
+      overflowIds.push(msg.id);
     }
+
+    return { messageId: primaryId, overflowIds };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/ai/snapshot.test.ts
+++ b/src/lib/ai/snapshot.test.ts
@@ -79,6 +79,7 @@ const usage: TurnUsage = {
   subagentTokens: 0,
   toolCallCount: 1,
   stepCount: 1,
+  toolNames: [],
 };
 
 describe("buildContextSnapshot", () => {

--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -30,7 +30,7 @@ vi.mock("@vercel/edge-config", () => ({
 }));
 
 const { AgentContext } = await import("./context.ts");
-const { buildUserMessage, streamTurn } = await import("./streaming.ts");
+const { buildUserMessage, parseModelSlug, streamTurn } = await import("./streaming.ts");
 type OrchestratorFactory = import("./streaming.ts").OrchestratorFactory;
 
 type StreamEvent = Record<string, unknown>;
@@ -482,6 +482,112 @@ describe("streamTurn: messages array", () => {
     expect(typeof messages[0].content).toBe("string");
     expect(typeof messages[1].content).toBe("string");
     expect(Array.isArray(messages[2].content)).toBe(true);
+  });
+});
+
+describe("parseModelSlug", () => {
+  it("splits a provider/model slug", () => {
+    expect(parseModelSlug("anthropic/claude-sonnet-4.6")).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+    });
+  });
+
+  it("returns undefined provider for a bare model name", () => {
+    expect(parseModelSlug("claude-sonnet-4.6")).toEqual({
+      provider: undefined,
+      model: "claude-sonnet-4.6",
+    });
+  });
+
+  it("treats a leading slash as no provider", () => {
+    expect(parseModelSlug("/foo")).toEqual({
+      provider: undefined,
+      model: "/foo",
+    });
+  });
+});
+
+describe("streamTurn: result shape", () => {
+  it("returns tool names, model slug, and the discord message id", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Done."], { toolCallsPerStep: 2, stepCount: 2 }),
+    });
+
+    expect(result.model).toBe("anthropic/claude-sonnet-4.6");
+    // Two steps × two tool calls = four "mock" entries from fakeOrchestrator.
+    expect(result.usage.toolNames).toEqual(["mock", "mock", "mock", "mock"]);
+    expect(result.discordMessageId).toBe("msg-1");
+  });
+
+  it("returns empty toolNames when the turn makes no tool calls", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Hi."]),
+    });
+    expect(result.usage.toolNames).toEqual([]);
+  });
+
+  it("returns the fallback message id when the placeholder edit fails", async () => {
+    const discord = createMockAPI();
+    discord.channels.editMessage = async () => {
+      throw new Error("rate limited");
+    };
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Hello!"]),
+    });
+    // Mock counter starts at 1 for the placeholder; the fallback createMessage
+    // is the second call, so `msg-2`.
+    expect(result.discordMessageId).toBe("msg-2");
+  });
+});
+
+describe("streamTurn: stream-event edge cases", () => {
+  it("handles tool-input-start without a toolName", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Done."], {
+        extraEvents: [{ type: "tool-input-start" }],
+      }),
+    });
+    // No toolName means no activity indicator was appended — the reply text
+    // should still be the streamed content, not wrapped in `Calling …`.
+    expect(result.text).toBe("Done.");
+  });
+
+  it("treats a text-delta without a text field as an empty string", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["First."], {
+        extraEvents: [{ type: "text-delta" }],
+      }),
+    });
+    expect(result.text).toBe("First.");
+  });
+
+  it("returns empty preview when subagent output has no text parts", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Final."], {
+        extraEvents: [
+          {
+            type: "tool-result",
+            preliminary: true,
+            // Only a non-text part — findLast(isTextUIPart) returns undefined,
+            // so the `?? ""` fallback kicks in and the preview is skipped.
+            output: { parts: [{ type: "tool-call" }] },
+          },
+        ],
+      }),
+    });
+    expect(result.text).toBe("Final.");
   });
 });
 

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -27,7 +27,7 @@ import { TurnUsageTracker } from "./turn-usage.ts";
  * provider + model parts for separate span attributes. Falls back to the
  * whole slug as the model name when no provider prefix is present.
  */
-function parseModelSlug(slug: string): { provider: string | undefined; model: string } {
+export function parseModelSlug(slug: string): { provider: string | undefined; model: string } {
   const slash = slug.indexOf("/");
   if (slash <= 0) return { provider: undefined, model: slug };
   return { provider: slug.slice(0, slash), model: slug.slice(slash + 1) };
@@ -179,7 +179,7 @@ async function runStreamTurn(args: {
     "ai.tool_calls": usage.toolCallCount,
     "ai.steps": usage.stepCount,
     ...(usage.toolNames.length > 0 ? { "ai.tool_names": usage.toolNames } : {}),
-    ...(finalized.messageId ? { "chat.discord_message_id": finalized.messageId } : {}),
+    "chat.discord_message_id": finalized.messageId,
   });
 
   logger.emit({
@@ -248,7 +248,7 @@ async function renderStream(
 
 interface FinalizeResult {
   metadataError: unknown;
-  finalized: { messageId: string | null; overflowIds: string[] };
+  finalized: { messageId: string; overflowIds: string[] };
 }
 
 async function finalizeTurn(args: {

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -6,20 +6,32 @@ import { isTextUIPart, type UIMessage } from "ai";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
 import { buildChatAttributes } from "@/lib/otel/chat-attributes";
-import { withSpan } from "@/lib/otel/tracing";
+import { setActiveSpanAttributes, withSpan } from "@/lib/otel/tracing";
 
 import type {
   Attachment,
   ChatMessage,
   SerializedAgentContext,
   StreamTurnOptions,
-  TurnUsage,
+  StreamTurnResult,
 } from "./types.ts";
 
+import { ORCHESTRATOR_MODEL } from "./constants.ts";
 import { AgentContext } from "./context.ts";
 import { MessageRenderer } from "./message-renderer.ts";
 import { createOrchestrator } from "./orchestrator.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
+
+/**
+ * Split an AI-gateway model slug (e.g. `"anthropic/claude-sonnet-4.6"`) into
+ * provider + model parts for separate span attributes. Falls back to the
+ * whole slug as the model name when no provider prefix is present.
+ */
+function parseModelSlug(slug: string): { provider: string | undefined; model: string } {
+  const slash = slug.indexOf("/");
+  if (slash <= 0) return { provider: undefined, model: slug };
+  return { provider: slug.slice(0, slash), model: slug.slice(slash + 1) };
+}
 
 export type { OrchestratorAgent, OrchestratorFactory, StreamTurnOptions } from "./types.ts";
 export { MessageRenderer } from "./message-renderer.ts";
@@ -78,11 +90,12 @@ export async function streamTurn(
   messages: ChatMessage[],
   serializedContext: SerializedAgentContext,
   options: StreamTurnOptions = {},
-): Promise<{ text: string; usage: TurnUsage }> {
+): Promise<StreamTurnResult> {
   const { taskId, workflowRunId, turnIndex } = options;
   const chatAttrs = workflowRunId
     ? buildChatAttributes({ workflowRunId, context: serializedContext, turnIndex })
     : undefined;
+  const { provider, model } = parseModelSlug(ORCHESTRATOR_MODEL);
   return withSpan(
     "chat.turn",
     {
@@ -90,6 +103,8 @@ export async function streamTurn(
       "chat.channel_id": serializedContext.channel.id,
       "chat.user_id": serializedContext.userId,
       "chat.message_count": messages.length,
+      "ai.model": model,
+      ...(provider ? { "ai.provider": provider } : {}),
       ...(taskId ? { "task.id": taskId } : {}),
     },
     () => runStreamTurn({ discord, channelId, messages, serializedContext, options, chatAttrs }),
@@ -103,7 +118,7 @@ async function runStreamTurn(args: {
   serializedContext: SerializedAgentContext;
   options: StreamTurnOptions;
   chatAttrs: ReturnType<typeof buildChatAttributes> | undefined;
-}): Promise<{ text: string; usage: TurnUsage }> {
+}): Promise<StreamTurnResult> {
   const { discord, channelId, messages, serializedContext, options, chatAttrs } = args;
   const { taskId, createAgent = createOrchestrator, workflowRunId, turnIndex } = options;
   const agentCtx = AgentContext.fromJSON(serializedContext);
@@ -140,7 +155,7 @@ async function runStreamTurn(args: {
 
   const elapsedMs = Date.now() - startTime;
   const traceId = trace.getActiveSpan()?.spanContext().traceId;
-  const metadataError = await finalizeTurn({
+  const { metadataError, finalized } = await finalizeTurn({
     result,
     tracker,
     renderer,
@@ -152,16 +167,42 @@ async function runStreamTurn(args: {
   countMetric("ai.turn.completed");
   recordDuration("ai.turn.duration", elapsedMs);
 
+  const usage = tracker.toTurnUsage();
+
+  // Mirror the per-turn totals onto the active chat.turn span so operators can
+  // query the trace directly without joining against wide events.
+  setActiveSpanAttributes({
+    "ai.input_tokens": usage.inputTokens,
+    "ai.output_tokens": usage.outputTokens,
+    "ai.subagent_tokens": usage.subagentTokens,
+    "ai.total_tokens": usage.totalTokens,
+    "ai.tool_calls": usage.toolCallCount,
+    "ai.steps": usage.stepCount,
+    ...(usage.toolNames.length > 0 ? { "ai.tool_names": usage.toolNames } : {}),
+    ...(finalized.messageId ? { "chat.discord_message_id": finalized.messageId } : {}),
+  });
+
   logger.emit({
     outcome: metadataError ? "partial" : "ok",
     duration_ms: elapsedMs,
     text_length: renderer.content.length,
-    tokens: tracker.totalTokens,
-    tool_calls: tracker.totalToolCalls,
-    steps: tracker.totalSteps,
+    tokens: usage.totalTokens,
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    subagent_tokens: usage.subagentTokens,
+    tool_calls: usage.toolCallCount,
+    tool_names: usage.toolNames,
+    steps: usage.stepCount,
+    model: ORCHESTRATOR_MODEL,
+    discord_message_id: finalized.messageId,
   });
 
-  return { text: renderer.content, usage: tracker.toTurnUsage() };
+  return {
+    text: renderer.content,
+    usage,
+    discordMessageId: finalized.messageId,
+    model: ORCHESTRATOR_MODEL,
+  };
 }
 
 async function renderStream(
@@ -205,6 +246,11 @@ async function renderStream(
   }
 }
 
+interface FinalizeResult {
+  metadataError: unknown;
+  finalized: { messageId: string | null; overflowIds: string[] };
+}
+
 async function finalizeTurn(args: {
   result: { totalUsage: PromiseLike<unknown>; steps: PromiseLike<unknown> };
   tracker: TurnUsageTracker;
@@ -212,7 +258,7 @@ async function finalizeTurn(args: {
   elapsedMs: number;
   logger: ReturnType<typeof createWideLogger>;
   traceId: string | undefined;
-}): Promise<unknown> {
+}): Promise<FinalizeResult> {
   const { result, tracker, renderer, elapsedMs, logger, traceId } = args;
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
@@ -221,7 +267,7 @@ async function finalizeTurn(args: {
       steps: steps as readonly { toolCalls: readonly unknown[] }[],
     });
 
-    await renderer.finalize({
+    const finalized = await renderer.finalize({
       elapsedMs,
       totalTokens: tracker.totalTokens,
       toolCallCount: tracker.totalToolCalls,
@@ -232,17 +278,17 @@ async function finalizeTurn(args: {
     recordDistribution("ai.turn.tokens", tracker.totalTokens);
     recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls);
     recordDistribution("ai.turn.steps", tracker.totalSteps);
-    return undefined;
+    return { metadataError: undefined, finalized };
   } catch (err) {
     countMetric("ai.turn.metadata_error");
     logger.warn("metadata collection failed", { reason: String(err) });
-    await renderer.finalize({
+    const finalized = await renderer.finalize({
       elapsedMs,
       totalTokens: undefined,
       toolCallCount: 0,
       stepCount: 0,
       traceId,
     });
-    return err;
+    return { metadataError: err, finalized };
   }
 }

--- a/src/lib/ai/subagent.test.ts
+++ b/src/lib/ai/subagent.test.ts
@@ -375,6 +375,15 @@ describe("recordSubagentMetrics", () => {
     expect(tracker.totalTokens).toBe(0);
     expect(tracker.totalToolCalls).toBe(0);
   });
+
+  it("collects tool names and skips entries without a string toolName", () => {
+    const tracker = new TurnUsageTracker();
+    recordSubagentMetrics(tracker, { name: "test" }, { totalTokens: 10 }, [
+      { toolCalls: [{ toolName: "search_entities" }, {}] },
+      { toolCalls: [{ toolName: "retrieve_entities" }] },
+    ]);
+    expect(tracker.toTurnUsage().toolNames).toEqual(["search_entities", "retrieve_entities"]);
+  });
 });
 
 describe("buildPrepareStep", () => {

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -34,6 +34,9 @@ const DEFAULT_TASK_INPUT_SCHEMA = z.object({
   task: z.string().describe("The task to delegate, forwarded verbatim"),
 });
 
+/** Shape of the AI SDK `result.steps` output we actually consume for metrics. */
+type SubagentSteps = { toolCalls: { toolName?: string }[] }[];
+
 /**
  * Create a delegation tool that spawns a focused domain subagent.
  *
@@ -56,11 +59,14 @@ export function recordSubagentMetrics(
   tracker: TurnUsageTracker,
   spec: Pick<SubagentSpec, "name">,
   usage: { totalTokens?: number },
-  steps: { toolCalls: unknown[] }[],
+  steps: SubagentSteps,
 ): void {
   const tokens = usage.totalTokens ?? 0;
   const toolCalls = steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
-  tracker.addSubagent({ tokens, toolCalls });
+  const toolNames = steps.flatMap((s) =>
+    s.toolCalls.flatMap((call) => (typeof call.toolName === "string" ? [call.toolName] : [])),
+  );
+  tracker.addSubagent({ tokens, toolCalls, toolNames });
   countMetric("ai.subagent.completed", { domain: spec.name });
   recordDistribution("ai.subagent.tokens", tokens, { domain: spec.name });
   recordDistribution("ai.subagent.tool_calls", toolCalls, { domain: spec.name });
@@ -71,6 +77,7 @@ export function recordSubagentMetrics(
     outcome: "ok",
     tokens,
     tool_calls: toolCalls,
+    tool_names: toolNames,
     steps: steps.length,
   });
 }
@@ -172,7 +179,7 @@ export function createDelegationTool(
       }
 
       const [usage, steps] = await Promise.all([result.totalUsage, result.steps]);
-      recordSubagentMetrics(tracker, spec, usage, steps as { toolCalls: unknown[] }[]);
+      recordSubagentMetrics(tracker, spec, usage, steps as SubagentSteps);
 
       if (spec.postFinish) {
         for await (const message of spec.postFinish({

--- a/src/lib/ai/turn-usage.test.ts
+++ b/src/lib/ai/turn-usage.test.ts
@@ -12,25 +12,30 @@ describe("TurnUsageTracker", () => {
       subagentTokens: 0,
       toolCallCount: 0,
       stepCount: 0,
+      toolNames: [],
     });
   });
 
   it("accumulates subagent contributions across calls", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 100, toolCalls: 2 });
-    t.addSubagent({ tokens: 250, toolCalls: 3 });
+    t.addSubagent({ tokens: 100, toolCalls: 2, toolNames: ["search", "open"] });
+    t.addSubagent({ tokens: 250, toolCalls: 3, toolNames: ["get_issue"] });
     expect(t.toTurnUsage()).toMatchObject({
       subagentTokens: 350,
       toolCallCount: 5,
+      toolNames: ["search", "open", "get_issue"],
     });
   });
 
   it("merges orchestrator usage with subagent totals", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 200, toolCalls: 4 });
+    t.addSubagent({ tokens: 200, toolCalls: 4, toolNames: ["list_issues"] });
     t.recordOrchestrator({
       usage: { inputTokens: 800, outputTokens: 150, totalTokens: 950 },
-      steps: [{ toolCalls: [1, 2] }, { toolCalls: [3] }],
+      steps: [
+        { toolCalls: [{ toolName: "delegate_linear" }, { toolName: "current_time" }] },
+        { toolCalls: [{ toolName: "resolve_organizer" }] },
+      ],
     });
     const usage = t.toTurnUsage();
     expect(usage).toEqual({
@@ -40,24 +45,30 @@ describe("TurnUsageTracker", () => {
       subagentTokens: 200,
       toolCallCount: 7,
       stepCount: 2,
+      toolNames: ["delegate_linear", "current_time", "resolve_organizer", "list_issues"],
     });
   });
 
   it("exposes convenience accessors after recordOrchestrator", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 50, toolCalls: 1 });
+    t.addSubagent({ tokens: 50, toolCalls: 1, toolNames: ["a"] });
     t.recordOrchestrator({
       usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-      steps: [{ toolCalls: [1, 2, 3] }],
+      steps: [
+        {
+          toolCalls: [{ toolName: "b" }, { toolName: "c" }, { toolName: "d" }],
+        },
+      ],
     });
     expect(t.totalTokens).toBe(200);
     expect(t.totalToolCalls).toBe(4);
     expect(t.totalSteps).toBe(1);
+    expect(t.totalToolNames).toEqual(["b", "c", "d", "a"]);
   });
 
   it("coerces undefined orchestrator tokens to zero", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 50, toolCalls: 1 });
+    t.addSubagent({ tokens: 50, toolCalls: 1, toolNames: [] });
     t.recordOrchestrator({
       usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
       steps: [],
@@ -68,6 +79,16 @@ describe("TurnUsageTracker", () => {
     expect(usage.outputTokens).toBe(0);
     expect(usage.toolCallCount).toBe(1);
     expect(usage.stepCount).toBe(0);
+    expect(usage.toolNames).toEqual([]);
+  });
+
+  it("skips tool calls that lack a string toolName", () => {
+    const t = new TurnUsageTracker();
+    t.recordOrchestrator({
+      usage: { totalTokens: 0 },
+      steps: [{ toolCalls: [{ toolName: "kept" }, {}, { toolName: 123 }] }],
+    });
+    expect(t.toTurnUsage().toolNames).toEqual(["kept"]);
   });
 });
 
@@ -80,6 +101,7 @@ describe("emptyTurnUsage", () => {
       subagentTokens: 0,
       toolCallCount: 0,
       stepCount: 0,
+      toolNames: [],
     });
   });
 });
@@ -93,6 +115,7 @@ describe("addTurnUsage", () => {
       subagentTokens: 20,
       toolCallCount: 2,
       stepCount: 3,
+      toolNames: ["a", "b"],
     };
     const b = {
       inputTokens: 200,
@@ -101,6 +124,7 @@ describe("addTurnUsage", () => {
       subagentTokens: 10,
       toolCallCount: 1,
       stepCount: 2,
+      toolNames: ["c"],
     };
     expect(addTurnUsage(a, b)).toEqual({
       inputTokens: 300,
@@ -109,6 +133,7 @@ describe("addTurnUsage", () => {
       subagentTokens: 30,
       toolCallCount: 3,
       stepCount: 5,
+      toolNames: ["a", "b", "c"],
     });
   });
 
@@ -120,6 +145,7 @@ describe("addTurnUsage", () => {
       subagentTokens: 2,
       toolCallCount: 1,
       stepCount: 1,
+      toolNames: ["x"],
     };
     expect(addTurnUsage(emptyTurnUsage(), b)).toEqual(b);
   });

--- a/src/lib/ai/turn-usage.ts
+++ b/src/lib/ai/turn-usage.ts
@@ -1,6 +1,15 @@
 import type { TurnUsage } from "./types.ts";
 
 /**
+ * Shape of an AI SDK tool call entry on a step's `toolCalls`. Every call
+ * carries a stable string name which we mirror into span attributes / wide
+ * events so operators can see what ran. Other fields are ignored here.
+ */
+interface ToolCallLike {
+  toolName?: string;
+}
+
+/**
  * Mutable accumulator for one orchestrator turn's worth of usage.
  *
  * Subagents call `addSubagent` to fold in their per-delegation totals as they
@@ -16,11 +25,14 @@ export class TurnUsageTracker {
   private orchestratorTotalTokens = 0;
   private orchestratorToolCalls = 0;
   private stepCount = 0;
+  private orchestratorToolNames: string[] = [];
+  private subagentToolNames: string[] = [];
 
   /** Add a subagent delegation's contribution. */
-  addSubagent(delta: { tokens: number; toolCalls: number }): void {
+  addSubagent(delta: { tokens: number; toolCalls: number; toolNames: readonly string[] }): void {
     this.subagentTokens += delta.tokens;
     this.subagentToolCalls += delta.toolCalls;
+    this.subagentToolNames.push(...delta.toolNames);
   }
 
   /**
@@ -37,6 +49,12 @@ export class TurnUsageTracker {
     this.orchestratorTotalTokens = args.usage.totalTokens ?? 0;
     this.orchestratorToolCalls = args.steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
     this.stepCount = args.steps.length;
+    this.orchestratorToolNames = args.steps.flatMap((step) =>
+      step.toolCalls.flatMap((call) => {
+        const name = (call as ToolCallLike).toolName;
+        return typeof name === "string" ? [name] : [];
+      }),
+    );
   }
 
   /** Convenience accessor for the post-stream tool-call total (orchestrator + subagent). */
@@ -54,6 +72,11 @@ export class TurnUsageTracker {
     return this.orchestratorTotalTokens + this.subagentTokens;
   }
 
+  /** Combined orchestrator + subagent tool names in call order. */
+  get totalToolNames(): string[] {
+    return [...this.orchestratorToolNames, ...this.subagentToolNames];
+  }
+
   /** Snapshot in the shape persisted to the context-snapshot store. */
   toTurnUsage(): TurnUsage {
     return {
@@ -63,6 +86,7 @@ export class TurnUsageTracker {
       subagentTokens: this.subagentTokens,
       toolCallCount: this.totalToolCalls,
       stepCount: this.stepCount,
+      toolNames: this.totalToolNames,
     };
   }
 }
@@ -76,6 +100,7 @@ export function emptyTurnUsage(): TurnUsage {
     subagentTokens: 0,
     toolCallCount: 0,
     stepCount: 0,
+    toolNames: [],
   };
 }
 
@@ -89,5 +114,6 @@ export function addTurnUsage(total: TurnUsage, turn: TurnUsage): TurnUsage {
     subagentTokens: total.subagentTokens + turn.subagentTokens,
     toolCallCount: total.toolCallCount + turn.toolCallCount,
     stepCount: total.stepCount + turn.stepCount,
+    toolNames: [...total.toolNames, ...turn.toolNames],
   };
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -90,6 +90,13 @@ export interface TurnUsage {
   subagentTokens: number;
   toolCallCount: number;
   stepCount: number;
+  /**
+   * Names of tools called during this turn, in call order. Includes both
+   * orchestrator-level calls (delegation tools) and subagent-level calls
+   * (tools run inside delegated subagents). Surfaced on spans and wide events
+   * so operators can see *what* ran, not just *how many*.
+   */
+  toolNames: string[];
 }
 
 export interface ModelInfo {
@@ -225,6 +232,30 @@ export type OrchestratorFactory = (
   tracker: TurnUsageTracker,
   extraMetadata?: TelemetryMetadata,
 ) => OrchestratorAgent;
+
+/**
+ * Return shape of `streamTurn`. Carries the reply text + usage accounting
+ * needed by the workflow, plus observability hooks (`discordMessageId`,
+ * `model`) that let the run_turn step emit a complete wide event for each
+ * turn without re-computing them.
+ */
+export interface StreamTurnResult {
+  text: string;
+  usage: TurnUsage;
+  /**
+   * Primary Discord message id for the reply (either the edited placeholder
+   * or a fallback createMessage). Null only if the renderer never saw an
+   * `init()` call successfully persist a message id — not expected in
+   * practice.
+   */
+  discordMessageId: string | null;
+  /**
+   * Full gateway model slug used by the orchestrator for this turn, e.g.
+   * `anthropic/claude-sonnet-4.6`. Included so the wide event records what
+   * actually ran, independent of whatever constant was read at build time.
+   */
+  model: string;
+}
 
 /**
  * Options bag for `streamTurn`. Split out so production callers don't need to

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -244,11 +244,11 @@ export interface StreamTurnResult {
   usage: TurnUsage;
   /**
    * Primary Discord message id for the reply (either the edited placeholder
-   * or a fallback createMessage). Null only if the renderer never saw an
-   * `init()` call successfully persist a message id — not expected in
-   * practice.
+   * or a fallback `createMessage`). Always a string because `streamTurn`
+   * runs `renderer.init()` before it can reach `finalize()`, and `finalize()`
+   * throws if that invariant is broken.
    */
-  discordMessageId: string | null;
+  discordMessageId: string;
   /**
    * Full gateway model slug used by the orchestrator for this turn, e.g.
    * `anthropic/claude-sonnet-4.6`. Included so the wide event records what

--- a/src/lib/otel/chat-attributes.test.ts
+++ b/src/lib/otel/chat-attributes.test.ts
@@ -19,7 +19,6 @@ describe("buildChatAttributes", () => {
       "chat.id": "run-1",
       "chat.channel_id": "c1",
       "chat.user_id": "u1",
-      "chat.workflow_run_id": "run-1",
     });
   });
 

--- a/src/lib/otel/chat-attributes.ts
+++ b/src/lib/otel/chat-attributes.ts
@@ -20,6 +20,5 @@ export function buildChatAttributes(args: {
     ...(context.thread?.id ? { "chat.thread_id": context.thread.id } : {}),
     "chat.user_id": context.userId,
     ...(turnIndex !== undefined ? { "chat.turn_index": turnIndex } : {}),
-    "chat.workflow_run_id": workflowRunId,
   };
 }

--- a/src/lib/otel/tracing.test.ts
+++ b/src/lib/otel/tracing.test.ts
@@ -1,20 +1,26 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { startActiveSpan, span } = vi.hoisted(() => {
-  const span = {
-    end: vi.fn(),
-    setAttributes: vi.fn(),
-    setAttribute: vi.fn(),
-    setStatus: vi.fn(),
-    recordException: vi.fn(),
-  };
-  return {
-    span,
-    startActiveSpan: vi.fn((_name: string, _opts: unknown, fn: (s: typeof span) => unknown) =>
-      fn(span),
-    ),
-  };
-});
+const { startActiveSpan, span, injectMock, extractMock, contextWithMock, activeContext } =
+  vi.hoisted(() => {
+    const span = {
+      end: vi.fn(),
+      setAttributes: vi.fn(),
+      setAttribute: vi.fn(),
+      setStatus: vi.fn(),
+      recordException: vi.fn(),
+    };
+    const activeContext = { __active: true };
+    return {
+      span,
+      activeContext,
+      startActiveSpan: vi.fn((_name: string, _opts: unknown, fn: (s: typeof span) => unknown) =>
+        fn(span),
+      ),
+      injectMock: vi.fn(),
+      extractMock: vi.fn(),
+      contextWithMock: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+    };
+  });
 
 vi.mock("@opentelemetry/api", () => ({
   SpanStatusCode: { ERROR: 2 },
@@ -22,9 +28,29 @@ vi.mock("@opentelemetry/api", () => ({
     getTracer: vi.fn(() => ({ startActiveSpan })),
     getActiveSpan: vi.fn(() => span),
   },
+  context: {
+    active: vi.fn(() => activeContext),
+    with: contextWithMock,
+  },
+  propagation: {
+    inject: injectMock,
+    extract: extractMock,
+  },
 }));
 
-import { setActiveSpanAttributes, withSpan } from "./tracing";
+import {
+  captureTraceparent,
+  setActiveSpanAttributes,
+  withSpan,
+  withSpanFromParent,
+} from "./tracing";
+
+beforeEach(() => {
+  injectMock.mockReset();
+  extractMock.mockReset();
+  contextWithMock.mockClear();
+  startActiveSpan.mockClear();
+});
 
 describe("withSpan", () => {
   it("runs fn inside a span and ends it on success", async () => {
@@ -60,5 +86,55 @@ describe("setActiveSpanAttributes", () => {
   it("forwards attributes to the active span", () => {
     setActiveSpanAttributes({ foo: "bar" });
     expect(span.setAttributes).toHaveBeenCalledWith({ foo: "bar" });
+  });
+});
+
+describe("captureTraceparent", () => {
+  it("returns the traceparent injected by the propagator", () => {
+    injectMock.mockImplementation((_ctx: unknown, carrier: Record<string, string>) => {
+      carrier.traceparent = "00-aaaa-bbbb-01";
+    });
+    expect(captureTraceparent()).toBe("00-aaaa-bbbb-01");
+    // Injector is called against the active context with a carrier object.
+    expect(injectMock).toHaveBeenCalledTimes(1);
+    expect(injectMock.mock.calls[0][0]).toBe(activeContext);
+  });
+
+  it("returns undefined when the propagator injects nothing", () => {
+    injectMock.mockImplementation(() => {});
+    expect(captureTraceparent()).toBeUndefined();
+  });
+});
+
+describe("withSpanFromParent", () => {
+  it("falls through to withSpan when no traceparent is provided", async () => {
+    const result = await withSpanFromParent(undefined, "no-parent", { foo: 1 }, async () => "ok");
+    expect(result).toBe("ok");
+    expect(extractMock).not.toHaveBeenCalled();
+    expect(contextWithMock).not.toHaveBeenCalled();
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      "no-parent",
+      { attributes: { foo: 1 } },
+      expect.any(Function),
+    );
+  });
+
+  it("extracts the parent context and runs withSpan inside it", async () => {
+    const extractedCtx = { __extracted: true };
+    extractMock.mockReturnValue(extractedCtx);
+    const result = await withSpanFromParent(
+      "00-trace-span-01",
+      "with-parent",
+      { bar: 2 },
+      async () => "done",
+    );
+    expect(result).toBe("done");
+    expect(extractMock).toHaveBeenCalledWith(activeContext, { traceparent: "00-trace-span-01" });
+    expect(contextWithMock).toHaveBeenCalledWith(extractedCtx, expect.any(Function));
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      "with-parent",
+      { attributes: { bar: 2 } },
+      expect.any(Function),
+    );
   });
 });

--- a/src/lib/otel/tracing.ts
+++ b/src/lib/otel/tracing.ts
@@ -1,4 +1,11 @@
-import { SpanStatusCode, trace, type Attributes, type Span } from "@opentelemetry/api";
+import {
+  SpanStatusCode,
+  context as otelContext,
+  propagation,
+  trace,
+  type Attributes,
+  type Span,
+} from "@opentelemetry/api";
 
 import { TRACER_NAME } from "./constants.ts";
 
@@ -36,4 +43,36 @@ export async function withSpan<T>(
 /** Set attributes on whatever span is currently active. No-op if none. */
 export function setActiveSpanAttributes(attributes: Attributes): void {
   trace.getActiveSpan()?.setAttributes(attributes);
+}
+
+/**
+ * Serialize the currently active OTEL context into a W3C `traceparent` string.
+ * Returns undefined when there is no active span to serialize.
+ *
+ * Used to smuggle a span's context across execution boundaries that OTEL
+ * cannot cross on its own — workflow `start(...)`, `resumeHook(...)` payloads,
+ * and anywhere a child unit of work runs in a separate process / sandbox
+ * without a live parent context. Pair with `withSpanFromParent` on the far
+ * side to re-enter the same trace.
+ */
+export function captureTraceparent(): string | undefined {
+  const carrier: Record<string, string> = {};
+  propagation.inject(otelContext.active(), carrier);
+  return carrier.traceparent;
+}
+
+/**
+ * Like `withSpan`, but if `traceparent` is provided, extracts it and runs the
+ * new span as a child of that context. Falls back to a root span when
+ * `traceparent` is absent or malformed.
+ */
+export async function withSpanFromParent<T>(
+  traceparent: string | undefined,
+  name: string,
+  attributes: Attributes,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  if (!traceparent) return withSpan(name, attributes, fn);
+  const parentCtx = propagation.extract(otelContext.active(), { traceparent });
+  return otelContext.with(parentCtx, () => withSpan(name, attributes, fn));
 }

--- a/src/lib/otel/types.ts
+++ b/src/lib/otel/types.ts
@@ -17,6 +17,5 @@ export interface ChatAttributes {
   "chat.thread_id"?: string;
   "chat.user_id": string;
   "chat.turn_index"?: number;
-  "chat.workflow_run_id": string;
   [key: string]: string | number | undefined;
 }

--- a/src/server/routes/handlers.ts
+++ b/src/server/routes/handlers.ts
@@ -10,7 +10,7 @@ import { EventRouter } from "@/bot/router";
 import { AgentContext } from "@/lib/ai/context";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric } from "@/lib/metrics";
-import { withSpan } from "@/lib/otel/tracing";
+import { captureTraceparent, withSpan } from "@/lib/otel/tracing";
 
 export const router = new EventRouter();
 
@@ -50,6 +50,7 @@ router.onMessage(async (packet, ctx) => {
           type: "message",
           content: packet.data.content,
           context: turnContext,
+          traceparent: captureTraceparent(),
         };
         await resumeHook(existing.workflowRunId, event);
         await ctx.store.touch(channelId);

--- a/src/server/routes/handlers.ts
+++ b/src/server/routes/handlers.ts
@@ -32,14 +32,13 @@ router.onMessage(async (packet, ctx) => {
     {
       "chat.id": existing.workflowRunId,
       "chat.channel_id": channelId,
-      "chat.workflow_run_id": existing.workflowRunId,
+      "chat.user_id": packet.data.author.id,
     },
     async () => {
       const logger = createWideLogger({
         op: "chat.resume_hook",
         chat: {
           id: existing.workflowRunId,
-          workflow_run_id: existing.workflowRunId,
           channel_id: channelId,
           user_id: packet.data.author.id,
         },

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -76,14 +76,26 @@ async function runTurn(args: RunTurnArgs) {
           duration_ms: Date.now() - startTime,
           turn: turnIndex === 1 ? "first" : "followup",
           tokens: result.usage.totalTokens,
+          input_tokens: result.usage.inputTokens,
+          output_tokens: result.usage.outputTokens,
+          subagent_tokens: result.usage.subagentTokens,
           tool_calls: result.usage.toolCallCount,
+          tool_names: result.usage.toolNames,
           steps: result.usage.stepCount,
           text_length: result.text.length,
+          model: result.model,
+          discord_message_id: result.discordMessageId,
         });
         return result;
       } catch (err) {
-        logger.error(err as Error);
-        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        const error = err as Error;
+        logger.error(error);
+        logger.emit({
+          outcome: "error",
+          duration_ms: Date.now() - startTime,
+          error_class: error.name,
+          error_message: error.message,
+        });
         throw err;
       } finally {
         recordDuration("workflow.chat.run_turn_duration", Date.now() - startTime, {
@@ -112,6 +124,7 @@ async function persistSnapshot(
     {
       "chat.channel_id": channelId,
       ...(threadId ? { "chat.thread_id": threadId } : {}),
+      "chat.user_id": args.context.userId,
       "chat.turn_count": args.turnCount,
     },
     async () => {
@@ -120,6 +133,7 @@ async function persistSnapshot(
         chat: {
           channel_id: channelId,
           thread_id: threadId,
+          user_id: args.context.userId,
           turn_count: args.turnCount,
           total_tokens: args.totalUsage.totalTokens,
         },
@@ -135,8 +149,14 @@ async function persistSnapshot(
         logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
       } catch (err) {
         countMetric("workflow.chat.snapshot_error");
-        logger.error(err as Error);
-        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
+        const error = err as Error;
+        logger.error(error);
+        logger.emit({
+          outcome: "error",
+          duration_ms: Date.now() - startTime,
+          error_class: error.name,
+          error_message: error.message,
+        });
       } finally {
         recordDuration("workflow.chat.persist_snapshot_duration", Date.now() - startTime);
       }
@@ -144,23 +164,26 @@ async function persistSnapshot(
   );
 }
 
-async function cleanupConversation(
-  channelId: string,
-  threadId: string | undefined,
-  traceparent: string | undefined,
-) {
+async function cleanupConversation(args: {
+  channelId: string;
+  threadId: string | undefined;
+  userId: string;
+  traceparent: string | undefined;
+}) {
   "use step";
+  const { channelId, threadId, userId, traceparent } = args;
   return withSpanFromParent(
     traceparent,
     "workflow.chat.cleanup",
     {
       "chat.channel_id": channelId,
       ...(threadId ? { "chat.thread_id": threadId } : {}),
+      "chat.user_id": userId,
     },
     async () => {
       const logger = createWideLogger({
         op: "workflow.chat.cleanup",
-        chat: { channel_id: channelId, thread_id: threadId },
+        chat: { channel_id: channelId, thread_id: threadId, user_id: userId },
       });
       const startTime = Date.now();
       const threadKey = threadId ?? channelId;
@@ -186,13 +209,46 @@ async function cleanupConversation(
       }
       recordDuration("workflow.chat.cleanup_duration", Date.now() - startTime);
       if (conversationResult.status === "rejected") {
-        logger.error(conversationResult.reason as Error);
-        logger.emit({ outcome: "error", duration_ms: Date.now() - startTime, cleanup });
+        const error = conversationResult.reason as Error;
+        logger.error(error);
+        logger.emit({
+          outcome: "error",
+          duration_ms: Date.now() - startTime,
+          cleanup,
+          error_class: error.name,
+          error_message: error.message,
+        });
         throw conversationResult.reason;
       }
       logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime, cleanup });
     },
   );
+}
+
+/**
+ * Per-conversation state mutated across turns. Passed by reference so helpers
+ * can push messages / bump counts / swap traceparents without returning a
+ * rebuilt state object each call.
+ */
+interface ConversationState {
+  messages: ChatMessage[];
+  turnCount: number;
+  totalUsage: TurnUsage;
+  traceparent: string | undefined;
+}
+
+/**
+ * Slice of `SerializedAgentContext` that stays fixed once the workflow
+ * starts: the conversation's channel/thread and the lead-in messages that
+ * preceded the initial mention. Re-applied on every followup turn so the
+ * event's per-turn context (author, role, attachments) combines cleanly
+ * with the pinned location.
+ */
+interface StableScope {
+  channel: SerializedAgentContext["channel"];
+  thread: SerializedAgentContext["thread"];
+  recentMessages: SerializedAgentContext["recentMessages"];
+  referencedContext: SerializedAgentContext["referencedContext"];
 }
 
 async function runFirstTurn(args: {
@@ -223,6 +279,43 @@ async function runFirstTurn(args: {
   return { messages, totalUsage };
 }
 
+async function handleFollowupTurn(args: {
+  event: Extract<ChatHookEvent, { type: "message" }>;
+  state: ConversationState;
+  stable: StableScope;
+  channelId: string;
+  threadId: string | undefined;
+  workflowRunId: string;
+}): Promise<void> {
+  const { event, state, stable, channelId, threadId, workflowRunId } = args;
+  if (event.traceparent) state.traceparent = event.traceparent;
+  const turnContext: SerializedAgentContext = { ...event.context, ...stable };
+  state.messages.push({ role: "user", content: event.content });
+  const turn = await runTurn({
+    channelId,
+    messages: state.messages,
+    serializedContext: turnContext,
+    workflowRunId,
+    turnIndex: state.turnCount + 1,
+    traceparent: state.traceparent,
+  });
+  state.messages.push({ role: "assistant", content: turn.text });
+  capHistory(state.messages);
+  state.turnCount += 1;
+  state.totalUsage = addTurnUsage(state.totalUsage, turn.usage);
+  await persistSnapshot(
+    channelId,
+    threadId,
+    {
+      context: turnContext,
+      messages: state.messages,
+      totalUsage: state.totalUsage,
+      turnCount: state.turnCount,
+    },
+    state.traceparent,
+  );
+}
+
 /**
  * Run the chat workflow body. Extracted from `chatWorkflow` so the outer
  * function can stay a thin span wrapper. Assumes it's invoked inside a
@@ -244,27 +337,27 @@ async function runChatWorkflow(payload: ChatPayload, workflowRunId: string): Pro
   countMetric("workflow.chat.started");
 
   // Stable for the lifetime of this workflow — the conversation is pinned to
-  // one Discord channel/thread and the pre-conversation message lead-in does
-  // not change. Per-turn context takes these verbatim from the initial payload.
-  const stableChannel = context.channel;
-  const stableThread = context.thread;
-  const stableRecentMessages = context.recentMessages;
-  const stableReferencedContext = context.referencedContext;
-
-  // Tracks the trace each turn's step spans join. Starts at the initial
-  // mention's traceparent and updates on every hook event so followup turns
-  // join their own mention's trace. Steps run in separate executions that do
-  // not inherit OTEL context, so we pass this through explicitly.
-  let currentTraceparent = traceparent;
+  // one Discord channel/thread and the pre-conversation lead-in does not
+  // change. Per-turn context splats these verbatim from the initial payload.
+  const stable: StableScope = {
+    channel: context.channel,
+    thread: context.thread,
+    recentMessages: context.recentMessages,
+    referencedContext: context.referencedContext,
+  };
 
   const workflowStart = Date.now();
   const { messages, totalUsage: initialUsage } = await runFirstTurn({
     payload,
     workflowRunId,
-    traceparent: currentTraceparent,
+    traceparent,
   });
-  let turnCount = 1;
-  let totalUsage = initialUsage;
+  const state: ConversationState = {
+    messages,
+    turnCount: 1,
+    totalUsage: initialUsage,
+    traceparent,
+  };
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
@@ -278,50 +371,23 @@ async function runChatWorkflow(payload: ChatPayload, workflowRunId: string): Pro
       break;
     }
     if (!event.content) continue;
-
     countMetric("workflow.chat.followup");
-
-    if (event.traceparent) currentTraceparent = event.traceparent;
-
-    // Merge the fresh per-turn identity from the event with the stable
-    // location + lead-in pinned at workflow start.
-    const turnContext: SerializedAgentContext = {
-      ...event.context,
-      channel: stableChannel,
-      thread: stableThread,
-      recentMessages: stableRecentMessages,
-      referencedContext: stableReferencedContext,
-    };
-
-    messages.push({ role: "user", content: event.content });
-    const turn = await runTurn({
-      channelId,
-      messages,
-      serializedContext: turnContext,
-      workflowRunId,
-      turnIndex: turnCount + 1,
-      traceparent: currentTraceparent,
-    });
-    messages.push({ role: "assistant", content: turn.text });
-    capHistory(messages);
-    turnCount += 1;
-    totalUsage = addTurnUsage(totalUsage, turn.usage);
-    await persistSnapshot(
-      channelId,
-      threadId,
-      { context: turnContext, messages, totalUsage, turnCount },
-      currentTraceparent,
-    );
+    await handleFollowupTurn({ event, state, stable, channelId, threadId, workflowRunId });
   }
 
-  await cleanupConversation(channelId, threadId, currentTraceparent);
+  await cleanupConversation({
+    channelId,
+    threadId,
+    userId: context.userId,
+    traceparent: state.traceparent,
+  });
   workflowLogger.emit({
     outcome: "ok",
     duration_ms: Date.now() - workflowStart,
     ended_by: endedByUser ? "user" : "hook_close",
-    turn_count: turnCount,
-    total_tokens: totalUsage.totalTokens,
-    tool_calls: totalUsage.toolCallCount,
+    turn_count: state.turnCount,
+    total_tokens: state.totalUsage.totalTokens,
+    tool_calls: state.totalUsage.toolCallCount,
   });
 }
 

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -11,7 +11,7 @@ import { streamTurn } from "@/lib/ai/streaming";
 import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDuration } from "@/lib/metrics";
-import { withSpan } from "@/lib/otel/tracing";
+import { withSpanFromParent } from "@/lib/otel/tracing";
 import { releaseSession } from "@/lib/sandbox/session";
 
 import type { ChatHookEvent, ChatPayload } from "./types";
@@ -32,15 +32,20 @@ function capHistory(messages: ChatMessage[]): void {
   messages.splice(0, excess + (excess % 2));
 }
 
-async function runTurn(
-  channelId: string,
-  messages: ChatMessage[],
-  serializedContext: SerializedAgentContext,
-  workflowRunId: string,
-  turnIndex: number,
-) {
+interface RunTurnArgs {
+  channelId: string;
+  messages: ChatMessage[];
+  serializedContext: SerializedAgentContext;
+  workflowRunId: string;
+  turnIndex: number;
+  traceparent: string | undefined;
+}
+
+async function runTurn(args: RunTurnArgs) {
   "use step";
-  return withSpan(
+  const { channelId, messages, serializedContext, workflowRunId, turnIndex, traceparent } = args;
+  return withSpanFromParent(
+    traceparent,
     "workflow.chat.run_turn",
     {
       "chat.id": workflowRunId,
@@ -98,9 +103,11 @@ async function persistSnapshot(
     totalUsage: TurnUsage;
     turnCount: number;
   },
+  traceparent: string | undefined,
 ) {
   "use step";
-  return withSpan(
+  return withSpanFromParent(
+    traceparent,
     "workflow.chat.persist_snapshot",
     {
       "chat.channel_id": channelId,
@@ -137,9 +144,14 @@ async function persistSnapshot(
   );
 }
 
-async function cleanupConversation(channelId: string, threadId: string | undefined) {
+async function cleanupConversation(
+  channelId: string,
+  threadId: string | undefined,
+  traceparent: string | undefined,
+) {
   "use step";
-  return withSpan(
+  return withSpanFromParent(
+    traceparent,
     "workflow.chat.cleanup",
     {
       "chat.channel_id": channelId,
@@ -183,11 +195,41 @@ async function cleanupConversation(channelId: string, threadId: string | undefin
   );
 }
 
-export async function chatWorkflow(payload: ChatPayload) {
-  "use workflow";
-
+async function runFirstTurn(args: {
+  payload: ChatPayload;
+  workflowRunId: string;
+  traceparent: string | undefined;
+}): Promise<{ messages: ChatMessage[]; totalUsage: TurnUsage }> {
+  const { payload, workflowRunId, traceparent } = args;
   const { channelId, threadId, content, context } = payload;
-  const { workflowRunId } = getWorkflowMetadata();
+  const messages: ChatMessage[] = [{ role: "user", content }];
+  const first = await runTurn({
+    channelId,
+    messages,
+    serializedContext: context,
+    workflowRunId,
+    turnIndex: 1,
+    traceparent,
+  });
+  messages.push({ role: "assistant", content: first.text });
+  capHistory(messages);
+  const totalUsage = addTurnUsage(emptyTurnUsage(), first.usage);
+  await persistSnapshot(
+    channelId,
+    threadId,
+    { context, messages, totalUsage, turnCount: 1 },
+    traceparent,
+  );
+  return { messages, totalUsage };
+}
+
+/**
+ * Run the chat workflow body. Extracted from `chatWorkflow` so the outer
+ * function can stay a thin span wrapper. Assumes it's invoked inside a
+ * `workflow.chat` span whose trace id was joined to the initiating mention.
+ */
+async function runChatWorkflow(payload: ChatPayload, workflowRunId: string): Promise<void> {
+  const { channelId, threadId, context, traceparent } = payload;
 
   const workflowLogger = createWideLogger({
     op: "workflow.chat",
@@ -209,15 +251,20 @@ export async function chatWorkflow(payload: ChatPayload) {
   const stableRecentMessages = context.recentMessages;
   const stableReferencedContext = context.referencedContext;
 
-  const workflowStart = Date.now();
-  const messages: ChatMessage[] = [{ role: "user", content }];
-  const first = await runTurn(channelId, messages, context, workflowRunId, 1);
-  messages.push({ role: "assistant", content: first.text });
-  capHistory(messages);
+  // Tracks the trace each turn's step spans join. Starts at the initial
+  // mention's traceparent and updates on every hook event so followup turns
+  // join their own mention's trace. Steps run in separate executions that do
+  // not inherit OTEL context, so we pass this through explicitly.
+  let currentTraceparent = traceparent;
 
+  const workflowStart = Date.now();
+  const { messages, totalUsage: initialUsage } = await runFirstTurn({
+    payload,
+    workflowRunId,
+    traceparent: currentTraceparent,
+  });
   let turnCount = 1;
-  let totalUsage = addTurnUsage(emptyTurnUsage(), first.usage);
-  await persistSnapshot(channelId, threadId, { context, messages, totalUsage, turnCount });
+  let totalUsage = initialUsage;
 
   using hook = createHook<ChatHookEvent>({ token: workflowRunId });
 
@@ -234,6 +281,8 @@ export async function chatWorkflow(payload: ChatPayload) {
 
     countMetric("workflow.chat.followup");
 
+    if (event.traceparent) currentTraceparent = event.traceparent;
+
     // Merge the fresh per-turn identity from the event with the stable
     // location + lead-in pinned at workflow start.
     const turnContext: SerializedAgentContext = {
@@ -245,20 +294,27 @@ export async function chatWorkflow(payload: ChatPayload) {
     };
 
     messages.push({ role: "user", content: event.content });
-    const turn = await runTurn(channelId, messages, turnContext, workflowRunId, turnCount + 1);
+    const turn = await runTurn({
+      channelId,
+      messages,
+      serializedContext: turnContext,
+      workflowRunId,
+      turnIndex: turnCount + 1,
+      traceparent: currentTraceparent,
+    });
     messages.push({ role: "assistant", content: turn.text });
     capHistory(messages);
     turnCount += 1;
     totalUsage = addTurnUsage(totalUsage, turn.usage);
-    await persistSnapshot(channelId, threadId, {
-      context: turnContext,
-      messages,
-      totalUsage,
-      turnCount,
-    });
+    await persistSnapshot(
+      channelId,
+      threadId,
+      { context: turnContext, messages, totalUsage, turnCount },
+      currentTraceparent,
+    );
   }
 
-  await cleanupConversation(channelId, threadId);
+  await cleanupConversation(channelId, threadId, currentTraceparent);
   workflowLogger.emit({
     outcome: "ok",
     duration_ms: Date.now() - workflowStart,
@@ -267,4 +323,22 @@ export async function chatWorkflow(payload: ChatPayload) {
     total_tokens: totalUsage.totalTokens,
     tool_calls: totalUsage.toolCallCount,
   });
+}
+
+export async function chatWorkflow(payload: ChatPayload) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  return withSpanFromParent(
+    payload.traceparent,
+    "workflow.chat",
+    {
+      "chat.id": workflowRunId,
+      "chat.channel_id": payload.channelId,
+      ...(payload.threadId ? { "chat.thread_id": payload.threadId } : {}),
+      "chat.user_id": payload.context.userId,
+    },
+    () => runChatWorkflow(payload, workflowRunId),
+  );
 }

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -7,10 +7,27 @@ export interface ChatPayload {
   threadId?: string;
   content: string;
   context: SerializedAgentContext;
+  /**
+   * W3C traceparent captured from the `chat.mention` span that initiated the
+   * workflow. The workflow extracts it so every span it creates (workflow
+   * body + steps) lives in the same trace as the originating mention.
+   */
+  traceparent?: string;
 }
 
 export type ChatHookEvent =
-  | { type: "message"; content: string; context: SerializedAgentContext }
+  | {
+      type: "message";
+      content: string;
+      context: SerializedAgentContext;
+      /**
+       * W3C traceparent captured from the `chat.mention` / `chat.resume_hook`
+       * span that fired this event. Lets the resumed turn's step spans join
+       * the trace of the mention that triggered this specific turn, rather
+       * than the workflow's initial mention.
+       */
+      traceparent?: string;
+    }
   | { type: "done" };
 
 /** Payload passed to start(). The `id` field on meta is ignored — the workflow sets it to its own runId. */


### PR DESCRIPTION
## Summary
- Propagate the initiating mention span's context through the chat workflow as a W3C `traceparent`, so a turn's `chat.mention → workflow.chat → workflow.chat.{run_turn, persist_snapshot, cleanup}` spans all live in a single trace instead of one per boundary.
- Fixes `workflow.chat` wide events going out with no `trace.id` (workflow body had no `withSpan` around it) and unifies step spans into the mention's trace so the Discord footer hex resolves to the full tree in Sentry.
- Followup turns (thread mention or in-channel resume) each capture their own originating span's `traceparent`, so the per-turn footer trace id matches that turn's mention.
- New helpers `captureTraceparent` / `withSpanFromParent` in `src/lib/otel/tracing.ts` keep propagation API details out of call sites; covered by 4 new unit tests.

## Test plan
- [ ] Mention the bot in Discord, paste the footer trace hex into Sentry, confirm the tree contains `chat.mention → workflow.chat → workflow.chat.run_turn (+ ai.*) → persist_snapshot`.
- [ ] Send a followup mention in the thread, confirm the turn-2 footer hex resolves to a separate trace rooted at the turn-2 `chat.mention`.
- [ ] Send a non-mention message in the conversation channel, confirm the resume trace is rooted at `chat.resume_hook`.
- [ ] End the conversation and confirm the `workflow.chat.cleanup` span + wide event land in the last turn's trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
