### PR TITLE
feat(voice-transcription): chunk oversized OGG Opus past Groq's 25 MB limit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@vercel/sandbox": "^1.10.0",
         "@vercel/sdk": "^1.19.35",
         "ai": "^6.0.160",
+        "codec-parser": "^2.5.0",
         "discord-api-types": "^0.38.46",
         "discord-interactions": "^4.4.0",
         "discord.js": "^14.26.3",
@@ -1544,6 +1545,8 @@
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
+    "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@vercel/sandbox": "^1.10.0",
     "@vercel/sdk": "^1.19.35",
     "ai": "^6.0.160",
+    "codec-parser": "^2.5.0",
     "discord-api-types": "^0.38.46",
     "discord-interactions": "^4.4.0",
     "discord.js": "^14.26.3",

--- a/src/bot/handlers/events/voice-transcription/index.ts
+++ b/src/bot/handlers/events/voice-transcription/index.ts
@@ -1,11 +1,107 @@
+import type { API } from "@discordjs/core/http-only";
+
 import { groq } from "@ai-sdk/groq";
 import { experimental_transcribe as transcribe } from "ai";
 import { MessageFlags } from "discord.js";
 import { log } from "evlog";
 
 import { defineEvent } from "@/bot/events/define";
+import { MessageRenderer } from "@/lib/ai/message-renderer";
+import { splitOggOpus } from "@/lib/audio/ogg-opus-splitter";
 
 const TRANSCRIPTION_FAILED = "Sorry, I couldn't transcribe that audio message.";
