### PR TITLE
perf(chat): cut mention → first-visible-message latency

### DIFF
--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -206,14 +206,27 @@ async function startFreshWorkflow(args: {
 }): Promise<void> {
   const { packet, ctx, content, routing, logger, startTime } = args;
   const { data } = packet;
-  const { conversationChannelId, conversationThreadId, createdThread } =
-    await ensureConversationThread({ ctx, packet, routing, content, logger });
+  // Thread creation and lead-in fetch are independent — they only converge
+  // when we build turnContext below. Parallelizing saves one Discord RTT on
+  // the fresh-workflow path (min of the two, typically 50–200ms).
+  const [threadResult, leadIn] = await Promise.all([
+    ensureConversationThread({ ctx, packet, routing, content, logger }),
+    fetchLeadInMessages(ctx.discord, routing.sourceChannelId, data),
+  ]);
+  const { conversationChannelId, conversationThreadId, createdThread } = threadResult;
+  const { recentMessages, referencedContext } = leadIn;
 
-  const { recentMessages, referencedContext } = await fetchLeadInMessages(
-    ctx.discord,
-    routing.sourceChannelId,
-    data,
-  );
+  // Pre-create the "> Thinking..." placeholder so it's visible before workflow
+  // cold-start and the first step boundary. Best-effort: on failure, leave
+  // placeholderMessageId undefined and the workflow's renderer will create
+  // one itself as a fallback.
+  const placeholder = await ctx.discord.channels
+    .createMessage(conversationChannelId, { content: "> Thinking..." })
+    .catch((err) => {
+      countMetric("chat.placeholder.create_failed");
+      logger.warn("placeholder create failed", { reason: String(err) });
+      return undefined;
+    });
 
   const turnContext = AgentContext.fromPacket(packet, {
     threadOverride: createdThread,
@@ -228,6 +241,7 @@ async function startFreshWorkflow(args: {
       content,
       context: turnContext,
       traceparent: captureTraceparent(),
+      placeholderMessageId: placeholder?.id,
     },
   ]);
 

--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -198,6 +198,33 @@ describe("MessageRenderer instance", () => {
     expect(sends[0]).toEqual(["ch-1", { content: "> Thinking..." }]);
   });
 
+  it("init adopts an existing message id without creating one", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init({ existingMessageId: "pre-posted-1" });
+
+    // No new placeholder — the renderer adopts the pre-posted message.
+    expect(discord.callsTo("channels.createMessage")).toHaveLength(0);
+
+    // Subsequent flush edits target the pre-posted message id.
+    await renderer.appendText("Hello!");
+    const edits = discord.callsTo("channels.editMessage");
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+    expect(edits[edits.length - 1][1]).toBe("pre-posted-1");
+  });
+
+  it("init seeds lastEdit at 0 so the first flush goes through immediately", async () => {
+    // No Date.now mock — if `lastEdit` were seeded with `Date.now()`, the
+    // first flush would be throttled for 1500ms. Seeding at 0 lets the first
+    // delta edit the placeholder right away.
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+    await renderer.appendText("Hi!");
+
+    expect(discord.callsTo("channels.editMessage")).toHaveLength(1);
+  });
+
   it("appendText accumulates text", async () => {
     const discord = createMockAPI();
     const renderer = new MessageRenderer(asAPI(discord), "ch-1");

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -30,14 +30,29 @@ export class MessageRenderer {
     return this.text;
   }
 
-  /** Create initial placeholder message. */
-  async init(): Promise<void> {
-    const msg = await this.discord.channels.createMessage(this.channelId, {
-      content: "> Thinking...",
-    });
-    this.messageId = msg.id;
+  /**
+   * Adopt or create the initial placeholder message.
+   *
+   * When `existingMessageId` is provided, the renderer takes over an already
+   * posted "> Thinking..." message — the mention handler pre-creates one so
+   * the placeholder appears before workflow cold-start. Otherwise the
+   * renderer creates the placeholder itself.
+   *
+   * `lastEdit` is seeded at 0 (not `Date.now()`) so the first real-content
+   * `flush()` after init bypasses the 1.5s rate limit — users see the first
+   * streamed chunk as soon as it arrives instead of waiting for the throttle.
+   */
+  async init(opts?: { existingMessageId?: string }): Promise<void> {
+    if (opts?.existingMessageId) {
+      this.messageId = opts.existingMessageId;
+    } else {
+      const msg = await this.discord.channels.createMessage(this.channelId, {
+        content: "> Thinking...",
+      });
+      this.messageId = msg.id;
+    }
     this.lastRendered = "> Thinking...";
-    this.lastEdit = Date.now();
+    this.lastEdit = 0;
   }
 
   /** Append streamed text. Clears activity/preview since text is arriving. */

--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -178,6 +178,28 @@ describe("streamTurn: basic text rendering", () => {
     expect(body.content).toMatch(/-# .+s · 150 tokens/);
   });
 
+  it("adopts placeholderMessageId instead of posting a new placeholder", async () => {
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      placeholderMessageId: "pre-posted-1",
+      createAgent: fakeOrchestrator(["Hello!"]),
+    });
+
+    // The renderer edits the pre-posted placeholder during streaming and on
+    // finalize; it never calls createMessage for the placeholder. (A
+    // createMessage could still happen as an overflow chunk, but not for the
+    // placeholder — and this turn's response is short enough that it won't.)
+    const sends = discord.callsTo("channels.createMessage");
+    expect(sends).toHaveLength(0);
+
+    const edits = discord.callsTo("channels.editMessage");
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+    expect(edits[edits.length - 1][1]).toBe("pre-posted-1");
+    expect(result.discordMessageId).toBe("pre-posted-1");
+  });
+
   it("includes task ID in footer when taskId is provided", async () => {
     const discord = createMockAPI();
     const ctx = AgentContext.fromPacket(messagePacket("hello"));

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -120,7 +120,13 @@ async function runStreamTurn(args: {
   chatAttrs: ReturnType<typeof buildChatAttributes> | undefined;
 }): Promise<StreamTurnResult> {
   const { discord, channelId, messages, serializedContext, options, chatAttrs } = args;
-  const { taskId, createAgent = createOrchestrator, workflowRunId, turnIndex } = options;
+  const {
+    taskId,
+    createAgent = createOrchestrator,
+    workflowRunId,
+    turnIndex,
+    placeholderMessageId,
+  } = options;
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const tracker = new TurnUsageTracker();
   // The `OrchestratorFactory` return type is a structural subset of the real
@@ -142,7 +148,7 @@ async function runStreamTurn(args: {
     ...(taskId ? { task: { id: taskId } } : {}),
   });
 
-  await renderer.init();
+  await renderer.init({ existingMessageId: placeholderMessageId });
 
   const priorMessages = messages.slice(0, -1).map((m) => ({ role: m.role, content: m.content }));
   const current = messages[messages.length - 1];

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -274,4 +274,11 @@ export interface StreamTurnOptions {
   workflowRunId?: string;
   /** Turn number within the conversation (1 = first turn). */
   turnIndex?: number;
+  /**
+   * Pre-created "> Thinking..." placeholder id. When provided, the renderer
+   * edits this message instead of posting a new one. Used on the first turn
+   * of a fresh workflow — the mention handler posts the placeholder before
+   * enqueuing the workflow so it's visible ahead of workflow cold-start.
+   */
+  placeholderMessageId?: string;
 }

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -39,11 +39,25 @@ interface RunTurnArgs {
   workflowRunId: string;
   turnIndex: number;
   traceparent: string | undefined;
+  /**
+   * Pre-created "> Thinking..." message id from the mention handler. Set only
+   * on the first turn of a fresh workflow so the renderer adopts it instead
+   * of posting a new placeholder.
+   */
+  placeholderMessageId?: string;
 }
 
 async function runTurn(args: RunTurnArgs) {
   "use step";
-  const { channelId, messages, serializedContext, workflowRunId, turnIndex, traceparent } = args;
+  const {
+    channelId,
+    messages,
+    serializedContext,
+    workflowRunId,
+    turnIndex,
+    traceparent,
+    placeholderMessageId,
+  } = args;
   return withSpanFromParent(
     traceparent,
     "workflow.chat.run_turn",
@@ -70,6 +84,7 @@ async function runTurn(args: RunTurnArgs) {
         const result = await streamTurn(discord, channelId, messages, serializedContext, {
           workflowRunId,
           turnIndex,
+          placeholderMessageId,
         });
         logger.emit({
           outcome: "ok",
@@ -257,7 +272,7 @@ async function runFirstTurn(args: {
   traceparent: string | undefined;
 }): Promise<{ messages: ChatMessage[]; totalUsage: TurnUsage }> {
   const { payload, workflowRunId, traceparent } = args;
-  const { channelId, threadId, content, context } = payload;
+  const { channelId, threadId, content, context, placeholderMessageId } = payload;
   const messages: ChatMessage[] = [{ role: "user", content }];
   const first = await runTurn({
     channelId,
@@ -266,6 +281,7 @@ async function runFirstTurn(args: {
     workflowRunId,
     turnIndex: 1,
     traceparent,
+    placeholderMessageId,
   });
   messages.push({ role: "assistant", content: first.text });
   capHistory(messages);

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -13,6 +13,16 @@ export interface ChatPayload {
    * body + steps) lives in the same trace as the originating mention.
    */
   traceparent?: string;
+  /**
+   * Discord message id for a "> Thinking..." placeholder the mention handler
+   * pre-created before enqueuing the workflow. When set, the first turn's
+   * renderer adopts it instead of posting a new placeholder — pulls the
+   * placeholder visibility ahead of workflow cold-start + the first step
+   * boundary. Undefined when the handler couldn't pre-create one (e.g. the
+   * Discord API call failed); the renderer then creates the placeholder
+   * itself as a fallback.
+   */
+  placeholderMessageId?: string;
 }
 
 export type ChatHookEvent =


### PR DESCRIPTION
## Summary
- Parallelize thread creation with lead-in fetch in the mention handler (was sequential) — saves ~50–200ms per fresh mention.
- Pre-create the "> Thinking..." placeholder in the mention handler and thread a new `placeholderMessageId` through `ChatPayload` → `runFirstTurn` → `runTurn` → `streamTurn` → `MessageRenderer.init({ existingMessageId })`, so the placeholder appears before workflow cold-start instead of after it (~300–1500ms earlier). Best-effort; on failure `MessageRenderer.init()` falls back to creating the placeholder itself, and a `chat.placeholder.create_failed` counter tracks failures.
- Seed `MessageRenderer.lastEdit = 0` in `init()` so the first content flush bypasses the 1.5s edit throttle — the first streamed tokens now render immediately instead of sitting behind "Thinking..." for another 1.5s.

## Test plan
- [x] `bun format`, `bun lint`, `bun typecheck`, `bun run test` (995 passing), `bun test:coverage` (99.43% stmt / 100% func), `bun knip`
- [x] New unit tests: `MessageRenderer.init({ existingMessageId })` adopts the id without creating a new message; `init()` seeds `lastEdit = 0` so the first flush edits immediately; `streamTurn` with `placeholderMessageId` skips the placeholder `createMessage` and edits the passed id
- [ ] Manual smoke: mention the bot in a fresh channel and confirm "Thinking..." appears noticeably faster, and the first real chunk renders without the ~1.5s gap
- [ ] Manual smoke: mention-as-reply still includes referenced context; thread-create failure still falls back to the source channel and posts the placeholder there

🤖 Generated with [Claude Code](https://claude.com/claude-code)