### PR TITLE
perf: parallelize voice chunks, Figma search, Linear team lookup

### DIFF
--- a/src/bot/handlers/events/voice-transcription/index.ts
+++ b/src/bot/handlers/events/voice-transcription/index.ts
@@ -30,30 +30,29 @@ async function transcribeOnce(audio: Uint8Array): Promise<string> {
 
 async function transcribeChunked(buffer: Uint8Array): Promise<{ text: string; partCount: number }> {
   const { chunks } = splitOggOpus(buffer, { targetBytes: CHUNK_TARGET });
-  const parts: string[] = [];
-  let successes = 0;
 
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i]!;
-    const label = i + 1 + "/" + chunks.length;
-    try {
-      parts.push(await transcribeOnce(chunk));
-      successes++;
-      continue;
-    } catch (err) {
-      log.warn("voice-transcription", "Chunk " + label + " first attempt failed: " + String(err));
-    }
+  const settled = await Promise.allSettled(
+    chunks.map(async (chunk, i) => {
+      const label = i + 1 + "/" + chunks.length;
+      try {
+        return await transcribeOnce(chunk);
+      } catch (err) {
+        log.warn("voice-transcription", "Chunk " + label + " first attempt failed: " + String(err));
+        await new Promise((resolve) => setTimeout(resolve, CHUNK_RETRY_DELAY_MS));
+        try {
+          return await transcribeOnce(chunk);
+        } catch (retryErr) {
+          log.warn("voice-transcription", "Chunk " + label + " retry failed: " + String(retryErr));
+          throw retryErr;
+        }
+      }
+    }),
+  );
 
-    await new Promise((resolve) => setTimeout(resolve, CHUNK_RETRY_DELAY_MS));
-
-    try {
-      parts.push(await transcribeOnce(chunk));
-      successes++;
-    } catch (err) {
-      log.warn("voice-transcription", "Chunk " + label + " retry failed: " + String(err));
-      parts.push("[part " + label + " failed]");
-    }
-  }
+  const parts = settled.map((s, i) =>
+    s.status === "fulfilled" ? s.value : "[part " + (i + 1) + "/" + chunks.length + " failed]",
+  );
+  const successes = settled.filter((s) => s.status === "fulfilled").length;
 
   if (successes === 0) {
     throw new Error("all chunks failed to transcribe");

--- a/src/lib/ai/tools/figma/base.ts
+++ b/src/lib/ai/tools/figma/base.ts
@@ -108,13 +108,22 @@ export const search_files = tool({
     const lowerQuery = query.toLowerCase();
     const matches: ReturnType<typeof summarizeFile>[] = [];
 
-    for (const proj of data.projects) {
-      if (matches.length >= limit) break;
-      const files = await figma.get<GetProjectFilesResponse>(`/v1/projects/${proj.id}/files`);
-      for (const f of files.files) {
-        if (matches.length >= limit) break;
-        if (f.name.toLowerCase().includes(lowerQuery)) {
-          matches.push(summarizeFile(f, proj.name));
+    const CONCURRENCY = 5;
+    for (let i = 0; i < data.projects.length && matches.length < limit; i += CONCURRENCY) {
+      const batch = data.projects.slice(i, i + CONCURRENCY);
+      const results = await Promise.all(
+        batch.map((p) =>
+          figma
+            .get<GetProjectFilesResponse>(`/v1/projects/${p.id}/files`)
+            .then((r) => ({ projectName: p.name, files: r.files })),
+        ),
+      );
+      for (const { projectName, files } of results) {
+        for (const f of files) {
+          if (matches.length >= limit) break;
+          if (f.name.toLowerCase().includes(lowerQuery)) {
+            matches.push(summarizeFile(f, projectName));
+          }
         }
       }
     }

--- a/src/lib/ai/tools/linear/teams.ts
+++ b/src/lib/ai/tools/linear/teams.ts
@@ -64,15 +64,14 @@ export const remove_user_from_team = admin(
         const user = await linear.user(user_id);
         const memberships = await user.teamMemberships();
 
-        for (const m of memberships.nodes) {
-          const team = await m.team;
-          if (team && team.id === team_id) {
-            const payload = await linear.deleteTeamMembership(m.id);
-            return JSON.stringify({ success: payload.success });
-          }
+        const teams = await Promise.all(memberships.nodes.map(async (m) => m.team));
+        const idx = teams.findIndex((t) => t?.id === team_id);
+        if (idx === -1) {
+          return JSON.stringify({ error: "User is not a member of this team" });
         }
 
-        return JSON.stringify({ error: "User is not a member of this team" });
+        const payload = await linear.deleteTeamMembership(memberships.nodes[idx]!.id);
+        return JSON.stringify({ success: payload.success });
       },
     }),
   ),


### PR DESCRIPTION
## Summary
- `transcribeChunked` now runs all Groq transcription chunks via `Promise.allSettled` (each with its own retry) instead of a serial for-loop — N× speedup for multi-chunk voice messages while preserving output ordering.
- Figma `search_files` fetches project file lists in bounded batches of 5 concurrent requests, still early-terminating between batches once the match limit is reached.
- Linear `remove_user_from_team` resolves membership→team relations in parallel and then picks the target, instead of awaiting one at a time.

## Test plan
- [x] \`bun format\`
- [x] \`bun lint\` (0 warnings, 0 errors)
- [x] \`bun typecheck\`
- [x] \`bun run test\` (992 tests passing)
- [x] \`bun test:coverage\` (99.43% stmts, 100% funcs)
- [x] \`bun knip\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)