+
+const CHUNK_THRESHOLD = 24 * 1024 * 1024;
+const CHUNK_TARGET = 20 * 1024 * 1024;
+const CHUNK_RETRY_DELAY_MS = 750;
+
+const MAX_DISCORD_CONTENT = 1900;
+
+const TOO_LARGE_PATTERN = /\b413\b|too large|payload|exceeds|size limit|too big/i;
+
+async function transcribeOnce(audio: Uint8Array): Promise<string> {
+  const result = await transcribe({
+    model: groq.transcription("whisper-large-v3"),
+    audio,
+    providerOptions: { groq: { language: "en" } },
+  });
+  return result.text;
+}
+
+async function transcribeChunked(buffer: Uint8Array): Promise<{ text: string; partCount: number }> {
+  const { chunks } = splitOggOpus(buffer, { targetBytes: CHUNK_TARGET });
+  const parts: string[] = [];
+  let successes = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]!;
+    const label = i + 1 + "/" + chunks.length;
+    try {
+      parts.push(await transcribeOnce(chunk));
+      successes++;
+      continue;
+    } catch (err) {
+      log.warn("voice-transcription", "Chunk " + label + " first attempt failed: " + String(err));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, CHUNK_RETRY_DELAY_MS));
+
+    try {
+      parts.push(await transcribeOnce(chunk));
+      successes++;
+    } catch (err) {
+      log.warn("voice-transcription", "Chunk " + label + " retry failed: " + String(err));
+      parts.push("[part " + label + " failed]");
+    }
+  }
+
+  if (successes === 0) {
+    throw new Error("all chunks failed to transcribe");
+  }
+
+  return { text: parts.join(" ").trim(), partCount: chunks.length };
+}
+
+async function postTranscript(
+  discord: API,
+  channelId: string,
+  messageId: string,
+  text: string,
+  partCount: number,
+): Promise<void> {
+  const footer = partCount > 1 ? "\n-# Transcribed in " + partCount + " parts" : "";
+  const body = text || TRANSCRIPTION_FAILED;
+
+  if (body.length + footer.length <= MAX_DISCORD_CONTENT) {
+    await discord.channels.createMessage(channelId, {
+      content: body + footer,
+      message_reference: { message_id: messageId },
+    });
+    return;
+  }
+
+  const messages = MessageRenderer.splitText(body, MAX_DISCORD_CONTENT);
+  const lastIdx = messages.length - 1;
+  if (footer) {
+    if (messages[lastIdx]!.length + footer.length <= MAX_DISCORD_CONTENT) {
+      messages[lastIdx] = messages[lastIdx]! + footer;
+    } else {
+      const reSplit = MessageRenderer.splitText(
+        messages[lastIdx]!,
+        MAX_DISCORD_CONTENT - footer.length,
+      );
+      messages.splice(lastIdx, 1, ...reSplit);
+      messages[messages.length - 1] = messages[messages.length - 1]! + footer;
+    }
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    await discord.channels.createMessage(channelId, {
+      content: messages[i]!,
+      ...(i === 0 ? { message_reference: { message_id: messageId } } : {}),
+    });
+  }
+}
 
 export const voiceTranscription = defineEvent({
   type: "message",
@@ -22,20 +118,28 @@ export const voiceTranscription = defineEvent({
       const response = await fetch(audio.url);
       const buffer = new Uint8Array(await response.arrayBuffer());
 
-      const result = await transcribe({
-        model: groq.transcription("whisper-large-v3"),
-        audio: buffer,
-        providerOptions: {
-          groq: { language: "en" },
-        },
-      });
+      let text: string;
+      let partCount: number;
 
-      await ctx.discord.channels.createMessage(channel.id, {
-        content: result.text || TRANSCRIPTION_FAILED,
-        message_reference: { message_id: messageId },
-      });
+      if (buffer.byteLength > CHUNK_THRESHOLD) {
+        ({ text, partCount } = await transcribeChunked(buffer));
+      } else {
+        try {
+          text = await transcribeOnce(buffer);
+          partCount = 1;
+        } catch (err) {
+          if (!TOO_LARGE_PATTERN.test(String(err))) throw err;
+          log.warn(
+            "voice-transcription",
+            "Fast path hit size error, falling back to chunked: " + String(err),
+          );
+          ({ text, partCount } = await transcribeChunked(buffer));
+        }
+      }
+
+      await postTranscript(ctx.discord, channel.id, messageId, text, partCount);
     } catch (err) {
-      log.warn("voice-transcription", `Failed: ${String(err)}`);
+      log.warn("voice-transcription", "Failed: " + String(err));
       await ctx.discord.channels.createMessage(channel.id, {
         content: TRANSCRIPTION_FAILED,
         message_reference: { message_id: messageId },

--- a/src/lib/audio/crc32-ogg.test.ts
+++ b/src/lib/audio/crc32-ogg.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+
+import { oggCrc32 } from "./crc32-ogg";
+
+describe("oggCrc32", () => {
+  it("returns 0 for empty input", () => {
+    expect(oggCrc32(new Uint8Array(0))).toBe(0);
+  });
+
+  it("returns 0 for any run of zero bytes (init=0, no xor-out)", () => {
+    expect(oggCrc32(new Uint8Array(1))).toBe(0);
+    expect(oggCrc32(new Uint8Array(16))).toBe(0);
+    expect(oggCrc32(new Uint8Array(1000))).toBe(0);
+  });
+
+  it("matches the libogg CRC table entry for byte 0x01", () => {
+    // libogg's lookup table is the single-byte-from-init-0 CRC: table[b] = crc32([b]).
+    // table[1] = 0x04C11DB7 (first nonzero entry, known from the libogg reference).
+    expect(oggCrc32(new Uint8Array([0x01]))).toBe(0x04c1_1db7);
+  });
+
+  it("matches the libogg CRC table entry for byte 0x02", () => {
+    // table[2] = 0x09823B6E (known from the libogg reference).
+    expect(oggCrc32(new Uint8Array([0x02]))).toBe(0x0982_3b6e);
+  });
+
+  it("matches the libogg CRC table entry for byte 0xFF", () => {
+    // table[0xFF] = 0xB1F740B4 (known from the libogg reference).
+    expect(oggCrc32(new Uint8Array([0xff]))).toBe(0xb1f7_40b4);
+  });
+
+  it("returns a non-negative 32-bit unsigned integer", () => {
+    const data = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    const crc = oggCrc32(data);
+    expect(crc).toBeGreaterThanOrEqual(0);
+    expect(crc).toBeLessThanOrEqual(0xffff_ffff);
+  });
+
+  it("is deterministic for the same input", () => {
+    const data = new Uint8Array([0x4f, 0x67, 0x67, 0x53, 0x00, 0x02, 0x00, 0x00]);
+    expect(oggCrc32(data)).toBe(oggCrc32(data));
+  });
+
+  it("produces different values for different inputs", () => {
+    const a = oggCrc32(new Uint8Array([0x01]));
+    const b = oggCrc32(new Uint8Array([0x02]));
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/audio/crc32-ogg.ts
+++ b/src/lib/audio/crc32-ogg.ts
@@ -1,0 +1,23 @@
+const POLYNOMIAL = 0x04c1_1db7;
+
+const TABLE: Uint32Array = (() => {
+  const t = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = (i << 24) >>> 0;
+    for (let b = 0; b < 8; b++) {
+      c = (c & 0x8000_0000) !== 0 ? ((c << 1) ^ POLYNOMIAL) >>> 0 : (c << 1) >>> 0;
+    }
+    t[i] = c;
+  }
+  return t;
+})();
+
+/** OGG CRC-32 per RFC 3533: poly 0x04C11DB7, init 0, no reflection, no xor-out. */
+export function oggCrc32(data: Uint8Array): number {
+  let crc = 0;
+  for (const byte of data) {
+    const idx = ((crc >>> 24) ^ byte) & 0xff;
+    crc = (((crc << 8) >>> 0) ^ TABLE[idx]!) >>> 0;
+  }
+  return crc >>> 0;
+}

--- a/src/lib/audio/errors.ts
+++ b/src/lib/audio/errors.ts
@@ -1,0 +1,23 @@
+export class OggSplitParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OggSplitParseError";
+  }
+}
+
+export class OggSplitNoAudioError extends Error {
+  constructor() {
+    super("OGG stream contains no audio pages");
+    this.name = "OggSplitNoAudioError";
+  }
+}
+
+export class OggSplitTooLargeError extends Error {
+  constructor(
+    public readonly chunks: number,
+    public readonly maxChunks: number,
+  ) {
+    super("OGG stream requires " + chunks + " chunks, exceeding max " + maxChunks);
+    this.name = "OggSplitTooLargeError";
+  }
+}

--- a/src/lib/audio/ogg-opus-splitter.test.ts
+++ b/src/lib/audio/ogg-opus-splitter.test.ts
@@ -1,0 +1,254 @@
+import type { OggPage } from "codec-parser";
+
+import CodecParser from "codec-parser";
+import { describe, it, expect } from "vitest";
+
+import { oggCrc32 } from "./crc32-ogg";
+import { OggSplitNoAudioError, OggSplitParseError, OggSplitTooLargeError } from "./errors";
+import { splitOggOpus } from "./ogg-opus-splitter";
+
+const EOS_FLAG = 0x04;
+const BOS_FLAG = 0x02;
+
+/** Build a single OGG page with the given body and header fields. */
+function makePage(opts: {
+  headerType: number;
+  granulePosition: bigint;
+  serialNumber: number;
+  sequenceNumber: number;
+  body: Uint8Array;
+}): Uint8Array {
+  const segments: number[] = [];
+  let remaining = opts.body.length;
+  while (remaining >= 255) {
+    segments.push(255);
+    remaining -= 255;
+  }
+  segments.push(remaining);
+  const numSegments = segments.length;
+  if (numSegments > 255) {
+    throw new Error("body too large for a single page");
+  }
+
+  const pageLen = 27 + numSegments + opts.body.length;
+  const page = new Uint8Array(pageLen);
+  const view = new DataView(page.buffer, page.byteOffset, page.byteLength);
+
+  page.set([0x4f, 0x67, 0x67, 0x53], 0);
+  page[4] = 0;
+  page[5] = opts.headerType;
+  view.setBigInt64(6, opts.granulePosition, true);
+  view.setUint32(14, opts.serialNumber, true);
+  view.setUint32(18, opts.sequenceNumber, true);
+  view.setUint32(22, 0, true);
+  page[26] = numSegments;
+  for (let i = 0; i < numSegments; i++) {
+    page[27 + i] = segments[i]!;
+  }
+  page.set(opts.body, 27 + numSegments);
+
+  view.setUint32(22, oggCrc32(page), true);
+  return page;
+}
+
+/** Minimal valid OpusHead identification body (19 bytes). */
+function opusHeadBody(): Uint8Array {
+  const body = new Uint8Array(19);
+  const view = new DataView(body.buffer);
+  body.set(new TextEncoder().encode("OpusHead"), 0);
+  body[8] = 1;
+  body[9] = 1;
+  view.setUint16(10, 0, true);
+  view.setUint32(12, 48_000, true);
+  view.setInt16(16, 0, true);
+  body[18] = 0;
+  return body;
+}
+
+/** Minimal valid OpusTags comment body (16 bytes: magic + empty vendor + 0 comments). */
+function opusTagsBody(): Uint8Array {
+  const body = new Uint8Array(16);
+  body.set(new TextEncoder().encode("OpusTags"), 0);
+  return body;
+}
+
+function audioBody(size: number, seed: number): Uint8Array {
+  const body = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    body[i] = (seed + i) & 0xff;
+  }
+  return body;
+}
+
+function buildStream(audioPageSizes: readonly number[]): {
+  buffer: Uint8Array;
+  headerBytes: number;
+} {
+  const serial = 0x1234_5678;
+  const opusHead = makePage({
+    headerType: BOS_FLAG,
+    granulePosition: 0n,
+    serialNumber: serial,
+    sequenceNumber: 0,
+    body: opusHeadBody(),
+  });
+  const opusTags = makePage({
+    headerType: 0,
+    granulePosition: 0n,
+    serialNumber: serial,
+    sequenceNumber: 1,
+    body: opusTagsBody(),
+  });
+
+  const allPages: Uint8Array[] = [opusHead, opusTags];
+  let granule = 0n;
+  for (let i = 0; i < audioPageSizes.length; i++) {
+    granule += 960n;
+    const isLast = i === audioPageSizes.length - 1;
+    allPages.push(
+      makePage({
+        headerType: isLast ? EOS_FLAG : 0,
+        granulePosition: granule,
+        serialNumber: serial,
+        sequenceNumber: i + 2,
+        body: audioBody(audioPageSizes[i]!, i),
+      }),
+    );
+  }
+
+  const total = allPages.reduce((sum, p) => sum + p.length, 0);
+  const buffer = new Uint8Array(total);
+  let off = 0;
+  for (const serialized of allPages) {
+    buffer.set(serialized, off);
+    off += serialized.length;
+  }
+
+  return { buffer, headerBytes: opusHead.length + opusTags.length };
+}
+
+function parsePages(buf: Uint8Array): OggPage[] {
+  return new CodecParser<OggPage>("audio/ogg").parseAll(buf);
+}
+
+function readU32LE(buf: Uint8Array, offset: number): number {
+  return (
+    (buf[offset]! |
+      (buf[offset + 1]! << 8) |
+      (buf[offset + 2]! << 16) |
+      (buf[offset + 3]! << 24)) >>>
+    0
+  );
+}
+
+describe("splitOggOpus bypass path", () => {
+  it("returns the input unchanged when buffer fits under targetBytes", () => {
+    const { buffer } = buildStream([200, 200, 200]);
+    const result = splitOggOpus(buffer, { targetBytes: 10 * 1024 });
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]).toBe(buffer);
+    expect(result.headerBytes).toBe(0);
+    expect(result.totalPages).toBe(0);
+  });
+});
+
+describe("splitOggOpus chunking behavior", () => {
+  const audioSizes = [400, 400, 400, 400, 400, 400];
+
+  it("splits a multi-page stream into multiple chunks under a small target", () => {
+    const { buffer, headerBytes } = buildStream(audioSizes);
+    const targetBytes = headerBytes + 900;
+    const result = splitOggOpus(buffer, { targetBytes });
+    expect(result.chunks.length).toBeGreaterThan(1);
+    expect(result.headerBytes).toBe(headerBytes);
+    expect(result.totalPages).toBe(2 + audioSizes.length);
+    for (const chunk of result.chunks) {
+      expect(chunk.byteLength).toBeLessThanOrEqual(targetBytes);
+    }
+  });
+
+  it("each emitted chunk starts with OpusHead + OpusTags and re-parses cleanly", () => {
+    const { buffer, headerBytes } = buildStream(audioSizes);
+    const result = splitOggOpus(buffer, { targetBytes: headerBytes + 900 });
+    for (const chunk of result.chunks) {
+      const parsed = parsePages(chunk);
+      expect(parsed.length).toBeGreaterThanOrEqual(3);
+      const textDecoder = new TextDecoder();
+      expect(textDecoder.decode(parsed[0]!.rawData.subarray(28, 28 + 8))).toBe("OpusHead");
+      expect(textDecoder.decode(parsed[1]!.rawData.subarray(28, 28 + 8))).toBe("OpusTags");
+    }
+  });
+
+  it("renumbers pageSequenceNumber contiguously from 0 within each chunk", () => {
+    const { buffer, headerBytes } = buildStream(audioSizes);
+    const result = splitOggOpus(buffer, { targetBytes: headerBytes + 900 });
+    for (const chunk of result.chunks) {
+      const parsed = parsePages(chunk);
+      for (let i = 0; i < parsed.length; i++) {
+        expect(parsed[i]!.pageSequenceNumber).toBe(i);
+      }
+    }
+  });
+
+  it("sets EOS on last page of every chunk and clears it elsewhere", () => {
+    const { buffer, headerBytes } = buildStream(audioSizes);
+    const result = splitOggOpus(buffer, { targetBytes: headerBytes + 900 });
+    for (const chunk of result.chunks) {
+      const parsed = parsePages(chunk);
+      for (let i = 0; i < parsed.length; i++) {
+        const headerType = parsed[i]!.rawData[5]!;
+        const hasEos = (headerType & EOS_FLAG) !== 0;
+        if (i === parsed.length - 1) {
+          expect(hasEos).toBe(true);
+        } else {
+          expect(hasEos).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("recomputes valid CRC checksums on every rewritten page", () => {
+    const { buffer, headerBytes } = buildStream(audioSizes);
+    const result = splitOggOpus(buffer, { targetBytes: headerBytes + 900 });
+    for (const chunk of result.chunks) {
+      const parsed = parsePages(chunk);
+      for (const entry of parsed) {
+        const storedCrc = readU32LE(entry.rawData, 22);
+        const copy = new Uint8Array(entry.rawData);
+        copy[22] = 0;
+        copy[23] = 0;
+        copy[24] = 0;
+        copy[25] = 0;
+        expect(oggCrc32(copy)).toBe(storedCrc);
+      }
+    }
+  });
+});
+
+describe("splitOggOpus error cases", () => {
+  it("throws OggSplitNoAudioError when stream has only header pages", () => {
+    const { buffer } = buildStream([]);
+    expect(() => splitOggOpus(buffer, { targetBytes: 1 })).toThrow(OggSplitNoAudioError);
+  });
+
+  it("throws OggSplitTooLargeError when splitting would exceed maxChunks", () => {
+    const { buffer, headerBytes } = buildStream([400, 400, 400, 400, 400, 400]);
+    expect(() => splitOggOpus(buffer, { targetBytes: headerBytes + 500, maxChunks: 2 })).toThrow(
+      OggSplitTooLargeError,
+    );
+  });
+
+  it("throws OggSplitParseError when header pages do not fit in target", () => {
+    const { buffer, headerBytes } = buildStream([400]);
+    expect(() => splitOggOpus(buffer, { targetBytes: headerBytes - 1 })).toThrow(
+      OggSplitParseError,
+    );
+  });
+
+  it("throws OggSplitParseError on a garbage input too small to contain a page", () => {
+    const garbage = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const bigger = new Uint8Array(200);
+    bigger.set(garbage);
+    expect(() => splitOggOpus(bigger, { targetBytes: 100 })).toThrow(OggSplitParseError);
+  });
+});

--- a/src/lib/audio/ogg-opus-splitter.test.ts
+++ b/src/lib/audio/ogg-opus-splitter.test.ts
@@ -150,6 +150,19 @@ describe("splitOggOpus bypass path", () => {
     expect(result.headerBytes).toBe(0);
     expect(result.totalPages).toBe(0);
   });
+
+  it("uses default 20 MB target when called without options", () => {
+    const { buffer } = buildStream([200, 200, 200]);
+    const result = splitOggOpus(buffer);
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]).toBe(buffer);
+  });
+
+  it("falls back to DEFAULT_MAX_CHUNKS when maxChunks option is omitted", () => {
+    const { buffer, headerBytes } = buildStream([400, 400, 400, 400, 400, 400]);
+    const result = splitOggOpus(buffer, { targetBytes: headerBytes + 900 });
+    expect(result.chunks.length).toBeGreaterThan(1);
+  });
 });
 
 describe("splitOggOpus chunking behavior", () => {

--- a/src/lib/audio/ogg-opus-splitter.ts
+++ b/src/lib/audio/ogg-opus-splitter.ts
@@ -21,20 +21,15 @@ const EOS_FLAG = 0x04;
  * every emitted chunk, `pageSequenceNumber` is renumbered, and CRC-32
  * checksums are recomputed for each rewritten page.
  */
-export function splitOggOpus(buffer: Uint8Array, options: OggSplitOptions = {}): OggSplitResult {
-  const targetBytes = options.targetBytes ?? DEFAULT_TARGET_BYTES;
-  const maxChunks = options.maxChunks ?? DEFAULT_MAX_CHUNKS;
+export function splitOggOpus(buffer: Uint8Array, options?: OggSplitOptions): OggSplitResult {
+  const targetBytes = options?.targetBytes ?? DEFAULT_TARGET_BYTES;
+  const maxChunks = options?.maxChunks ?? DEFAULT_MAX_CHUNKS;
 
   if (buffer.byteLength <= targetBytes) {
     return { chunks: [buffer], headerBytes: 0, totalPages: 0 };
   }
 
-  let pages: OggPage[];
-  try {
-    pages = new CodecParser<OggPage>("audio/ogg").parseAll(buffer);
-  } catch (err) {
-    throw new OggSplitParseError("Failed to parse OGG stream: " + String(err));
-  }
+  const pages: OggPage[] = new CodecParser<OggPage>("audio/ogg").parseAll(buffer);
 
   if (pages.length < 2) {
     throw new OggSplitParseError("Expected at least 2 header pages, got " + pages.length);
@@ -54,6 +49,8 @@ export function splitOggOpus(buffer: Uint8Array, options: OggSplitOptions = {}):
     );
   }
 
+  // audioPages is non-empty (guarded above) and every loop iteration pushes
+  // onto `current`, so post-loop `current` always has ≥1 page to emit.
   const groups: OggPage[][] = [];
   let current: OggPage[] = [];
   let currentBytes = 0;
@@ -67,7 +64,7 @@ export function splitOggOpus(buffer: Uint8Array, options: OggSplitOptions = {}):
     current.push(audio);
     currentBytes += pageLen;
   }
-  if (current.length > 0) groups.push(current);
+  groups.push(current);
 
   if (groups.length > maxChunks) {
     throw new OggSplitTooLargeError(groups.length, maxChunks);

--- a/src/lib/audio/ogg-opus-splitter.ts
+++ b/src/lib/audio/ogg-opus-splitter.ts
@@ -1,0 +1,124 @@
+import type { OggPage } from "codec-parser";
+
+import CodecParser from "codec-parser";
+
+import type { OggSplitOptions, OggSplitResult } from "./types.ts";
+
+import { oggCrc32 } from "./crc32-ogg.ts";
+import { OggSplitNoAudioError, OggSplitParseError, OggSplitTooLargeError } from "./errors.ts";
+
+const DEFAULT_TARGET_BYTES = 20 * 1024 * 1024;
+const DEFAULT_MAX_CHUNKS = 10;
+
+const OFFSET_HEADER_TYPE = 5;
+const OFFSET_PAGE_SEQUENCE = 18;
+const OFFSET_CHECKSUM = 22;
+const EOS_FLAG = 0x04;
+
+/**
+ * Split an OGG Opus byte stream into multiple valid OGG Opus streams, each
+ * below `targetBytes`. Header pages (OpusHead + OpusTags) are replicated into
+ * every emitted chunk, `pageSequenceNumber` is renumbered, and CRC-32
+ * checksums are recomputed for each rewritten page.
+ */
+export function splitOggOpus(buffer: Uint8Array, options: OggSplitOptions = {}): OggSplitResult {
+  const targetBytes = options.targetBytes ?? DEFAULT_TARGET_BYTES;
+  const maxChunks = options.maxChunks ?? DEFAULT_MAX_CHUNKS;
+
+  if (buffer.byteLength <= targetBytes) {
+    return { chunks: [buffer], headerBytes: 0, totalPages: 0 };
+  }
+
+  let pages: OggPage[];
+  try {
+    pages = new CodecParser<OggPage>("audio/ogg").parseAll(buffer);
+  } catch (err) {
+    throw new OggSplitParseError("Failed to parse OGG stream: " + String(err));
+  }
+
+  if (pages.length < 2) {
+    throw new OggSplitParseError("Expected at least 2 header pages, got " + pages.length);
+  }
+
+  const headerPages = pages.slice(0, 2);
+  const audioPages = pages.slice(2);
+  if (audioPages.length === 0) {
+    throw new OggSplitNoAudioError();
+  }
+
+  const headerBytes = headerPages[0]!.rawData.length + headerPages[1]!.rawData.length;
+  const audioBudget = targetBytes - headerBytes;
+  if (audioBudget <= 0) {
+    throw new OggSplitParseError(
+      "Header pages (" + headerBytes + "B) do not fit in target (" + targetBytes + "B)",
+    );
+  }
+
+  const groups: OggPage[][] = [];
+  let current: OggPage[] = [];
+  let currentBytes = 0;
+  for (const audio of audioPages) {
+    const pageLen = audio.rawData.length;
+    if (currentBytes + pageLen > audioBudget && current.length > 0) {
+      groups.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(audio);
+    currentBytes += pageLen;
+  }
+  if (current.length > 0) groups.push(current);
+
+  if (groups.length > maxChunks) {
+    throw new OggSplitTooLargeError(groups.length, maxChunks);
+  }
+
+  const chunks: Uint8Array[] = groups.map((pagesInGroup) => emitChunk(headerPages, pagesInGroup));
+
+  return { chunks, headerBytes, totalPages: pages.length };
+}
+
+function emitChunk(headerPages: OggPage[], audioGroup: OggPage[]): Uint8Array {
+  const groupBytes = audioGroup.reduce((sum, p) => sum + p.rawData.length, 0);
+  const headerBytes = headerPages.reduce((sum, p) => sum + p.rawData.length, 0);
+  const chunk = new Uint8Array(headerBytes + groupBytes);
+
+  const pageSlots: Array<{ offset: number; length: number }> = [];
+  let off = 0;
+  for (const header of headerPages) {
+    chunk.set(header.rawData, off);
+    pageSlots.push({ offset: off, length: header.rawData.length });
+    off += header.rawData.length;
+  }
+  for (const audio of audioGroup) {
+    chunk.set(audio.rawData, off);
+    pageSlots.push({ offset: off, length: audio.rawData.length });
+    off += audio.rawData.length;
+  }
+
+  const lastIdx = pageSlots.length - 1;
+  for (let i = 0; i < pageSlots.length; i++) {
+    const slot = pageSlots[i]!;
+    const isLast = i === lastIdx;
+
+    const headerType = chunk[slot.offset + OFFSET_HEADER_TYPE]!;
+    chunk[slot.offset + OFFSET_HEADER_TYPE] = isLast
+      ? headerType | EOS_FLAG
+      : headerType & ~EOS_FLAG;
+
+    writeU32LE(chunk, slot.offset + OFFSET_PAGE_SEQUENCE, i);
+    writeU32LE(chunk, slot.offset + OFFSET_CHECKSUM, 0);
+
+    const crc = oggCrc32(chunk.subarray(slot.offset, slot.offset + slot.length));
+    writeU32LE(chunk, slot.offset + OFFSET_CHECKSUM, crc);
+  }
+
+  return chunk;
+}
+
+function writeU32LE(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff;
+  buf[offset + 1] = (value >>> 8) & 0xff;
+  buf[offset + 2] = (value >>> 16) & 0xff;
+  buf[offset + 3] = (value >>> 24) & 0xff;
+}

--- a/src/lib/audio/types.ts
+++ b/src/lib/audio/types.ts
@@ -1,0 +1,10 @@
+export interface OggSplitOptions {
+  readonly targetBytes?: number;
+  readonly maxChunks?: number;
+}
+
+export interface OggSplitResult {
+  readonly chunks: readonly Uint8Array[];
+  readonly headerBytes: number;
+  readonly totalPages: number;
+}


### PR DESCRIPTION
## Summary

Voice messages larger than Groq Whisper's 25 MB upload limit previously failed silently with the generic "Sorry, I couldn't transcribe..." fallback. This PR adds a pure-JS OGG Opus page splitter (new \`src/lib/audio/\` module using \`codec-parser\` + a RFC 3533 CRC-32 implementation) that re-emits oversized streams as multiple sub-25 MB chunks, with OpusHead/OpusTags replicated, \`pageSequenceNumber\` renumbered, EOS bits fixed, and CRCs recomputed per page.

The handler at \`src/bot/handlers/events/voice-transcription/index.ts\` now size-checks the attachment, takes the fast path under 24 MB (falling through to chunking on any 413/"too large" error), transcribes chunks sequentially with one retry + backoff per chunk, and on partial failure emits \`[part i/N failed]\` markers instead of losing the whole transcript. The combined transcript is posted as one message, overflowing into additional messages via the existing \`MessageRenderer.splitText\` when it exceeds 1900 characters, with a \`-# Transcribed in N parts\` footer when chunked.

## Test plan

- [x] \`bun format\`, \`bun lint\` (0 warnings), \`bun typecheck\` green
- [x] \`bun run test\` — 974 passed (+18 new in \`src/lib/audio/\`)
- [x] \`bun test:coverage\` — 99.34 / 98.04 / 100 / 99.28 against 90/85/90/90 thresholds
- [x] \`bun knip\` — green
- [ ] Manual: send a <25 MB voice message in dev Discord — verify single-message transcript (fast path)
- [ ] Manual: send (or synthesize) a >25 MB voice message — verify combined transcript posted with \`-# Transcribed in N parts\` footer
- [ ] Manual: simulate a mid-chunk Groq failure and confirm \`[part N/M failed]\` marker appears in the combined transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)