### PR TITLE
test(ai): guard system prompt <tools> section against unregistered tools

### DIFF
--- a/src/lib/ai/orchestrator.test.ts
+++ b/src/lib/ai/orchestrator.test.ts
@@ -3,6 +3,7 @@ import type { MockLanguageModelV3 } from "ai/test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  contextForRole,
   discordRESTClass,
   installMockProvider,
   linearClientClass,
@@ -14,6 +15,7 @@ import {
   uninstallMockProvider,
 } from "@/lib/test/fixtures";
 
+import { UserRole } from "./constants.ts";
 import { AgentContext } from "./context.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
 
@@ -36,7 +38,8 @@ vi.mock("@vercel/sandbox", () => ({
   Sandbox: class MockSandbox {},
 }));
 
-const { createOrchestrator } = await import("./orchestrator.ts");
+const { createOrchestrator, getOrchestratorTools, SYSTEM_PROMPT } =
+  await import("./orchestrator.ts");
 
 const BASE_TOOLS = [
   "cancel_task",
@@ -100,6 +103,20 @@ describe("createOrchestrator", () => {
         "delegate_sentry",
       ]),
     );
+  });
+
+  it("only documents registered tools in the system prompt <tools> section", () => {
+    // Admin context: every delegate tool named in the prompt is role-gated
+    // (delegate_code is admin-only), so a public surface would false-fail.
+    const tools = getOrchestratorTools(contextForRole(UserRole.Admin), new TurnUsageTracker());
+
+    const section = SYSTEM_PROMPT.match(/<tools>([\s\S]*?)<\/tools>/)?.[1] ?? "";
+    const documented = [...section.matchAll(/^- \*\*([^*]+)\*\*/gm)].flatMap((m) =>
+      m[1]!.split("/").map((name) => name.trim()),
+    );
+
+    expect(documented).toContain("web_search");
+    expect(Object.keys(tools)).toEqual(expect.arrayContaining(documented));
   });
 
   it("injects execution context into system prompt via buildInstructions", async () => {


### PR DESCRIPTION
## Why

The orchestrator's system prompt and `getOrchestratorTools` have no shared source of truth, so they drift: `web_search` shipped documented in the prompt but unregistered in the tool set, making every model attempt to call it burn a step on an AI SDK `NoSuchToolError` until #127 wired it in. This adds a regression test so documented-but-unregistered tools fail CI instead of failing in production.

Before:

```
SYSTEM_PROMPT documents a tool → nothing checks it exists in
getOrchestratorTools → ghost tools reach production
(web_search: NoSuchToolError on every web-lookup request)
```

After:

```
orchestrator.test.ts parses every `- **name**` bullet in the <tools>
section and asserts each name exists on the admin tool surface →
a misnamed or unregistered documented tool fails `bun run test`
```

## What changed

- New test in `src/lib/ai/orchestrator.test.ts`: extracts tool names from `SYSTEM_PROMPT`'s `<tools>` section (handling `a / b / c` grouped bullets) and asserts each is registered in `getOrchestratorTools` built from an **admin**-role context — all `delegate_*` tools are role-gated and `delegate_code` is admin-only, so a public-role surface would false-fail.
- The check is deliberately one-directional (documented ⊆ registered): five delegate domains (cms, figma, finance, sentry, shopping) are registered but not yet documented; documenting them is plan 07's job. An `expect(documented).toContain("web_search")` guard prevents a vacuous pass if the section format ever changes.

## Test plan

- `bun run validate` — typecheck, lint, 1057 tests across 114 files, all green.
- `bun format --check` — green (CI runs this separately from `validate`).
- Mutation check: typo'ing `**web_search**` → `**web_serch**` in the prompt makes the new test fail; reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)