### PR TITLE
feat(observability): wire errors, traces, crons, logs, cost, and feedback into Sentry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Reference documentation for the Wack Hacker codebase. The top-level [README](../
 | [Skills](./skills/README.md)                    | `SKILL.md` format, the registry, progressive disclosure, admin gating, and adding skills or whole delegate domains. |
 | [Workflows & scheduling](./workflows/README.md) | `chatWorkflow` for multi-turn conversations, Vercel Queue + Turso for scheduled reminders.                          |
 | [Deployment](./deployment/README.md)            | `vercel.ts`, queue triggers, environment variables, build pipeline.                                                 |
+| [Observability](./observability.md)             | Sentry pipelines (errors, traces, logs, cron monitors), cost attribution, feedback capture, dashboards and alerts.  |
 | [Testing](./testing.md)                         | Vitest setup, unit vs integration suites, coverage thresholds.                                                      |
 
 ## Conventions

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,150 @@
+# Observability
+
+How errors, traces, logs, metrics, cron monitors, and user feedback flow into
+Sentry, and the dashboards/alerts worth building on top of them. Everything
+here describes what the code actually emits — metric and attribute names are
+the ones in `src/`.
+
+## The four pipelines
+
+### Errors → Sentry Issues
+
+There is exactly **one** error-reporting path: `createWideLogger(...).error(err)`
+(`src/lib/logging/wide.ts`) forwards to `Sentry.captureException` before
+delegating to evlog. Every existing `logger.error` site — `runInstrumented`'s
+catch, the gateway `relay()` catch, the queue consumer, `processEvent`, and
+every other wide-event op — becomes a Sentry issue with no extra code.
+
+Do **not** add bare `captureException` calls next to a `logger.error` call;
+that double-reports the same error.
+
+The queue consumer (`src/app/api/discord/events/route.ts`) wraps its
+`logger.error` in `Sentry.withScope` so issues there are **fingerprinted by
+packet type** and tagged `queue.terminal: "true"` on the attempt that
+dead-letters the message (`deliveryCount >= 3`).
+
+### Traces
+
+One trace now spans gateway relay → queue consume → workflow → orchestrator
+(`gen_ai.invoke_agent`) → subagent → tool call:
+
+- `relay()` (`src/server/routes/gateway/index.ts`) opens a **detached root
+  span** per packet via `withDetachedRootSpan` — detaching matters because the
+  discord.js socket callbacks otherwise inherit the keepalive request's stale
+  trace context and its sampling decision — then serializes the new context
+  with `captureTraceparent()` onto the packet (`traceparent` field, optional on
+  all seven packet schemas in `src/lib/protocol/packets.ts`).
+- The consumer joins it with `withSpanFromParent(packet.traceparent, "discord.event", …)`.
+- Scheduled tasks carry `traceparent` **only from the creating tool call**
+  (`src/lib/ai/tools/schedule/index.ts`). Checkpoint hops and recurring
+  re-enqueues intentionally start fresh traces — re-propagating would chain a
+  recurring task into one unbounded trace spanning weeks.
+- AI spans (`gen_ai.*`) come from `vercelAIIntegration({force: true, …})` in
+  `sentry.server.config.ts`. `force` is required because the `ai` package is
+  bundled by Next, so the integration's require-hook never sees it. These
+  spans power the **AI Agents Insights** module.
+
+Sampling (`tracesSampler` in `sentry.server.config.ts`): development 1.0;
+propagated traces follow `parentSampled`; the gateway keepalive route 0.01
+(~160 no-value invocations/day); `/api/crons/` routes and roots named
+`gateway.relay` / `discord.event` / `chat.*` / `workflow*` /
+`scheduled_task.fire` 1.0; everything else 0.1.
+
+The OTEL trace id is printed in every finalized bot reply footer, so any
+Discord message can be pasted straight into Sentry's trace search.
+
+### Wide events → Sentry Logs
+
+evlog wide events are JSON lines on stdout; `consoleLoggingIntegration`
+captures them into **Sentry Logs**. `createWideLogger` injects the active
+`trace.id` into every emit, so log lines join their trace in the UI. Query
+wide events in **Explore → Logs**, e.g. ops like `ai.turn`, `gateway.relay`,
+`discord.event.callback`, `ai.feedback`.
+
+### Cron monitors (Check-Ins)
+
+- Every cron handler is covered by one `Sentry.withMonitor` at the dispatch
+  chokepoint (`src/server/routes/crons.ts`); the **monitor slug is the cron
+  name** (`heartbeat`, `hack-night-create`, `hack-night-cleanup`, …).
+- The gateway listener has its own monitor, slug **`discord-gateway`**
+  (`*/9 * * * *`, mirroring `vercel.ts`). If its check-ins stop, the bot is
+  deaf.
+- `automaticVercelMonitors` was removed from `next.config.ts` — it read a
+  `vercel.json` that doesn't exist and is Pages-Router-only. Monitors are
+  explicit now.
+
+**Alerts cannot be created from code.** In Sentry: **Insights → Crons** →
+select the monitor → **Alerts → Create Alert**, condition *missed check-in*
+(also add *failed check-in* for `discord-gateway`). Do this once per slug
+after the first deploy registers them.
+
+## Cost attribution
+
+A static price table (`src/lib/ai/pricing.ts`, USD per MTok, input/output/
+cache-read rates per gateway model slug) feeds `estimateCostUsd`. The AI SDK's
+`inputTokens` includes cache reads, so cached tokens are subtracted and
+re-priced at the cache-read rate. Unknown model slugs emit
+`ai.cost.unknown_model` (count, attrs `{model, domain?}`) instead of a wrong
+number — **extend the table when adding a model**.
+
+| Metric | Type | Attributes |
+| --- | --- | --- |
+| `ai.turn.cost_usd` | distribution | `model`, `user` (hashed bucket) |
+| `ai.subagent.cost_usd` | distribution | `domain`, `model` |
+| `ai.turn.tokens` / `.tool_calls` / `.steps` | distribution | `model`, `user` |
+| `ai.subagent.tokens` / `.input_tokens` / `.output_tokens` / `.cached_input_tokens` / `.tool_calls` | distribution | `domain`, `model` |
+| `ai.subagent.completed` | count | `domain`, `model` |
+
+The `user` attribute is a stable 16-way hash bucket (`u00`–`u15`,
+`bucketUserId` in `src/lib/ai/streaming.ts`) — **never put raw user ids in
+metric attributes** (unbounded cardinality); raw ids are fine on wide events.
+
+`ai.subagent.cached_input_tokens` is the verification metric for prompt-cache
+work: it should be > 0 on step 2+ once caching layers correctly.
+
+Spans mirror the totals: `chat.turn` carries `ai.cost_usd`,
+`ai.cached_input_tokens`, and the token/tool/step attributes.
+
+## Feedback capture
+
+Closing the loop from a reaction on a bot reply back to the exact turn:
+
+- At finalize time, `streamTurn` writes `turn-message:<discordMessageId>` →
+  `{chatId, traceId, domains, channelId, userId}` to Redis (7-day TTL,
+  `TurnMessageStore` in `src/bot/turn-message-store.ts`), for the primary
+  reply and every overflow chunk. Persistence is non-fatal — failures count
+  `ai.feedback.index_error` and the turn still succeeds.
+- The `feedback` reaction handler (`src/bot/handlers/events/feedback/`) looks
+  the message up; a miss means "not a bot turn reply" (the lookup **is** the
+  bot-authored filter). On a hit it emits:
+  - metric `ai.feedback` (count, attrs `{emoji, positive}` where positive is
+    `"true"` / `"false"` / `"unknown"` from a small sentiment map), and
+  - wide event `op:"ai.feedback"` with `message_id`, `emoji`, `user_id`,
+    `chat_id`, `trace_id`, `domains` — joinable to the turn's trace and to
+    cost/usage by `trace_id` / `chat_id`.
+
+## Dashboards worth building
+
+All metric queries live in **Explore → Metrics** (trace-metrics); log queries
+in **Explore → Logs**; trace queries in **Explore → Traces**.
+
+| Dashboard | Query |
+| --- | --- |
+| Cost / day by model & domain | `ai.turn.cost_usd` summed, grouped by `model`; `ai.subagent.cost_usd` grouped by `domain`, `model` |
+| Cache hit ratio | `ai.subagent.cached_input_tokens` ÷ `ai.subagent.input_tokens`, by `domain` (also `ai.cached_input_tokens` vs `ai.input_tokens` on `chat.turn` spans) |
+| Subagent activity & failure proxy | `ai.subagent.completed` by `domain`, `model`; failures appear as issues from the `ai.subagent` wide-event path (dedicated failure metrics land with the subagent-resilience plan) |
+| Step-cap exhaustion | `ai.subagent.completed` filtered where `ai.turn.steps` ≈ the spec's `stopSteps`; spikes mean truncated work |
+| Queue dead-letters | Issues tagged `queue.terminal:true`, grouped by fingerprint (= packet type); rate via `discord.event.callback_error` by `type` |
+| Cron health | Crons page (slugs above); plus `cron.completed` / `cron.error` by `name` and `cron.duration` |
+| Gateway blackouts | `gateway.listener.hold_duration` gaps, `gateway.leader.lost`, `gateway.listener.login_failed`; monitor `discord-gateway` missed check-ins are the alert |
+| Feedback | `ai.feedback` by `positive`, `emoji`; drill into a reaction via its wide event's `trace_id` |
+| Approval latency / timeout rate | no metrics yet — lands with the approvals-hardening plan; today approvals are visible only in `chat.turn` traces |
+
+## Alerts to configure (Sentry UI, one-time)
+
+1. Missed check-in on **every cron slug** and missed/failed check-in on
+   **`discord-gateway`** (Insights → Crons → monitor → Alerts).
+2. Issue alert on new issues tagged `queue.terminal:true` (a packet was
+   dead-lettered after 3 attempts).
+3. Metric alert on `ai.turn.cost_usd` daily sum exceeding budget.
+4. Metric alert on `gateway.listener.login_failed` > 0 in 15 min.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -74,8 +74,8 @@ wide events in **Explore → Logs**, e.g. ops like `ai.turn`, `gateway.relay`,
   explicit now.
 
 **Alerts cannot be created from code.** In Sentry: **Insights → Crons** →
-select the monitor → **Alerts → Create Alert**, condition *missed check-in*
-(also add *failed check-in* for `discord-gateway`). Do this once per slug
+select the monitor → **Alerts → Create Alert**, condition _missed check-in_
+(also add _failed check-in_ for `discord-gateway`). Do this once per slug
 after the first deploy registers them.
 
 ## Cost attribution
@@ -83,17 +83,18 @@ after the first deploy registers them.
 A static price table (`src/lib/ai/pricing.ts`, USD per MTok, input/output/
 cache-read rates per gateway model slug) feeds `estimateCostUsd`. The AI SDK's
 `inputTokens` includes cache reads, so cached tokens are subtracted and
-re-priced at the cache-read rate. Unknown model slugs emit
-`ai.cost.unknown_model` (count, attrs `{model, domain?}`) instead of a wrong
-number — **extend the table when adding a model**.
+re-priced at the cache-read rate. Unknown subagent model slugs emit
+`ai.cost.unknown_model` (count, attrs `{model, domain}`) and contribute 0 to
+the turn total instead of a wrong number — **extend the table when adding a
+model** (pricing.test.ts pins every slug the repo runs).
 
-| Metric | Type | Attributes |
-| --- | --- | --- |
-| `ai.turn.cost_usd` | distribution | `model`, `user` (hashed bucket) |
-| `ai.subagent.cost_usd` | distribution | `domain`, `model` |
-| `ai.turn.tokens` / `.tool_calls` / `.steps` | distribution | `model`, `user` |
-| `ai.subagent.tokens` / `.input_tokens` / `.output_tokens` / `.cached_input_tokens` / `.tool_calls` | distribution | `domain`, `model` |
-| `ai.subagent.completed` | count | `domain`, `model` |
+| Metric                                                                                             | Type         | Attributes                      |
+| -------------------------------------------------------------------------------------------------- | ------------ | ------------------------------- |
+| `ai.turn.cost_usd`                                                                                 | distribution | `model`, `user` (hashed bucket) |
+| `ai.subagent.cost_usd`                                                                             | distribution | `domain`, `model`               |
+| `ai.turn.tokens` / `.tool_calls` / `.steps`                                                        | distribution | `model`, `user`                 |
+| `ai.subagent.tokens` / `.input_tokens` / `.output_tokens` / `.cached_input_tokens` / `.tool_calls` | distribution | `domain`, `model`               |
+| `ai.subagent.completed`                                                                            | count        | `domain`, `model`               |
 
 The `user` attribute is a stable 16-way hash bucket (`u00`–`u15`,
 `bucketUserId` in `src/lib/ai/streaming.ts`) — **never put raw user ids in
@@ -128,17 +129,17 @@ Closing the loop from a reaction on a bot reply back to the exact turn:
 All metric queries live in **Explore → Metrics** (trace-metrics); log queries
 in **Explore → Logs**; trace queries in **Explore → Traces**.
 
-| Dashboard | Query |
-| --- | --- |
-| Cost / day by model & domain | `ai.turn.cost_usd` summed, grouped by `model`; `ai.subagent.cost_usd` grouped by `domain`, `model` |
-| Cache hit ratio | `ai.subagent.cached_input_tokens` ÷ `ai.subagent.input_tokens`, by `domain` (also `ai.cached_input_tokens` vs `ai.input_tokens` on `chat.turn` spans) |
+| Dashboard                         | Query                                                                                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cost / day by model & domain      | `ai.turn.cost_usd` summed, grouped by `model`; `ai.subagent.cost_usd` grouped by `domain`, `model`                                                                                |
+| Cache hit ratio                   | `ai.subagent.cached_input_tokens` ÷ `ai.subagent.input_tokens`, by `domain` (also `ai.cached_input_tokens` vs `ai.input_tokens` on `chat.turn` spans)                             |
 | Subagent activity & failure proxy | `ai.subagent.completed` by `domain`, `model`; failures appear as issues from the `ai.subagent` wide-event path (dedicated failure metrics land with the subagent-resilience plan) |
-| Step-cap exhaustion | `ai.subagent.completed` filtered where `ai.turn.steps` ≈ the spec's `stopSteps`; spikes mean truncated work |
-| Queue dead-letters | Issues tagged `queue.terminal:true`, grouped by fingerprint (= packet type); rate via `discord.event.callback_error` by `type` |
-| Cron health | Crons page (slugs above); plus `cron.completed` / `cron.error` by `name` and `cron.duration` |
-| Gateway blackouts | `gateway.listener.hold_duration` gaps, `gateway.leader.lost`, `gateway.listener.login_failed`; monitor `discord-gateway` missed check-ins are the alert |
-| Feedback | `ai.feedback` by `positive`, `emoji`; drill into a reaction via its wide event's `trace_id` |
-| Approval latency / timeout rate | no metrics yet — lands with the approvals-hardening plan; today approvals are visible only in `chat.turn` traces |
+| Step-cap exhaustion               | `ai.subagent.completed` filtered where `ai.turn.steps` ≈ the spec's `stopSteps`; spikes mean truncated work                                                                       |
+| Queue dead-letters                | Issues tagged `queue.terminal:true`, grouped by fingerprint (= packet type); rate via `discord.event.callback_error` by `type`                                                    |
+| Cron health                       | Crons page (slugs above); plus `cron.completed` / `cron.error` by `name` and `cron.duration`                                                                                      |
+| Gateway blackouts                 | `gateway.listener.hold_duration` gaps, `gateway.leader.lost`, `gateway.listener.login_failed`; monitor `discord-gateway` missed check-ins are the alert                           |
+| Feedback                          | `ai.feedback` by `positive`, `emoji`; drill into a reaction via its wide event's `trace_id`                                                                                       |
+| Approval latency / timeout rate   | no metrics yet — lands with the approvals-hardening plan; today approvals are visible only in `chat.turn` traces                                                                  |
 
 ## Alerts to configure (Sentry UI, one-time)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,4 @@ export default withSentryConfig(withWorkflow(nextConfig), {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: !process.env.CI,
   widenClientFileUpload: true,
-  webpack: {
-    automaticVercelMonitors: true,
-  },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,14 +6,43 @@ Sentry.init({
     process.env.SENTRY_DSN ??
     "https://23174d7cbef96f2fd9276db93bd566cf@o4510744753405952.ingest.us.sentry.io/4511219848904704",
 
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  tracesSampler: ({ name, parentSampled }) => {
+    if (process.env.NODE_ENV === "development") return 1.0;
+    // Propagated traces follow the parent's decision so a distributed trace
+    // (gateway → queue → workflow → agent) is never partially sampled.
+    if (typeof parentSampled === "boolean") return parentSampled;
+    // The keepalive cron pings this route every 9 minutes (~160 no-value
+    // invocations/day); real event traces root at gateway.relay instead.
+    if (name.includes("/api/discord/gateway")) return 0.01;
+    // Cron executions root at the HTTP request span (`cron.execute` is its
+    // child and inherits via parentSampled), so the route is what must be
+    // fully sampled — ~25 low-volume invocations/day.
+    if (name.includes("/api/crons/")) return 1.0;
+    const fullySampledRoots = [
+      "gateway.relay",
+      "discord.event",
+      "chat.",
+      "workflow",
+      "scheduled_task.fire",
+      "cron.execute",
+    ];
+    if (fullySampledRoots.some((root) => name.startsWith(root))) return 1.0;
+    return 0.1;
+  },
 
   sendDefaultPii: true,
   includeLocalVariables: true,
   enableLogs: true,
 
   integrations: [
-    Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
+    // `force: true` because the `ai` package is bundled by Next, so the
+    // integration's CJS require-hook never observes it and would otherwise
+    // skip registering its ai.* → gen_ai.* span processors.
+    Sentry.vercelAIIntegration({ force: true, recordInputs: true, recordOutputs: true }),
+    // evlog wide events are JSON lines on stdout; this turns them into
+    // Sentry Logs (requires enableLogs), joined to traces by the trace.id
+    // that createWideLogger injects.
+    Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
     Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 5000 }),
   ],
 });

--- a/src/app/api/discord/events/route.ts
+++ b/src/app/api/discord/events/route.ts
@@ -1,7 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
+
 import { ConversationStore } from "@/bot/store";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDuration } from "@/lib/metrics";
-import { withSpan } from "@/lib/otel/tracing";
+import { withSpanFromParent } from "@/lib/otel/tracing";
 import { PacketCodec } from "@/lib/protocol/packets";
 import { handleCallback } from "@/lib/tasks/queue/client";
 import { processEvent } from "@/server/process-event";
@@ -11,7 +13,8 @@ const MAX_RETRIES = 3;
 export const POST = handleCallback<string>(
   async (encoded, metadata) => {
     const packet = PacketCodec.decode(encoded);
-    return withSpan(
+    return withSpanFromParent(
+      packet.traceparent,
       "discord.event",
       {
         "packet.type": packet.type,
@@ -31,7 +34,14 @@ export const POST = handleCallback<string>(
           logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
         } catch (err) {
           countMetric("discord.event.callback_error", { type: packet.type });
-          logger.error(err as Error);
+          // logger.error forwards to Sentry.captureException; the scope
+          // fingerprints by packet type and marks the terminal-acknowledge
+          // attempt (deliveryCount >= MAX_RETRIES dead-letters the message).
+          Sentry.withScope((scope) => {
+            scope.setFingerprint([packet.type]);
+            scope.setTag("queue.terminal", String(metadata.deliveryCount >= MAX_RETRIES));
+            logger.error(err as Error);
+          });
           logger.emit({ outcome: "error", duration_ms: Date.now() - startTime });
           throw err;
         } finally {

--- a/src/bot/handlers/events/feedback/index.test.ts
+++ b/src/bot/handlers/events/feedback/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { TurnMessageRecord } from "@/bot/turn-message-store";
+
+import { TurnMessageStore } from "@/bot/turn-message-store";
+import { createMemoryRedis, reactionPacket } from "@/lib/test/fixtures";
+
+const { emitted, loggerContexts } = vi.hoisted(() => ({
+  emitted: vi.fn(),
+  loggerContexts: [] as Record<string, unknown>[],
+}));
+
+vi.mock("evlog", () => ({
+  createLogger: vi.fn((context: Record<string, unknown>) => {
+    loggerContexts.push(context);
+    return {
+      set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      emit: emitted,
+      getContext: () => context,
+    };
+  }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  metrics: { count: vi.fn(), distribution: vi.fn() },
+}));
+
+import * as Sentry from "@sentry/nextjs";
+
+import { createFeedbackHandler, feedback } from "./index";
+
+const turnRecord: TurnMessageRecord = {
+  chatId: "wf-run-1",
+  traceId: "0af7651916cd43dd8448eb211c80319c",
+  domains: ["linear"],
+  channelId: "ch-1",
+  userId: "user-9",
+};
+
+/** Store pre-indexed with a turn record for the fixture packet's `msg-1`. */
+async function indexedStore(): Promise<TurnMessageStore> {
+  const store = new TurnMessageStore(createMemoryRedis());
+  await store.set("msg-1", turnRecord);
+  return store;
+}
+
+function clearCaptures(): void {
+  vi.mocked(Sentry.metrics.count).mockClear();
+  emitted.mockClear();
+  loggerContexts.length = 0;
+}
+
+describe("feedback reaction handler", () => {
+  it("registers as a reactionAdd handler", () => {
+    expect(feedback.type).toBe("reactionAdd");
+  });
+
+  it("ignores reactions to messages that are not indexed turn replies", async () => {
+    clearCaptures();
+    const handler = createFeedbackHandler(new TurnMessageStore(createMemoryRedis()));
+    await handler.handle(reactionPacket("\u{1F44D}"));
+    expect(Sentry.metrics.count).not.toHaveBeenCalled();
+    expect(emitted).not.toHaveBeenCalled();
+  });
+
+  it("ignores reactions added by bots", async () => {
+    clearCaptures();
+    const handler = createFeedbackHandler(await indexedStore());
+    const packet = reactionPacket("\u{1F44D}");
+    packet.data.creator = { ...packet.data.creator, bot: true };
+    await handler.handle(packet);
+    expect(Sentry.metrics.count).not.toHaveBeenCalled();
+    expect(emitted).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["\u{1F44D}", "true"],
+    ["❤️", "true"],
+    ["\u{1F525}", "true"],
+    ["\u{1F4AF}", "true"],
+    ["✅", "true"],
+    ["\u{1F44E}", "false"],
+    ["❌", "false"],
+    ["\u{1F914}", "unknown"],
+    ["custom_blob", "unknown"],
+  ])("counts ai.feedback for %s with positive=%s", async (emoji, positive) => {
+    clearCaptures();
+    const handler = createFeedbackHandler(await indexedStore());
+    await handler.handle(reactionPacket(emoji));
+    expect(Sentry.metrics.count).toHaveBeenCalledWith("ai.feedback", 1, {
+      attributes: { emoji, positive },
+    });
+  });
+
+  it("emits an ai.feedback wide event joining the reaction to the turn", async () => {
+    clearCaptures();
+    const handler = createFeedbackHandler(await indexedStore());
+    await handler.handle(reactionPacket("❌"));
+    expect(loggerContexts).toContainEqual({ op: "ai.feedback" });
+    expect(emitted).toHaveBeenCalledWith({
+      message_id: "msg-1",
+      emoji: "❌",
+      positive: "false",
+      user_id: "user-1",
+      chat_id: "wf-run-1",
+      trace_id: "0af7651916cd43dd8448eb211c80319c",
+      domains: ["linear"],
+    });
+  });
+});

--- a/src/bot/handlers/events/feedback/index.ts
+++ b/src/bot/handlers/events/feedback/index.ts
@@ -1,0 +1,50 @@
+import { defineEvent } from "@/bot/events/define";
+import { TurnMessageStore } from "@/bot/turn-message-store";
+import { createWideLogger } from "@/lib/logging/wide";
+import { countMetric } from "@/lib/metrics";
+
+// Thumbs-up, red heart (with the variation selector, as Discord sends it), fire, 100, check.
+const POSITIVE_EMOJI = new Set(["\u{1F44D}", "❤️", "\u{1F525}", "\u{1F4AF}", "✅"]);
+// Thumbs-down, cross mark.
+const NEGATIVE_EMOJI = new Set(["\u{1F44E}", "❌"]);
+
+function sentiment(emojiName: string): string {
+  if (POSITIVE_EMOJI.has(emojiName)) return "true";
+  if (NEGATIVE_EMOJI.has(emojiName)) return "false";
+  return "unknown";
+}
+
+/**
+ * Reaction-driven feedback on bot turn replies. The turn-message lookup is
+ * also the bot-authored filter: only finalized turn replies are indexed, so a
+ * miss means the reaction targets some other message — no Discord fetch
+ * needed to decide.
+ */
+export function createFeedbackHandler(turnMessages?: TurnMessageStore) {
+  return defineEvent({
+    type: "reactionAdd",
+    async handle(packet) {
+      if (packet.data.creator.bot) return;
+
+      const store = turnMessages ?? new TurnMessageStore();
+      const turn = await store.get(packet.data.messageId);
+      if (!turn) return;
+
+      const emoji = packet.data.emoji.name;
+      const positive = sentiment(emoji);
+      countMetric("ai.feedback", { emoji, positive });
+      // Raw user_id is fine on wide events; it is only forbidden in metric attributes.
+      createWideLogger({ op: "ai.feedback" }).emit({
+        message_id: packet.data.messageId,
+        emoji,
+        positive,
+        user_id: packet.data.creator.id,
+        chat_id: turn.chatId,
+        trace_id: turn.traceId,
+        domains: turn.domains,
+      });
+    },
+  });
+}
+
+export const feedback = createFeedbackHandler();

--- a/src/bot/handlers/events/index.ts
+++ b/src/bot/handlers/events/index.ts
@@ -7,3 +7,4 @@ export * from "./ship-scraper";
 export * from "./ship-scraper/delete";
 export * from "./hack-night-upload";
 export * from "./hack-night-reaction";
+export * from "./feedback";

--- a/src/bot/turn-message-store.test.ts
+++ b/src/bot/turn-message-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createMemoryRedis } from "@/lib/test/fixtures";
+
+import type { TurnMessageRecord } from "./turn-message-store";
+
+import { TurnMessageStore } from "./turn-message-store";
+
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
+
+const sampleRecord: TurnMessageRecord = {
+  chatId: "wf-run-1",
+  traceId: "0af7651916cd43dd8448eb211c80319c",
+  domains: ["linear", "notion"],
+  channelId: "ch-1",
+  userId: "user-1",
+};
+
+describe("TurnMessageStore", () => {
+  it("sets and gets a record keyed by discord message id", async () => {
+    const store = new TurnMessageStore(createMemoryRedis());
+    await store.set("msg-1", sampleRecord);
+    expect(await store.get("msg-1")).toEqual(sampleRecord);
+  });
+
+  it("keys records independently per message id", async () => {
+    const store = new TurnMessageStore(createMemoryRedis());
+    await store.set("msg-1", sampleRecord);
+    expect(await store.get("msg-2")).toBeNull();
+  });
+
+  it("returns null for a missing record", async () => {
+    const store = new TurnMessageStore(createMemoryRedis());
+    expect(await store.get("nope")).toBeNull();
+  });
+
+  it("expires records after the 7-day TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new TurnMessageStore(createMemoryRedis());
+      await store.set("msg-1", sampleRecord);
+      vi.advanceTimersByTime(7 * 24 * 60 * 60 * 1000 + 1);
+      expect(await store.get("msg-1")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps records alive within the TTL window", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new TurnMessageStore(createMemoryRedis());
+      await store.set("msg-1", sampleRecord);
+      vi.advanceTimersByTime(6 * 24 * 60 * 60 * 1000);
+      expect(await store.get("msg-1")).toEqual(sampleRecord);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses Redis.fromEnv when no redis argument is provided", async () => {
+    const store = new TurnMessageStore();
+    expect(await store.get("nonexistent")).toBeNull();
+  });
+});

--- a/src/bot/turn-message-store.ts
+++ b/src/bot/turn-message-store.ts
@@ -1,0 +1,32 @@
+import type { RedisClient } from "@/lib/redis/client";
+
+import { createRedis } from "@/lib/redis/client";
+
+import type { TurnMessageRecord } from "./types";
+
+export type { TurnMessageRecord } from "./types";
+
+const TTL = 7 * 24 * 60 * 60;
+
+/**
+ * Discord-message-id → turn index. This is the join from a message id back to
+ * the exact turn/trajectory that produced it: the trace id is already printed
+ * in the bot message footer and `chat.discord_message_id` is already a span
+ * attribute — this store closes the reverse direction so a reaction on a bot
+ * reply resolves to its turn.
+ */
+export class TurnMessageStore {
+  constructor(private redis: RedisClient = createRedis()) {}
+
+  private key(messageId: string): string {
+    return `turn-message:${messageId}`;
+  }
+
+  async get(messageId: string): Promise<TurnMessageRecord | null> {
+    return this.redis.get<TurnMessageRecord>(this.key(messageId));
+  }
+
+  async set(messageId: string, record: TurnMessageRecord): Promise<void> {
+    await this.redis.set(this.key(messageId), record, { ex: TTL });
+  }
+}

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -30,6 +30,25 @@ export interface ToolDefSnapshot {
 }
 
 /**
+ * Join from a Discord message id back to the exact turn/trajectory that
+ * produced it. The turn's trace id is already printed in the bot message
+ * footer and `chat.discord_message_id` is already a span attribute — this
+ * record is the reverse lookup, written at finalize time and consumed by the
+ * feedback reaction handler.
+ */
+export interface TurnMessageRecord {
+  /** Chat workflow run id (`chat.id` on spans/wide events); absent outside chat workflows. */
+  chatId?: string;
+  /** OTEL trace id for the turn — the same id rendered in the reply footer. */
+  traceId?: string;
+  /** Subagent domains that ran during the turn, deduplicated. */
+  domains: string[];
+  channelId: string;
+  /** Discord user id of the person whose message triggered the turn. */
+  userId: string;
+}
+
+/**
  * Per-turn snapshot of everything the orchestrator receives. Written by the
  * chat workflow after each turn completes; read by the /Inspect Context message
  * command. Stored under a separate Redis key from `ConversationState` to keep

--- a/src/lib/ai/pricing.test.ts
+++ b/src/lib/ai/pricing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { ORCHESTRATOR_MODEL, SUBAGENT_MODEL } from "./constants.ts";
+import { estimateCostUsd } from "./pricing.ts";
+
+// The code domain's spec.model override (delegates.ts). Hardcoded here instead
+// of importing delegates.ts, which instantiates SDK clients at import time.
+const CODE_SUBAGENT_MODEL = "anthropic/claude-opus-4.7";
+
+describe("estimateCostUsd", () => {
+  it("prices a known model with no cached tokens", () => {
+    // Sonnet: $3/M input + $15/M output.
+    const cost = estimateCostUsd({
+      model: "anthropic/claude-sonnet-4.6",
+      inputTokens: 1_000_000,
+      outputTokens: 200_000,
+    });
+    expect(cost).toBeCloseTo(3 + 3, 10);
+  });
+
+  it("discounts cache reads at the cached-input rate", () => {
+    // 600k uncached * $3/M + 400k cached * $0.30/M + 200k out * $15/M.
+    const cost = estimateCostUsd({
+      model: "anthropic/claude-sonnet-4.6",
+      inputTokens: 1_000_000,
+      outputTokens: 200_000,
+      cachedInputTokens: 400_000,
+    });
+    expect(cost).toBeCloseTo(1.8 + 0.12 + 3, 10);
+  });
+
+  it("treats omitted cachedInputTokens as zero", () => {
+    const withZero = estimateCostUsd({
+      model: SUBAGENT_MODEL,
+      inputTokens: 50_000,
+      outputTokens: 10_000,
+      cachedInputTokens: 0,
+    });
+    const withOmitted = estimateCostUsd({
+      model: SUBAGENT_MODEL,
+      inputTokens: 50_000,
+      outputTokens: 10_000,
+    });
+    expect(withOmitted).toBe(withZero);
+  });
+
+  it("clamps cachedInputTokens to inputTokens so cost never goes negative", () => {
+    // Provider quirk guard: cached reads can never exceed the total prompt.
+    const cost = estimateCostUsd({
+      model: SUBAGENT_MODEL,
+      inputTokens: 100,
+      outputTokens: 0,
+      cachedInputTokens: 500,
+    });
+    expect(cost).toBeCloseTo((100 * 0.025) / 1_000_000, 12);
+  });
+
+  it("returns undefined for unknown models", () => {
+    expect(
+      estimateCostUsd({ model: "acme/unpriced-1", inputTokens: 1_000, outputTokens: 100 }),
+    ).toBeUndefined();
+  });
+
+  it("covers every model slug the repo actually runs", () => {
+    for (const model of [ORCHESTRATOR_MODEL, SUBAGENT_MODEL, CODE_SUBAGENT_MODEL]) {
+      const cost = estimateCostUsd({ model, inputTokens: 1_000, outputTokens: 1_000 });
+      expect(cost).toBeGreaterThan(0);
+    }
+  });
+
+  it("prices the code-subagent Opus override well above the mini default", () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    const opus = estimateCostUsd({ model: CODE_SUBAGENT_MODEL, ...usage });
+    const mini = estimateCostUsd({ model: SUBAGENT_MODEL, ...usage });
+    expect(mini).toBeDefined();
+    expect(opus).toBeGreaterThan((mini ?? 0) * 10);
+  });
+});

--- a/src/lib/ai/pricing.ts
+++ b/src/lib/ai/pricing.ts
@@ -1,0 +1,48 @@
+interface ModelPricing {
+  /** USD per million uncached input tokens. */
+  inputPerMTok: number;
+  /** USD per million output tokens. */
+  outputPerMTok: number;
+  /** USD per million cache-read input tokens. */
+  cachedInputPerMTok: number;
+}
+
+/**
+ * Static list prices by AI-gateway model slug, per Anthropic/OpenAI published
+ * API pricing as of June 2026. Covers every slug this repo actually runs
+ * (`ORCHESTRATOR_MODEL`, `SUBAGENT_MODEL`, and the code domain's Opus
+ * override). Order of magnitude matters more than cent-accuracy here — this
+ * feeds cost-attribution metrics, not billing.
+ */
+const PRICE_TABLE: Record<string, ModelPricing> = {
+  "anthropic/claude-sonnet-4.6": { inputPerMTok: 3, outputPerMTok: 15, cachedInputPerMTok: 0.3 },
+  "anthropic/claude-opus-4.7": { inputPerMTok: 5, outputPerMTok: 25, cachedInputPerMTok: 0.5 },
+  "openai/gpt-5.4-mini": { inputPerMTok: 0.25, outputPerMTok: 2, cachedInputPerMTok: 0.025 },
+};
+
+/**
+ * Estimate the USD cost of one model invocation (or an aggregate of them).
+ * Returns `undefined` for models missing from the price table — callers skip
+ * the cost metric and count `ai.cost.unknown_model` instead of emitting a
+ * misleading figure.
+ *
+ * The AI SDK's `inputTokens` is the TOTAL prompt (cache reads included), so
+ * cached tokens are subtracted out and re-priced at the cache-read rate.
+ */
+export function estimateCostUsd(args: {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}): number | undefined {
+  const price = PRICE_TABLE[args.model];
+  if (!price) return undefined;
+  const cached = Math.min(args.cachedInputTokens ?? 0, args.inputTokens);
+  const uncached = args.inputTokens - cached;
+  return (
+    (uncached * price.inputPerMTok +
+      cached * price.cachedInputPerMTok +
+      args.outputTokens * price.outputPerMTok) /
+    1_000_000
+  );
+}

--- a/src/lib/ai/streaming.test.ts
+++ b/src/lib/ai/streaming.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessage } from "./types.ts";
 
 import {
   asAPI,
+  createMemoryRedis,
   createMockAPI,
   discordRESTClass,
   installMockProvider,
@@ -28,9 +29,22 @@ vi.mock("resend", () => ({ Resend: resendClass() }));
 vi.mock("@vercel/edge-config", () => ({
   createClient: vi.fn(() => ({ getAll: vi.fn().mockResolvedValue({}) })),
 }));
+vi.mock("@sentry/nextjs", () => ({
+  metrics: { count: vi.fn(), distribution: vi.fn() },
+  captureException: vi.fn(),
+}));
+// The default turn-message index path builds a Redis client from env vars;
+// back it with the in-memory fake so finalize-time persistence never needs
+// real credentials in tests.
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => createMemoryRedis() },
+}));
 
+const Sentry = await import("@sentry/nextjs");
+const { TurnMessageStore } = await import("@/bot/turn-message-store");
 const { AgentContext } = await import("./context.ts");
-const { buildUserMessage, parseModelSlug, streamTurn } = await import("./streaming.ts");
+const { bucketUserId, buildUserMessage, parseModelSlug, streamTurn } =
+  await import("./streaming.ts");
 type OrchestratorFactory = import("./streaming.ts").OrchestratorFactory;
 
 type StreamEvent = Record<string, unknown>;
@@ -610,6 +624,127 @@ describe("streamTurn: stream-event edge cases", () => {
       }),
     });
     expect(result.text).toBe("Final.");
+  });
+});
+
+describe("bucketUserId", () => {
+  it("is deterministic for the same id", () => {
+    expect(bucketUserId("207129618375179508")).toBe(bucketUserId("207129618375179508"));
+  });
+
+  it("always yields a bucket in u00–u15", () => {
+    for (let i = 0; i < 200; i++) {
+      expect(bucketUserId(String(900000000000000000n + BigInt(i) * 7919n))).toMatch(
+        /^u(0\d|1[0-5])$/,
+      );
+    }
+  });
+
+  it("spreads distinct ids across multiple buckets", () => {
+    const buckets = new Set(
+      Array.from({ length: 100 }, (_, i) => bucketUserId(`user-${i * 104_729}`)),
+    );
+    expect(buckets.size).toBeGreaterThan(1);
+  });
+});
+
+describe("streamTurn: cost + metric attributes", () => {
+  it("attributes turn distributions with model + user bucket and records ai.turn.cost_usd", async () => {
+    vi.mocked(Sentry.metrics.distribution).mockClear();
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+
+    await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Done."], {
+        totalUsage: Promise.resolve({
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          totalTokens: 1_100_000,
+          cachedInputTokens: 500_000,
+        }),
+      }),
+    });
+
+    const calls = vi.mocked(Sentry.metrics.distribution).mock.calls;
+    const tokens = calls.find(([name]) => name === "ai.turn.tokens");
+    expect(tokens?.[1]).toBe(1_100_000);
+    const attrs = tokens?.[2]?.attributes as Record<string, string> | undefined;
+    expect(attrs?.model).toBe("anthropic/claude-sonnet-4.6");
+    expect(attrs?.user).toMatch(/^u(0\d|1[0-5])$/);
+
+    const cost = calls.find(([name]) => name === "ai.turn.cost_usd");
+    // Sonnet 4.6: 500k uncached * $3/M + 500k cached * $0.30/M + 100k out * $15/M.
+    expect(cost?.[1]).toBeCloseTo(1.5 + 0.15 + 1.5, 10);
+    expect(cost?.[2]?.attributes).toEqual(attrs);
+
+    const steps = calls.find(([name]) => name === "ai.turn.steps");
+    expect(steps?.[2]?.attributes).toEqual(attrs);
+  });
+});
+
+describe("streamTurn: feedback message index", () => {
+  /** Minimal subagent usage record for seeding the tracker with a domain. */
+  const subagentRecord = (domain: string) => ({
+    domain,
+    model: "anthropic/claude-haiku-4.5",
+    tokens: 10,
+    inputTokens: 5,
+    outputTokens: 5,
+    cachedInputTokens: 0,
+    toolCalls: 1,
+    toolNames: ["search"],
+  });
+
+  it("persists the message → turn join for primary and overflow ids", async () => {
+    const store = new TurnMessageStore(createMemoryRedis());
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+    // 3000 chars of text forces one overflow message at finalize.
+    const base = fakeOrchestrator(["a".repeat(3000)]);
+    const createAgent: OrchestratorFactory = (agentCtx, tracker, meta) => {
+      for (const domain of ["linear", "notion", "linear"]) {
+        tracker.addSubagent(subagentRecord(domain));
+      }
+      return base(agentCtx, tracker, meta);
+    };
+
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent,
+      workflowRunId: "wf-run-1",
+      turnMessageStore: store,
+    });
+
+    const record = await store.get(result.discordMessageId);
+    expect(record).toMatchObject({
+      chatId: "wf-run-1",
+      channelId: "ch-1",
+      userId: "user-1",
+      domains: ["linear", "notion"],
+    });
+
+    // The placeholder is msg-1 and the mock API hands out sequential ids, so
+    // the finalize-time overflow chunk is msg-2; it must resolve to the same turn.
+    expect(await store.get("msg-2")).toEqual(record);
+  });
+
+  it("does not fail the turn when the index write fails", async () => {
+    vi.mocked(Sentry.metrics.count).mockClear();
+    const redis = createMemoryRedis();
+    redis.set = async () => {
+      throw new Error("redis down");
+    };
+    const discord = createMockAPI();
+    const ctx = AgentContext.fromPacket(messagePacket("hello"));
+
+    const result = await streamTurn(asAPI(discord), "ch-1", userMsg("hello"), ctx.toJSON(), {
+      createAgent: fakeOrchestrator(["Done."]),
+      turnMessageStore: new TurnMessageStore(redis),
+    });
+
+    expect(result.text).toBe("Done.");
+    const counted = vi.mocked(Sentry.metrics.count).mock.calls.map(([name]) => name);
+    expect(counted).toContain("ai.feedback.index_error");
+    expect(counted).toContain("ai.turn.completed");
   });
 });
 

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -3,6 +3,9 @@ import type { API } from "@discordjs/core/http-only";
 import { trace } from "@opentelemetry/api";
 import { isTextUIPart, type UIMessage } from "ai";
 
+import type { TurnMessageRecord } from "@/bot/types";
+
+import { TurnMessageStore } from "@/bot/turn-message-store";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution, recordDuration } from "@/lib/metrics";
 import { buildChatAttributes } from "@/lib/otel/chat-attributes";
@@ -14,12 +17,15 @@ import type {
   SerializedAgentContext,
   StreamTurnOptions,
   StreamTurnResult,
+  TurnUsage,
+  UsageLike,
 } from "./types.ts";
 
 import { ORCHESTRATOR_MODEL } from "./constants.ts";
 import { AgentContext } from "./context.ts";
 import { MessageRenderer } from "./message-renderer.ts";
 import { createOrchestrator } from "./orchestrator.ts";
+import { estimateCostUsd } from "./pricing.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
 
 /**
@@ -31,6 +37,42 @@ export function parseModelSlug(slug: string): { provider: string | undefined; mo
   const slash = slug.indexOf("/");
   if (slash <= 0) return { provider: undefined, model: slug };
   return { provider: slug.slice(0, slash), model: slug.slice(slash + 1) };
+}
+
+const USER_BUCKET_COUNT = 16;
+
+/**
+ * Deterministically fold a Discord user id into one of 16 stable buckets
+ * (`"u00"`–`"u15"`) for metric attributes. Raw user ids are forbidden there
+ * (unbounded cardinality); a bucket is enough to spot one user dominating
+ * token spend without identifying them. FNV-1a 32-bit over UTF-16 code units.
+ */
+export function bucketUserId(userId: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `u${(hash % USER_BUCKET_COUNT).toString().padStart(2, "0")}`;
+}
+
+/**
+ * Orchestrator cost at `ORCHESTRATOR_MODEL` rates plus each subagent
+ * delegation at its own model's rates. Undefined when the orchestrator model
+ * is missing from the price table — the caller counts `ai.cost.unknown_model`
+ * instead of emitting a misleadingly partial figure. Unknown subagent models
+ * were already counted at `recordSubagentMetrics` time and contribute 0 here.
+ */
+function computeTurnCostUsd(tracker: TurnUsageTracker): number | undefined {
+  const orchestratorCost = estimateCostUsd({
+    model: ORCHESTRATOR_MODEL,
+    ...tracker.orchestratorUsage,
+  });
+  if (orchestratorCost === undefined) return undefined;
+  return tracker.subagentUsage.reduce(
+    (sum, record) => sum + (estimateCostUsd(record) ?? 0),
+    orchestratorCost,
+  );
 }
 
 export type { OrchestratorAgent, OrchestratorFactory, StreamTurnOptions } from "./types.ts";
@@ -126,6 +168,7 @@ async function runStreamTurn(args: {
     workflowRunId,
     turnIndex,
     placeholderMessageId,
+    turnMessageStore,
   } = options;
   const agentCtx = AgentContext.fromJSON(serializedContext);
   const tracker = new TurnUsageTracker();
@@ -161,46 +204,41 @@ async function runStreamTurn(args: {
 
   const elapsedMs = Date.now() - startTime;
   const traceId = trace.getActiveSpan()?.spanContext().traceId;
-  const { metadataError, finalized } = await finalizeTurn({
+  const { metadataError, finalized, costUsd } = await finalizeTurn({
     result,
     tracker,
     renderer,
     elapsedMs,
     logger,
     traceId,
+    userBucket: bucketUserId(serializedContext.userId),
+  });
+
+  await indexTurnMessages({
+    store: turnMessageStore,
+    messageIds: [finalized.messageId, ...finalized.overflowIds],
+    record: {
+      chatId: workflowRunId,
+      traceId,
+      domains: [...new Set(tracker.subagentUsage.map((s) => s.domain))],
+      channelId,
+      userId: serializedContext.userId,
+    },
   });
 
   countMetric("ai.turn.completed");
   recordDuration("ai.turn.duration", elapsedMs);
 
   const usage = tracker.toTurnUsage();
-
-  // Mirror the per-turn totals onto the active chat.turn span so operators can
-  // query the trace directly without joining against wide events.
-  setActiveSpanAttributes({
-    "ai.input_tokens": usage.inputTokens,
-    "ai.output_tokens": usage.outputTokens,
-    "ai.subagent_tokens": usage.subagentTokens,
-    "ai.total_tokens": usage.totalTokens,
-    "ai.tool_calls": usage.toolCallCount,
-    "ai.steps": usage.stepCount,
-    ...(usage.toolNames.length > 0 ? { "ai.tool_names": usage.toolNames } : {}),
-    "chat.discord_message_id": finalized.messageId,
-  });
-
-  logger.emit({
-    outcome: metadataError ? "partial" : "ok",
-    duration_ms: elapsedMs,
-    text_length: renderer.content.length,
-    tokens: usage.totalTokens,
-    input_tokens: usage.inputTokens,
-    output_tokens: usage.outputTokens,
-    subagent_tokens: usage.subagentTokens,
-    tool_calls: usage.toolCallCount,
-    tool_names: usage.toolNames,
-    steps: usage.stepCount,
-    model: ORCHESTRATOR_MODEL,
-    discord_message_id: finalized.messageId,
+  emitTurnTelemetry({
+    usage,
+    cachedInputTokens: tracker.totalCachedInputTokens,
+    costUsd,
+    metadataError,
+    elapsedMs,
+    textLength: renderer.content.length,
+    logger,
+    messageId: finalized.messageId,
   });
 
   return {
@@ -209,6 +247,62 @@ async function runStreamTurn(args: {
     discordMessageId: finalized.messageId,
     model: ORCHESTRATOR_MODEL,
   };
+}
+
+/**
+ * Mirror the per-turn totals onto the active chat.turn span (so operators can
+ * query the trace directly without joining against wide events) and emit the
+ * turn's terminal wide event.
+ */
+function emitTurnTelemetry(args: {
+  usage: TurnUsage;
+  cachedInputTokens: number;
+  costUsd: number | undefined;
+  metadataError: unknown;
+  elapsedMs: number;
+  textLength: number;
+  logger: ReturnType<typeof createWideLogger>;
+  messageId: string;
+}): void {
+  const {
+    usage,
+    cachedInputTokens,
+    costUsd,
+    metadataError,
+    elapsedMs,
+    textLength,
+    logger,
+    messageId,
+  } = args;
+  setActiveSpanAttributes({
+    "ai.input_tokens": usage.inputTokens,
+    "ai.output_tokens": usage.outputTokens,
+    "ai.cached_input_tokens": cachedInputTokens,
+    "ai.subagent_tokens": usage.subagentTokens,
+    "ai.total_tokens": usage.totalTokens,
+    "ai.tool_calls": usage.toolCallCount,
+    "ai.steps": usage.stepCount,
+    ...(usage.toolNames.length > 0 ? { "ai.tool_names": usage.toolNames } : {}),
+    ...(costUsd !== undefined ? { "ai.cost_usd": costUsd } : {}),
+    "chat.discord_message_id": messageId,
+  });
+
+  logger.emit({
+    outcome: metadataError ? "partial" : "ok",
+    duration_ms: elapsedMs,
+    text_length: textLength,
+    tokens: usage.totalTokens,
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    cached_input_tokens: cachedInputTokens,
+    subagent_tokens: usage.subagentTokens,
+    ...(costUsd !== undefined ? { cost_usd: costUsd } : {}),
+    tool_calls: usage.toolCallCount,
+    tool_names: usage.toolNames,
+    steps: usage.stepCount,
+    model: ORCHESTRATOR_MODEL,
+    discord_message_id: messageId,
+  });
 }
 
 async function renderStream(
@@ -255,6 +349,8 @@ async function renderStream(
 interface FinalizeResult {
   metadataError: unknown;
   finalized: { messageId: string; overflowIds: string[] };
+  /** Estimated USD cost for the whole turn; undefined when usage collection failed. */
+  costUsd: number | undefined;
 }
 
 async function finalizeTurn(args: {
@@ -264,12 +360,13 @@ async function finalizeTurn(args: {
   elapsedMs: number;
   logger: ReturnType<typeof createWideLogger>;
   traceId: string | undefined;
+  userBucket: string;
 }): Promise<FinalizeResult> {
-  const { result, tracker, renderer, elapsedMs, logger, traceId } = args;
+  const { result, tracker, renderer, elapsedMs, logger, traceId, userBucket } = args;
   try {
     const [totalUsage, steps] = await Promise.all([result.totalUsage, result.steps]);
     tracker.recordOrchestrator({
-      usage: totalUsage as { inputTokens?: number; outputTokens?: number; totalTokens?: number },
+      usage: totalUsage as UsageLike,
       steps: steps as readonly { toolCalls: readonly unknown[] }[],
     });
 
@@ -281,10 +378,18 @@ async function finalizeTurn(args: {
       traceId,
     });
 
-    recordDistribution("ai.turn.tokens", tracker.totalTokens);
-    recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls);
-    recordDistribution("ai.turn.steps", tracker.totalSteps);
-    return { metadataError: undefined, finalized };
+    // Full model slug + hashed user bucket — never the raw user id (cardinality).
+    const metricAttrs = { model: ORCHESTRATOR_MODEL, user: userBucket };
+    recordDistribution("ai.turn.tokens", tracker.totalTokens, metricAttrs);
+    recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls, metricAttrs);
+    recordDistribution("ai.turn.steps", tracker.totalSteps, metricAttrs);
+    const costUsd = computeTurnCostUsd(tracker);
+    if (costUsd === undefined) {
+      countMetric("ai.cost.unknown_model", { model: ORCHESTRATOR_MODEL });
+    } else {
+      recordDistribution("ai.turn.cost_usd", costUsd, metricAttrs);
+    }
+    return { metadataError: undefined, finalized, costUsd };
   } catch (err) {
     countMetric("ai.turn.metadata_error");
     logger.warn("metadata collection failed", { reason: String(err) });
@@ -295,6 +400,25 @@ async function finalizeTurn(args: {
       stepCount: 0,
       traceId,
     });
-    return { metadataError: err, finalized };
+    return { metadataError: err, finalized, costUsd: undefined };
+  }
+}
+
+/**
+ * Persist the message-id → turn join consumed by the feedback reaction
+ * handler — the primary reply and every overflow chunk map to the same turn.
+ * Non-fatal by design: the reply has already been delivered, so an index
+ * failure must not fail the turn — count it and continue.
+ */
+async function indexTurnMessages(args: {
+  store: TurnMessageStore | undefined;
+  messageIds: string[];
+  record: TurnMessageRecord;
+}): Promise<void> {
+  try {
+    const store = args.store ?? new TurnMessageStore();
+    await Promise.all(args.messageIds.map((id) => store.set(id, args.record)));
+  } catch {
+    countMetric("ai.feedback.index_error");
   }
 }

--- a/src/lib/ai/streaming.ts
+++ b/src/lib/ai/streaming.ts
@@ -58,21 +58,17 @@ export function bucketUserId(userId: string): string {
 
 /**
  * Orchestrator cost at `ORCHESTRATOR_MODEL` rates plus each subagent
- * delegation at its own model's rates. Undefined when the orchestrator model
- * is missing from the price table — the caller counts `ai.cost.unknown_model`
- * instead of emitting a misleadingly partial figure. Unknown subagent models
- * were already counted at `recordSubagentMetrics` time and contribute 0 here.
+ * delegation at its own model's rates. Models missing from the price table
+ * contribute 0 — they were already counted via `ai.cost.unknown_model` at
+ * `recordSubagentMetrics` time, and pricing.test.ts pins the orchestrator
+ * model into the table so its lookup cannot miss.
  */
-function computeTurnCostUsd(tracker: TurnUsageTracker): number | undefined {
-  const orchestratorCost = estimateCostUsd({
-    model: ORCHESTRATOR_MODEL,
-    ...tracker.orchestratorUsage,
-  });
-  if (orchestratorCost === undefined) return undefined;
-  return tracker.subagentUsage.reduce(
-    (sum, record) => sum + (estimateCostUsd(record) ?? 0),
-    orchestratorCost,
-  );
+function computeTurnCostUsd(tracker: TurnUsageTracker): number {
+  const records = [
+    { model: ORCHESTRATOR_MODEL, ...tracker.orchestratorUsage },
+    ...tracker.subagentUsage,
+  ];
+  return records.reduce((sum, record) => sum + (estimateCostUsd(record) ?? 0), 0);
 }
 
 export type { OrchestratorAgent, OrchestratorFactory, StreamTurnOptions } from "./types.ts";
@@ -384,11 +380,7 @@ async function finalizeTurn(args: {
     recordDistribution("ai.turn.tool_calls", tracker.totalToolCalls, metricAttrs);
     recordDistribution("ai.turn.steps", tracker.totalSteps, metricAttrs);
     const costUsd = computeTurnCostUsd(tracker);
-    if (costUsd === undefined) {
-      countMetric("ai.cost.unknown_model", { model: ORCHESTRATOR_MODEL });
-    } else {
-      recordDistribution("ai.turn.cost_usd", costUsd, metricAttrs);
-    }
+    recordDistribution("ai.turn.cost_usd", costUsd, metricAttrs);
     return { metadataError: undefined, finalized, costUsd };
   } catch (err) {
     countMetric("ai.turn.metadata_error");

--- a/src/lib/ai/subagent.test.ts
+++ b/src/lib/ai/subagent.test.ts
@@ -2,7 +2,16 @@ import type { UIMessage } from "ai";
 import type { ModelMessage, StepResult, ToolSet } from "ai";
 import type { MockLanguageModelV3 } from "ai/test";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Third-party SDK mock at the package boundary so recordSubagentMetrics's
+// Sentry metric calls (via lib/metrics + lib/logging/wide) are observable.
+vi.mock("@sentry/nextjs", () => ({
+  metrics: { count: vi.fn(), distribution: vi.fn() },
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
 
 import { UserRole } from "@/lib/ai/constants";
 import {
@@ -359,9 +368,11 @@ describe("createDelegationTool — toModelOutput()", () => {
 });
 
 describe("recordSubagentMetrics", () => {
+  const model = "openai/gpt-5.4-mini";
+
   it("records the model's totalTokens when present", () => {
     const tracker = new TurnUsageTracker();
-    recordSubagentMetrics(tracker, { name: "test" }, { totalTokens: 42 }, [
+    recordSubagentMetrics(tracker, { name: "test" }, model, { totalTokens: 42 }, [
       { toolCalls: [{}, {}] },
       { toolCalls: [{}] },
     ]);
@@ -369,20 +380,137 @@ describe("recordSubagentMetrics", () => {
     expect(tracker.totalToolCalls).toBe(3);
   });
 
-  it("falls back to 0 when totalTokens is undefined", () => {
+  it("falls back to 0 when usage fields are undefined", () => {
     const tracker = new TurnUsageTracker();
-    recordSubagentMetrics(tracker, { name: "test" }, {}, []);
+    recordSubagentMetrics(tracker, { name: "test" }, model, {}, []);
     expect(tracker.totalTokens).toBe(0);
     expect(tracker.totalToolCalls).toBe(0);
+    expect(tracker.subagentUsage).toEqual([
+      {
+        domain: "test",
+        model,
+        tokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedInputTokens: 0,
+        toolCalls: 0,
+        toolNames: [],
+      },
+    ]);
   });
 
   it("collects tool names and skips entries without a string toolName", () => {
     const tracker = new TurnUsageTracker();
-    recordSubagentMetrics(tracker, { name: "test" }, { totalTokens: 10 }, [
+    recordSubagentMetrics(tracker, { name: "test" }, model, { totalTokens: 10 }, [
       { toolCalls: [{ toolName: "search_entities" }, {}] },
       { toolCalls: [{ toolName: "retrieve_entities" }] },
     ]);
     expect(tracker.toTurnUsage().toolNames).toEqual(["search_entities", "retrieve_entities"]);
+  });
+
+  it("pushes the model + token splits into the tracker's subagent record", () => {
+    const tracker = new TurnUsageTracker();
+    recordSubagentMetrics(
+      tracker,
+      { name: "code" },
+      "anthropic/claude-opus-4.7",
+      { totalTokens: 100, inputTokens: 70, outputTokens: 30, cachedInputTokens: 40 },
+      [{ toolCalls: [{ toolName: "run_command" }] }],
+    );
+    expect(tracker.subagentUsage).toEqual([
+      {
+        domain: "code",
+        model: "anthropic/claude-opus-4.7",
+        tokens: 100,
+        inputTokens: 70,
+        outputTokens: 30,
+        cachedInputTokens: 40,
+        toolCalls: 1,
+        toolNames: ["run_command"],
+      },
+    ]);
+    expect(tracker.totalCachedInputTokens).toBe(40);
+  });
+
+  it("prefers inputTokenDetails.cacheReadTokens over the deprecated alias", () => {
+    const tracker = new TurnUsageTracker();
+    recordSubagentMetrics(
+      tracker,
+      { name: "test" },
+      model,
+      { inputTokens: 100, cachedInputTokens: 1, inputTokenDetails: { cacheReadTokens: 80 } },
+      [],
+    );
+    expect(tracker.subagentUsage[0]?.cachedInputTokens).toBe(80);
+  });
+});
+
+describe("recordSubagentMetrics — Sentry metrics", () => {
+  const model = "openai/gpt-5.4-mini";
+
+  beforeEach(() => {
+    vi.mocked(Sentry.metrics.count).mockClear();
+    vi.mocked(Sentry.metrics.distribution).mockClear();
+  });
+
+  it("tags every subagent distribution with {domain, model}", () => {
+    recordSubagentMetrics(
+      new TurnUsageTracker(),
+      { name: "test" },
+      model,
+      { totalTokens: 5, inputTokens: 3, outputTokens: 2 },
+      [],
+    );
+    const calls = vi.mocked(Sentry.metrics.distribution).mock.calls;
+    expect(calls.map(([name]) => name)).toEqual(
+      expect.arrayContaining([
+        "ai.subagent.tokens",
+        "ai.subagent.input_tokens",
+        "ai.subagent.output_tokens",
+        "ai.subagent.cached_input_tokens",
+        "ai.subagent.tool_calls",
+        "ai.subagent.cost_usd",
+      ]),
+    );
+    for (const [, , options] of calls) {
+      expect(options?.attributes).toEqual({ domain: "test", model });
+    }
+  });
+
+  it("records ai.subagent.cost_usd for a known model", () => {
+    recordSubagentMetrics(
+      new TurnUsageTracker(),
+      { name: "test" },
+      model,
+      { totalTokens: 2_000_000, inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      [],
+    );
+    const cost = vi
+      .mocked(Sentry.metrics.distribution)
+      .mock.calls.find(([name]) => name === "ai.subagent.cost_usd");
+    // gpt-5.4-mini: $0.25/M input + $2/M output.
+    expect(cost?.[1]).toBeCloseTo(2.25, 10);
+    const unknown = vi
+      .mocked(Sentry.metrics.count)
+      .mock.calls.filter(([name]) => name === "ai.cost.unknown_model");
+    expect(unknown).toHaveLength(0);
+  });
+
+  it("counts ai.cost.unknown_model and skips the cost distribution for unknown models", () => {
+    recordSubagentMetrics(
+      new TurnUsageTracker(),
+      { name: "test" },
+      "acme/unpriced-1",
+      { totalTokens: 10 },
+      [],
+    );
+    const cost = vi
+      .mocked(Sentry.metrics.distribution)
+      .mock.calls.filter(([name]) => name === "ai.subagent.cost_usd");
+    expect(cost).toHaveLength(0);
+    expect(Sentry.metrics.count).toHaveBeenCalledWith("ai.cost.unknown_model", 1, {
+      attributes: { model: "acme/unpriced-1", domain: "test" },
+    });
   });
 });
 

--- a/src/lib/ai/subagent.ts
+++ b/src/lib/ai/subagent.ts
@@ -15,18 +15,19 @@ import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution } from "@/lib/metrics";
 
 import type { AgentContext } from "./context.ts";
-import type { SubagentSpec, TelemetryMetadata } from "./types.ts";
+import type { SubagentSpec, TelemetryMetadata, UsageLike } from "./types.ts";
 
 import { wrapApprovalTools } from "./approvals/index.ts";
 import { addCacheControl } from "./cache-control.ts";
 import { SUBAGENT_MODEL, SUBAGENT_PREAMBLE, UserRole } from "./constants.ts";
+import { estimateCostUsd } from "./pricing.ts";
 import {
   SkillRegistry,
   createLoadSkillTool,
   computeActiveTools,
   filterAdmin,
 } from "./skills/index.ts";
-import { TurnUsageTracker } from "./turn-usage.ts";
+import { TurnUsageTracker, extractCachedInputTokens } from "./turn-usage.ts";
 
 export type { SubagentSpec } from "./types.ts";
 
@@ -52,30 +53,61 @@ type SubagentSteps = { toolCalls: { toolName?: string }[] }[];
  */
 /**
  * Push subagent usage into the TurnUsageTracker and emit Sentry metrics.
- * Exported so we can unit-test the `?? 0` fallback for missing totalTokens
- * without driving a full mocked ToolLoopAgent.
+ * Takes the resolved model slug + the full AI SDK usage object so the
+ * distributions carry `{domain, model}` attributes and input/output/cached
+ * splits — `cachedInputTokens` here is the verification metric for prompt
+ * caching, and the splits feed per-model cost attribution at turn end.
+ * Exported so we can unit-test the `?? 0` fallbacks without driving a full
+ * mocked ToolLoopAgent.
  */
 export function recordSubagentMetrics(
   tracker: TurnUsageTracker,
   spec: Pick<SubagentSpec, "name">,
-  usage: { totalTokens?: number },
+  model: string,
+  usage: UsageLike,
   steps: SubagentSteps,
 ): void {
   const tokens = usage.totalTokens ?? 0;
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const cachedInputTokens = extractCachedInputTokens(usage);
   const toolCalls = steps.reduce((sum, s) => sum + s.toolCalls.length, 0);
   const toolNames = steps.flatMap((s) =>
     s.toolCalls.flatMap((call) => (typeof call.toolName === "string" ? [call.toolName] : [])),
   );
-  tracker.addSubagent({ tokens, toolCalls, toolNames });
-  countMetric("ai.subagent.completed", { domain: spec.name });
-  recordDistribution("ai.subagent.tokens", tokens, { domain: spec.name });
-  recordDistribution("ai.subagent.tool_calls", toolCalls, { domain: spec.name });
+  tracker.addSubagent({
+    domain: spec.name,
+    model,
+    tokens,
+    inputTokens,
+    outputTokens,
+    cachedInputTokens,
+    toolCalls,
+    toolNames,
+  });
+  const attrs = { domain: spec.name, model };
+  countMetric("ai.subagent.completed", attrs);
+  recordDistribution("ai.subagent.tokens", tokens, attrs);
+  recordDistribution("ai.subagent.input_tokens", inputTokens, attrs);
+  recordDistribution("ai.subagent.output_tokens", outputTokens, attrs);
+  recordDistribution("ai.subagent.cached_input_tokens", cachedInputTokens, attrs);
+  recordDistribution("ai.subagent.tool_calls", toolCalls, attrs);
+  const costUsd = estimateCostUsd({ model, inputTokens, outputTokens, cachedInputTokens });
+  if (costUsd === undefined) {
+    countMetric("ai.cost.unknown_model", { model, domain: spec.name });
+  } else {
+    recordDistribution("ai.subagent.cost_usd", costUsd, attrs);
+  }
   createWideLogger({
     op: "ai.subagent",
-    subagent: { domain: spec.name },
+    subagent: { domain: spec.name, model },
   }).emit({
     outcome: "ok",
     tokens,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cached_input_tokens: cachedInputTokens,
+    ...(costUsd !== undefined ? { cost_usd: costUsd } : {}),
     tool_calls: toolCalls,
     tool_names: toolNames,
     steps: steps.length,
@@ -179,7 +211,7 @@ export function createDelegationTool(
       }
 
       const [usage, steps] = await Promise.all([result.totalUsage, result.steps]);
-      recordSubagentMetrics(tracker, spec, usage, steps as SubagentSteps);
+      recordSubagentMetrics(tracker, spec, resolvedModel, usage, steps as SubagentSteps);
 
       if (spec.postFinish) {
         for await (const message of spec.postFinish({

--- a/src/lib/ai/tools/schedule/index.test.ts
+++ b/src/lib/ai/tools/schedule/index.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { propagation, type TextMapPropagator } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ScheduledTaskRow } from "@/lib/tasks/types";
 
@@ -175,6 +176,53 @@ describe("schedule_task: successful scheduling", () => {
       ),
     ).rejects.toThrow("queue down");
     expect(hoisted.saveScheduledTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("schedule_task: trace propagation", () => {
+  const TEST_TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+  // Real `captureTraceparent()` runs; only the third-party propagation API is
+  // swapped at the package boundary so it has something to capture.
+  const injectingPropagator: TextMapPropagator = {
+    inject: (_unused, carrier, setter) => setter.set(carrier, "traceparent", TEST_TRACEPARENT),
+    extract: (incoming) => incoming,
+    fields: () => ["traceparent"],
+  };
+
+  afterEach(() => {
+    propagation.disable();
+  });
+
+  async function scheduleOnce(): Promise<void> {
+    const schedule_task = createScheduleTask(contextWithRoles());
+    const result = await schedule_task.execute!(
+      {
+        description: "Traced task",
+        action_type: "message",
+        channel_id: "ch-1",
+        content: "hi",
+        schedule_type: ScheduleType.Once,
+        run_at: futureISO(),
+        user_id: "user-1",
+      },
+      toolOpts,
+    );
+    expect(result).toContain("Scheduled");
+  }
+
+  it("passes the captured traceparent to sendScheduledFire at creation", async () => {
+    propagation.setGlobalPropagator(injectingPropagator);
+    await scheduleOnce();
+
+    expect(hoisted.sendScheduledFire).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendScheduledFire.mock.calls[0][3]).toBe(TEST_TRACEPARENT);
+  });
+
+  it("passes undefined when there is no active trace to capture", async () => {
+    await scheduleOnce();
+
+    expect(hoisted.sendScheduledFire).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendScheduledFire.mock.calls[0][3]).toBeUndefined();
   });
 });
 

--- a/src/lib/ai/tools/schedule/index.ts
+++ b/src/lib/ai/tools/schedule/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { TaskAction } from "@/lib/tasks/types";
 
+import { captureTraceparent } from "@/lib/otel/tracing";
 import { DEFAULT_TIMEZONE } from "@/lib/tasks/constants";
 import { listScheduledTasks, saveScheduledTask, updateScheduledTask } from "@/lib/tasks/db";
 import { ScheduledTaskStatus, ScheduleType } from "@/lib/tasks/enums";
@@ -142,7 +143,9 @@ export function createScheduleTask(context: AgentContext) {
         // Send first: a failed send surfaces to the user immediately and
         // leaves no orphan DB row. If the save fails after a successful send,
         // the fire handler looks up a missing row and no-ops — no side effect.
-        const { messageId } = await sendScheduledFire(id, target, delaySec);
+        // Creation is the ONLY site that propagates the trace; internal
+        // re-enqueues deliberately drop it (see ScheduledTaskFirePayload).
+        const { messageId } = await sendScheduledFire(id, target, delaySec, captureTraceparent());
         await saveScheduledTask({
           id,
           userId: user_id,

--- a/src/lib/ai/turn-usage.test.ts
+++ b/src/lib/ai/turn-usage.test.ts
@@ -1,6 +1,28 @@
 import { describe, it, expect } from "vitest";
 
-import { TurnUsageTracker, addTurnUsage, emptyTurnUsage } from "./turn-usage.ts";
+import type { SubagentUsage } from "./types.ts";
+
+import {
+  TurnUsageTracker,
+  addTurnUsage,
+  emptyTurnUsage,
+  extractCachedInputTokens,
+} from "./turn-usage.ts";
+
+/** Test-local fixture for the per-delegation usage record. */
+function subagentRecord(overrides: Partial<SubagentUsage> = {}): SubagentUsage {
+  return {
+    domain: "linear",
+    model: "openai/gpt-5.4-mini",
+    tokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    toolCalls: 0,
+    toolNames: [],
+    ...overrides,
+  };
+}
 
 describe("TurnUsageTracker", () => {
   it("starts empty", () => {
@@ -14,12 +36,14 @@ describe("TurnUsageTracker", () => {
       stepCount: 0,
       toolNames: [],
     });
+    expect(t.subagentUsage).toEqual([]);
+    expect(t.totalCachedInputTokens).toBe(0);
   });
 
   it("accumulates subagent contributions across calls", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 100, toolCalls: 2, toolNames: ["search", "open"] });
-    t.addSubagent({ tokens: 250, toolCalls: 3, toolNames: ["get_issue"] });
+    t.addSubagent(subagentRecord({ tokens: 100, toolCalls: 2, toolNames: ["search", "open"] }));
+    t.addSubagent(subagentRecord({ tokens: 250, toolCalls: 3, toolNames: ["get_issue"] }));
     expect(t.toTurnUsage()).toMatchObject({
       subagentTokens: 350,
       toolCallCount: 5,
@@ -29,7 +53,7 @@ describe("TurnUsageTracker", () => {
 
   it("merges orchestrator usage with subagent totals", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 200, toolCalls: 4, toolNames: ["list_issues"] });
+    t.addSubagent(subagentRecord({ tokens: 200, toolCalls: 4, toolNames: ["list_issues"] }));
     t.recordOrchestrator({
       usage: { inputTokens: 800, outputTokens: 150, totalTokens: 950 },
       steps: [
@@ -51,7 +75,7 @@ describe("TurnUsageTracker", () => {
 
   it("exposes convenience accessors after recordOrchestrator", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 50, toolCalls: 1, toolNames: ["a"] });
+    t.addSubagent(subagentRecord({ tokens: 50, toolCalls: 1, toolNames: ["a"] }));
     t.recordOrchestrator({
       usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
       steps: [
@@ -68,7 +92,7 @@ describe("TurnUsageTracker", () => {
 
   it("coerces undefined orchestrator tokens to zero", () => {
     const t = new TurnUsageTracker();
-    t.addSubagent({ tokens: 50, toolCalls: 1, toolNames: [] });
+    t.addSubagent(subagentRecord({ tokens: 50, toolCalls: 1 }));
     t.recordOrchestrator({
       usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
       steps: [],
@@ -80,6 +104,7 @@ describe("TurnUsageTracker", () => {
     expect(usage.toolCallCount).toBe(1);
     expect(usage.stepCount).toBe(0);
     expect(usage.toolNames).toEqual([]);
+    expect(t.totalCachedInputTokens).toBe(0);
   });
 
   it("skips tool calls that lack a string toolName", () => {
@@ -89,6 +114,79 @@ describe("TurnUsageTracker", () => {
       steps: [{ toolCalls: [{ toolName: "kept" }, {}, { toolName: 123 }] }],
     });
     expect(t.toTurnUsage().toolNames).toEqual(["kept"]);
+  });
+});
+
+describe("TurnUsageTracker — cost-attribution splits", () => {
+  it("keeps per-subagent records (model + splits) for cost attribution", () => {
+    const t = new TurnUsageTracker();
+    const linear = subagentRecord({
+      tokens: 300,
+      inputTokens: 250,
+      outputTokens: 50,
+      cachedInputTokens: 100,
+    });
+    const code = subagentRecord({
+      domain: "code",
+      model: "anthropic/claude-opus-4.7",
+      tokens: 900,
+      inputTokens: 700,
+      outputTokens: 200,
+      cachedInputTokens: 400,
+    });
+    t.addSubagent(linear);
+    t.addSubagent(code);
+    expect(t.subagentUsage).toEqual([linear, code]);
+  });
+
+  it("exposes orchestrator usage splits including cache reads", () => {
+    const t = new TurnUsageTracker();
+    t.recordOrchestrator({
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        totalTokens: 1200,
+        inputTokenDetails: { cacheReadTokens: 600 },
+      },
+      steps: [],
+    });
+    expect(t.orchestratorUsage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 200,
+      totalTokens: 1200,
+      cachedInputTokens: 600,
+    });
+  });
+
+  it("sums cached input tokens across orchestrator and subagents", () => {
+    const t = new TurnUsageTracker();
+    t.addSubagent(subagentRecord({ cachedInputTokens: 150 }));
+    t.addSubagent(subagentRecord({ cachedInputTokens: 50 }));
+    t.recordOrchestrator({
+      usage: { inputTokens: 500, outputTokens: 100, totalTokens: 600, cachedInputTokens: 300 },
+      steps: [],
+    });
+    expect(t.totalCachedInputTokens).toBe(500);
+  });
+});
+
+describe("extractCachedInputTokens", () => {
+  it("prefers inputTokenDetails.cacheReadTokens over the deprecated alias", () => {
+    expect(
+      extractCachedInputTokens({
+        cachedInputTokens: 1,
+        inputTokenDetails: { cacheReadTokens: 80 },
+      }),
+    ).toBe(80);
+  });
+
+  it("falls back to the deprecated top-level alias", () => {
+    expect(extractCachedInputTokens({ cachedInputTokens: 25 })).toBe(25);
+    expect(extractCachedInputTokens({ cachedInputTokens: 25, inputTokenDetails: {} })).toBe(25);
+  });
+
+  it("coerces missing values to zero", () => {
+    expect(extractCachedInputTokens({})).toBe(0);
   });
 });
 

--- a/src/lib/ai/turn-usage.ts
+++ b/src/lib/ai/turn-usage.ts
@@ -1,4 +1,4 @@
-import type { TurnUsage } from "./types.ts";
+import type { SubagentUsage, TurnUsage, UsageLike } from "./types.ts";
 
 /**
  * Shape of an AI SDK tool call entry on a step's `toolCalls`. Every call
@@ -10,29 +10,37 @@ interface ToolCallLike {
 }
 
 /**
+ * Cache-read token count from an AI SDK usage object. Prefers the
+ * non-deprecated `inputTokenDetails.cacheReadTokens`, falls back to the
+ * deprecated top-level alias, and coerces missing values to 0.
+ */
+export function extractCachedInputTokens(usage: UsageLike): number {
+  return usage.inputTokenDetails?.cacheReadTokens ?? usage.cachedInputTokens ?? 0;
+}
+
+/**
  * Mutable accumulator for one orchestrator turn's worth of usage.
  *
- * Subagents call `addSubagent` to fold in their per-delegation totals as they
- * complete; the streaming layer calls `recordOrchestrator` once with the
- * orchestrator's terminal usage + step trace. `toTurnUsage` produces the
- * persisted `TurnUsage` shape (subagent totals + orchestrator totals merged).
+ * Subagents call `addSubagent` to fold in their per-delegation usage records
+ * as they complete; the streaming layer calls `recordOrchestrator` once with
+ * the orchestrator's terminal usage + step trace. `toTurnUsage` produces the
+ * persisted `TurnUsage` shape (subagent totals + orchestrator totals merged),
+ * while `subagentUsage`/`orchestratorUsage` expose the per-model splits the
+ * cost-attribution metrics are computed from at turn end.
  */
 export class TurnUsageTracker {
-  private subagentTokens = 0;
-  private subagentToolCalls = 0;
+  private subagents: SubagentUsage[] = [];
   private orchestratorInputTokens = 0;
   private orchestratorOutputTokens = 0;
   private orchestratorTotalTokens = 0;
+  private orchestratorCachedInputTokens = 0;
   private orchestratorToolCalls = 0;
   private stepCount = 0;
   private orchestratorToolNames: string[] = [];
-  private subagentToolNames: string[] = [];
 
-  /** Add a subagent delegation's contribution. */
-  addSubagent(delta: { tokens: number; toolCalls: number; toolNames: readonly string[] }): void {
-    this.subagentTokens += delta.tokens;
-    this.subagentToolCalls += delta.toolCalls;
-    this.subagentToolNames.push(...delta.toolNames);
+  /** Add a subagent delegation's usage record. */
+  addSubagent(record: SubagentUsage): void {
+    this.subagents.push(record);
   }
 
   /**
@@ -41,12 +49,13 @@ export class TurnUsageTracker {
    * internal TurnUsage contract stays numeric.
    */
   recordOrchestrator(args: {
-    usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+    usage: UsageLike;
     steps: ReadonlyArray<{ toolCalls: ReadonlyArray<unknown> }>;
   }): void {
     this.orchestratorInputTokens = args.usage.inputTokens ?? 0;
     this.orchestratorOutputTokens = args.usage.outputTokens ?? 0;
     this.orchestratorTotalTokens = args.usage.totalTokens ?? 0;
+    this.orchestratorCachedInputTokens = extractCachedInputTokens(args.usage);
     this.orchestratorToolCalls = args.steps.reduce((sum, step) => sum + step.toolCalls.length, 0);
     this.stepCount = args.steps.length;
     this.orchestratorToolNames = args.steps.flatMap((step) =>
@@ -57,9 +66,41 @@ export class TurnUsageTracker {
     );
   }
 
+  private get subagentTokens(): number {
+    return this.subagents.reduce((sum, s) => sum + s.tokens, 0);
+  }
+
+  /** Per-delegation usage records (model + token splits), in completion order. */
+  get subagentUsage(): readonly SubagentUsage[] {
+    return this.subagents;
+  }
+
+  /** Orchestrator terminal usage splits, for pricing at the orchestrator model's rates. */
+  get orchestratorUsage(): {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    cachedInputTokens: number;
+  } {
+    return {
+      inputTokens: this.orchestratorInputTokens,
+      outputTokens: this.orchestratorOutputTokens,
+      totalTokens: this.orchestratorTotalTokens,
+      cachedInputTokens: this.orchestratorCachedInputTokens,
+    };
+  }
+
+  /** Cache reads across orchestrator + subagents — the verification metric for prompt caching. */
+  get totalCachedInputTokens(): number {
+    return (
+      this.orchestratorCachedInputTokens +
+      this.subagents.reduce((sum, s) => sum + s.cachedInputTokens, 0)
+    );
+  }
+
   /** Convenience accessor for the post-stream tool-call total (orchestrator + subagent). */
   get totalToolCalls(): number {
-    return this.orchestratorToolCalls + this.subagentToolCalls;
+    return this.orchestratorToolCalls + this.subagents.reduce((sum, s) => sum + s.toolCalls, 0);
   }
 
   /** Convenience accessor for the post-stream step count. */
@@ -74,7 +115,7 @@ export class TurnUsageTracker {
 
   /** Combined orchestrator + subagent tool names in call order. */
   get totalToolNames(): string[] {
-    return [...this.orchestratorToolNames, ...this.subagentToolNames];
+    return [...this.orchestratorToolNames, ...this.subagents.flatMap((s) => s.toolNames)];
   }
 
   /** Snapshot in the shape persisted to the context-snapshot store. */

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,6 +1,8 @@
 import type { ToolSet, UIMessage } from "ai";
 import type { z } from "zod";
 
+import type { TurnMessageStore } from "@/bot/turn-message-store";
+
 import type { AgentContext } from "./context.ts";
 import type { SkillBundle } from "./skills/types.ts";
 import type { TurnUsageTracker } from "./turn-usage.ts";
@@ -112,6 +114,41 @@ export interface TurnUsage {
    * so operators can see *what* ran, not just *how many*.
    */
   toolNames: string[];
+}
+
+/**
+ * Structural subset of the AI SDK v5 `LanguageModelUsage` we consume for
+ * accounting. `cachedInputTokens` is the SDK's deprecated alias for
+ * `inputTokenDetails.cacheReadTokens`; both are accepted so callers can hand
+ * over the usage object as-is.
+ */
+export interface UsageLike {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedInputTokens?: number;
+  inputTokenDetails?: { cacheReadTokens?: number };
+}
+
+/**
+ * One subagent delegation's usage record, accumulated in `TurnUsageTracker`.
+ * Carries the resolved model slug plus input/output/cached token splits so
+ * per-model cost can be computed at turn end (each delegation priced at its
+ * own model's rates — Opus and gpt-mini differ by orders of magnitude).
+ */
+export interface SubagentUsage {
+  /** Subagent domain name (the spec's telemetry identifier). */
+  domain: string;
+  /** Resolved gateway model slug the delegation actually ran on. */
+  model: string;
+  /** Total tokens (input + output), the AI SDK's `totalTokens`. */
+  tokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  /** Cache-read input tokens — subset of `inputTokens`, priced at the cache-read rate. */
+  cachedInputTokens: number;
+  toolCalls: number;
+  toolNames: readonly string[];
 }
 
 export interface ModelInfo {
@@ -231,10 +268,11 @@ export interface OrchestratorAgent {
 /**
  * Telemetry metadata passed through to every AI SDK `experimental_telemetry.metadata`
  * call in an orchestrator + its subagents. Flat key/value pairs; the AI SDK
- * flattens these into `ai.telemetry.metadata.<key>` span attributes so Axiom
- * can query by `chat.id` across the whole conversation. Undefined values are
- * tolerated so callers can build metadata from optional fields without first
- * filtering them out.
+ * flattens these into `ai.telemetry.metadata.<key>` span attributes, which
+ * land in Sentry (AI Agents Insights / trace explorer) where a whole
+ * conversation can be queried by `chat.id`. Undefined values are tolerated so
+ * callers can build metadata from optional fields without first filtering
+ * them out.
  */
 export type TelemetryMetadata = Record<string, string | number | undefined>;
 
@@ -284,7 +322,7 @@ export interface StreamTurnOptions {
   /**
    * Workflow run id for the containing chat workflow. Used to populate
    * `chat.*` attributes on the turn span + every AI SDK span so a whole
-   * conversation is one Axiom query (`chat.id == <workflowRunId>`).
+   * conversation is one Sentry trace-explorer query (`chat.id == <workflowRunId>`).
    */
   workflowRunId?: string;
   /** Turn number within the conversation (1 = first turn). */
@@ -296,4 +334,11 @@ export interface StreamTurnOptions {
    * enqueuing the workflow so it's visible ahead of workflow cold-start.
    */
   placeholderMessageId?: string;
+  /**
+   * Dependency-injected message → turn index written at finalize time so the
+   * feedback reaction handler can resolve reactions on bot replies back to
+   * the turn that produced them. Defaults to the Redis-backed store; tests
+   * inject one built on an in-memory redis fake.
+   */
+  turnMessageStore?: TurnMessageStore;
 }

--- a/src/lib/logging/wide.test.ts
+++ b/src/lib/logging/wide.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { baseEmit, traceId } = vi.hoisted(() => ({
+const { baseEmit, baseError, traceId } = vi.hoisted(() => ({
   baseEmit: vi.fn((overrides: Record<string, unknown>) => ({ emitted: overrides })),
+  baseError: vi.fn(),
   traceId: { current: undefined as string | undefined },
 }));
 
@@ -10,7 +11,7 @@ vi.mock("evlog", () => ({
     set: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
-    error: vi.fn(),
+    error: baseError,
     emit: baseEmit,
     getContext: () => context,
   })),
@@ -22,6 +23,12 @@ vi.mock("@opentelemetry/api", () => ({
       traceId.current ? { spanContext: () => ({ traceId: traceId.current }) } : undefined,
   },
 }));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
 
 import { createWideLogger } from "./wide";
 
@@ -48,5 +55,36 @@ describe("createWideLogger", () => {
     const logger = createWideLogger({ op: "test.op" });
     logger.emit();
     expect(baseEmit).toHaveBeenCalledWith({});
+  });
+
+  it("forwards .error() to Sentry.captureException exactly once and delegates to evlog", () => {
+    baseError.mockClear();
+    vi.mocked(Sentry.captureException).mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    const boom = new Error("bang");
+    logger.error(boom, { step: "publish" });
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(boom);
+    expect(baseError).toHaveBeenCalledTimes(1);
+    expect(baseError).toHaveBeenCalledWith(boom, { step: "publish" });
+  });
+
+  it("forwards string errors to Sentry.captureException as well", () => {
+    baseError.mockClear();
+    vi.mocked(Sentry.captureException).mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    logger.error("publish failed");
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith("publish failed");
+    expect(baseError).toHaveBeenCalledWith("publish failed", undefined);
+  });
+
+  it("does not capture to Sentry on emit", () => {
+    traceId.current = "abc123";
+    baseEmit.mockClear();
+    vi.mocked(Sentry.captureException).mockClear();
+    const logger = createWideLogger({ op: "test.op" });
+    logger.emit({ outcome: "error" });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/logging/wide.ts
+++ b/src/lib/logging/wide.ts
@@ -1,4 +1,5 @@
 import { trace } from "@opentelemetry/api";
+import * as Sentry from "@sentry/nextjs";
 import { createLogger, type RequestLogger } from "evlog";
 
 type WideContext = Record<string, unknown>;
@@ -7,7 +8,15 @@ type WideContext = Record<string, unknown>;
  * Create a scoped wide-event logger for one unit of work. Wraps `evlog`'s
  * `createLogger` so:
  *   - The emitted event automatically includes the current OTEL trace id
- *     (`trace.id`), which Sentry uses to join a log line to a trace.
+ *     (`trace.id`). evlog writes the event as JSON to stdout, where
+ *     `Sentry.consoleLoggingIntegration` (sentry.server.config.ts) captures
+ *     it into Sentry Logs; the injected trace.id joins the log line to its
+ *     trace there.
+ *   - `.error()` forwards the error to `Sentry.captureException` before
+ *     delegating to evlog, so every call site gets a Sentry issue while the
+ *     wide event still accumulates the parsed error fields. This is the one
+ *     error-reporting path for the codebase — do not add bare
+ *     `captureException` calls next to `logger.error`, that double-reports.
  *   - Base context (op, chat, user, workflow ids, …) is set once up front and
  *     flows through `.set()`, `.info()`, `.warn()`, `.error()`, and `.emit()`.
  *
@@ -41,6 +50,11 @@ export function createWideLogger(context: WideContext = {}): RequestLogger {
       ...(traceId ? { trace: { id: traceId } } : {}),
       ...overrides,
     });
+  };
+  const originalError = logger.error.bind(logger);
+  logger.error = (error, errorContext) => {
+    Sentry.captureException(error);
+    originalError(error, errorContext);
   };
   return logger;
 }

--- a/src/lib/otel/tracing.test.ts
+++ b/src/lib/otel/tracing.test.ts
@@ -1,35 +1,81 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { startActiveSpan, span, injectMock, extractMock, contextWithMock, activeContext } =
-  vi.hoisted(() => {
-    const span = {
-      end: vi.fn(),
-      setAttributes: vi.fn(),
-      setAttribute: vi.fn(),
-      setStatus: vi.fn(),
-      recordException: vi.fn(),
-    };
-    const activeContext = { __active: true };
-    return {
-      span,
-      activeContext,
-      startActiveSpan: vi.fn((_name: string, _opts: unknown, fn: (s: typeof span) => unknown) =>
-        fn(span),
-      ),
-      injectMock: vi.fn(),
-      extractMock: vi.fn(),
-      contextWithMock: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
-    };
-  });
+const {
+  startActiveSpan,
+  span,
+  injectMock,
+  extractMock,
+  contextWithMock,
+  deleteSpanMock,
+  activeContext,
+  ctxState,
+} = vi.hoisted(() => {
+  // Spy methods are shared across every span the fake tracer creates, so
+  // assertions against the singleton `span` cover spans made inside withSpan.
+  const spanMethods = {
+    end: vi.fn(),
+    setAttributes: vi.fn(),
+    setAttribute: vi.fn(),
+    setStatus: vi.fn(),
+    recordException: vi.fn(),
+  };
+  type FakeSpan = typeof spanMethods & {
+    spanContext: () => { traceId: string; spanId: string };
+  };
+  type FakeCtx = { span?: FakeSpan; [key: string]: unknown };
+  let spanSeq = 0;
+  let traceSeq = 0;
+  const makeSpan = (traceId: string): FakeSpan => {
+    const spanId = `span-${++spanSeq}`;
+    return { ...spanMethods, spanContext: () => ({ traceId, spanId }) };
+  };
+  const span = makeSpan("trace-singleton");
+  const activeContext: FakeCtx = { __active: true };
+  const ctxState = { current: activeContext };
+  // Mirrors real OTEL semantics: a new span joins the active span's trace, or
+  // starts a fresh trace when the active context carries no span.
+  const startActiveSpan = vi.fn(
+    (_name: string, _opts: unknown, fn: (s: FakeSpan) => unknown): unknown => {
+      const parent = ctxState.current.span;
+      const newSpan = makeSpan(parent ? parent.spanContext().traceId : `trace-${++traceSeq}`);
+      const prev = ctxState.current;
+      ctxState.current = { ...ctxState.current, span: newSpan };
+      try {
+        return fn(newSpan);
+      } finally {
+        ctxState.current = prev;
+      }
+    },
+  );
+  return {
+    span,
+    activeContext,
+    ctxState,
+    startActiveSpan,
+    injectMock: vi.fn(),
+    extractMock: vi.fn(),
+    deleteSpanMock: vi.fn((ctx: FakeCtx): FakeCtx => ({ ...ctx, span: undefined })),
+    contextWithMock: vi.fn((ctx: FakeCtx, fn: () => unknown): unknown => {
+      const prev = ctxState.current;
+      ctxState.current = ctx;
+      try {
+        return fn();
+      } finally {
+        ctxState.current = prev;
+      }
+    }),
+  };
+});
 
 vi.mock("@opentelemetry/api", () => ({
   SpanStatusCode: { ERROR: 2 },
   trace: {
     getTracer: vi.fn(() => ({ startActiveSpan })),
     getActiveSpan: vi.fn(() => span),
+    deleteSpan: deleteSpanMock,
   },
   context: {
-    active: vi.fn(() => activeContext),
+    active: vi.fn(() => ctxState.current),
     with: contextWithMock,
   },
   propagation: {
@@ -41,6 +87,7 @@ vi.mock("@opentelemetry/api", () => ({
 import {
   captureTraceparent,
   setActiveSpanAttributes,
+  withDetachedRootSpan,
   withSpan,
   withSpanFromParent,
 } from "./tracing";
@@ -136,5 +183,70 @@ describe("withSpanFromParent", () => {
       { attributes: { bar: 2 } },
       expect.any(Function),
     );
+  });
+});
+
+describe("withDetachedRootSpan", () => {
+  beforeEach(() => {
+    // Serialize whatever span is on the injected context, like the W3C
+    // propagator would, so captureTraceparent reflects the active context.
+    injectMock.mockImplementation(
+      (
+        ctx: { span?: { spanContext: () => { traceId: string; spanId: string } } },
+        carrier: Record<string, string>,
+      ) => {
+        const spanContext = ctx.span?.spanContext();
+        if (spanContext) {
+          carrier.traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-01`;
+        }
+      },
+    );
+  });
+
+  it("starts a new root whose traceId differs from the enclosing active span", async () => {
+    let outerTraceId: string | undefined;
+    let detachedTraceId: string | undefined;
+    let nestedTraceId: string | undefined;
+
+    await withSpan("outer", {}, async (outer) => {
+      outerTraceId = outer.spanContext().traceId;
+      await withDetachedRootSpan("detached", { foo: "bar" }, async (detached) => {
+        detachedTraceId = detached.spanContext().traceId;
+        // Children opened inside the detached root join its NEW trace, not
+        // the enclosing request trace.
+        await withSpan("nested", {}, async (nested) => {
+          nestedTraceId = nested.spanContext().traceId;
+        });
+      });
+    });
+
+    expect(outerTraceId).toBeDefined();
+    expect(detachedTraceId).toBeDefined();
+    expect(detachedTraceId).not.toBe(outerTraceId);
+    expect(nestedTraceId).toBe(detachedTraceId);
+    expect(deleteSpanMock).toHaveBeenCalled();
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      "detached",
+      { attributes: { foo: "bar" } },
+      expect.any(Function),
+    );
+  });
+
+  it("captureTraceparent inside the detached span serializes the new root's context", async () => {
+    let outerTraceparent: string | undefined;
+    let detachedTraceparent: string | undefined;
+    let detachedTraceId: string | undefined;
+
+    await withSpan("outer", {}, async () => {
+      outerTraceparent = captureTraceparent();
+      await withDetachedRootSpan("detached", {}, async (detached) => {
+        detachedTraceId = detached.spanContext().traceId;
+        detachedTraceparent = captureTraceparent();
+      });
+    });
+
+    expect(detachedTraceparent).toBeDefined();
+    expect(detachedTraceparent).toContain(detachedTraceId);
+    expect(detachedTraceparent).not.toBe(outerTraceparent);
   });
 });

--- a/src/lib/otel/tracing.ts
+++ b/src/lib/otel/tracing.ts
@@ -40,6 +40,23 @@ export async function withSpan<T>(
   });
 }
 
+/**
+ * Like `withSpan`, but the span is opened as a NEW ROOT, detached from the
+ * ambient context. Needed where long-lived callbacks inherit a stale request
+ * context: the discord.js client is created inside the gateway request
+ * handler, so socket callbacks inherit that request's ALS context — without
+ * detaching, every relayed event for the ~10-minute hold nests under one
+ * stale request trace and inherits its sampling decision.
+ */
+export async function withDetachedRootSpan<T>(
+  name: string,
+  attributes: Attributes,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  const detachedCtx = trace.deleteSpan(otelContext.active());
+  return otelContext.with(detachedCtx, () => withSpan(name, attributes, fn));
+}
+
 /** Set attributes on whatever span is currently active. No-op if none. */
 export function setActiveSpanAttributes(attributes: Attributes): void {
   trace.getActiveSpan()?.setAttributes(attributes);

--- a/src/lib/protocol/packets.test.ts
+++ b/src/lib/protocol/packets.test.ts
@@ -127,6 +127,53 @@ describe("PacketCodec - mentions defaulting", () => {
   });
 });
 
+describe("PacketCodec - traceparent propagation", () => {
+  const TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+  it("roundtrips traceparent on every packet variant", () => {
+    const variants = [
+      messagePacket("hello"),
+      reactionPacket("👋"),
+      reactionPacket("👋", "GATEWAY_MESSAGE_REACTION_REMOVE"),
+      deletePacket(),
+      voiceStatePacket(),
+      threadCreatePacket(),
+    ];
+    for (const packet of variants) {
+      const decoded = PacketCodec.decode(
+        PacketCodec.encode({ ...packet, traceparent: TRACEPARENT }),
+      );
+      expect(decoded.traceparent).toBe(TRACEPARENT);
+      expect(decoded.timestamp).toBeInstanceOf(Date);
+    }
+  });
+
+  it("roundtrips traceparent on a message update packet", () => {
+    const raw = JSON.stringify({
+      type: "GATEWAY_MESSAGE_UPDATE",
+      timestamp: new Date("2024-01-01"),
+      traceparent: TRACEPARENT,
+      data: { id: "msg-1", channelId: "ch-1", guildId: "guild-1" },
+    });
+    const decoded = PacketCodec.decode(raw);
+    expect(decoded.traceparent).toBe(TRACEPARENT);
+  });
+
+  it("still parses legacy payloads without traceparent", () => {
+    const decoded = PacketCodec.decode(PacketCodec.encode(messagePacket("hello")));
+    expect(decoded.traceparent).toBeUndefined();
+    expect(decoded.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("revives timestamp on packets that carry a traceparent", () => {
+    const decoded = PacketCodec.decode(
+      PacketCodec.encode({ ...messagePacket("hello"), traceparent: TRACEPARENT }),
+    );
+    expect(decoded.timestamp).toBeInstanceOf(Date);
+    expect(decoded.timestamp.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+  });
+});
+
 describe("PacketSchema validation", () => {
   it("rejects unknown type", () => {
     expect(

--- a/src/lib/protocol/packets.ts
+++ b/src/lib/protocol/packets.ts
@@ -96,33 +96,43 @@ const MessageDeleteData = z.object({
 
 // ── Packets ──
 
+// W3C trace context captured at relay time so the queue consumer can join the
+// publisher's trace. Optional both directions for rollout safety: old
+// in-flight messages decode without it, and old consumers strip it.
+const PacketTraceparent = z.string().optional();
+
 export const MessageCreatePacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_CREATE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: MessageCreateData,
 });
 
 export const MessageReactionAddPacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_REACTION_ADD"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: ReactionData,
 });
 
 export const MessageReactionRemovePacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_REACTION_REMOVE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: ReactionData,
 });
 
 export const MessageDeletePacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_DELETE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: MessageDeleteData,
 });
 
 export const MessageUpdatePacket = z.object({
   type: z.literal("GATEWAY_MESSAGE_UPDATE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: MessageData.partial().extend({
     id: z.string(),
     channelId: z.string(),
@@ -144,6 +154,7 @@ const VoiceStateData = z.object({
 export const VoiceStateUpdatePacket = z.object({
   type: z.literal("GATEWAY_VOICE_STATE_UPDATE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: VoiceStateData,
 });
 
@@ -160,6 +171,7 @@ const ThreadCreateData = z.object({
 export const ThreadCreatePacket = z.object({
   type: z.literal("GATEWAY_THREAD_CREATE"),
   timestamp: PacketTimestamp,
+  traceparent: PacketTraceparent,
   data: ThreadCreateData,
 });
 

--- a/src/lib/tasks/queue/handlers/scheduled-task-fire.test.ts
+++ b/src/lib/tasks/queue/handlers/scheduled-task-fire.test.ts
@@ -1,4 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ROOT_CONTEXT,
+  context as otelContext,
+  propagation,
+  trace,
+  type Context,
+  type ContextManager,
+  type TextMapPropagator,
+} from "@opentelemetry/api";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ScheduledTaskRow } from "@/lib/tasks/types";
 
@@ -100,6 +110,18 @@ describe("scheduled-task-fire: validation + short-circuits", () => {
       scheduledTaskFire.schema.safeParse({ taskId: "x", targetIso: "2026-01-01T00:00Z" }).success,
     ).toBe(true);
     expect(scheduledTaskFire.schema.safeParse({ taskId: 5 }).success).toBe(false);
+  });
+
+  it("accepts an optional string traceparent and rejects non-string values", () => {
+    const base = { taskId: "x", targetIso: "2026-01-01T00:00Z" };
+    expect(
+      scheduledTaskFire.schema.safeParse({
+        ...base,
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      }).success,
+    ).toBe(true);
+    expect(scheduledTaskFire.schema.safeParse(base).success).toBe(true);
+    expect(scheduledTaskFire.schema.safeParse({ ...base, traceparent: 42 }).success).toBe(false);
   });
 
   it("no-ops when the row is missing", async () => {
@@ -379,5 +401,124 @@ describe("scheduled-task-fire: agent action", () => {
       ...discord.callsTo("channels.editMessage").map((c) => c[2] as { content: string }),
     ];
     expect(bodies.some((b) => b.content.includes("-# Task: task-1"))).toBe(true);
+  });
+});
+
+// --- trace propagation -------------------------------------------------------
+// Real @opentelemetry/api with a test ALS context manager + W3C-shaped
+// propagator registered: the NoopTracer reuses a valid parent span context
+// from the active context, so the trace id observed inside the handler is
+// the behavioral proof that `traceparent` was (or was not) joined.
+
+const PARENT_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const PARENT_TRACEPARENT = `00-${PARENT_TRACE_ID}-00f067aa0ba902b7-01`;
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+const contextStorage = new AsyncLocalStorage<Context>();
+const alsContextManager: ContextManager = {
+  active: () => contextStorage.getStore() ?? ROOT_CONTEXT,
+  with: (ctx, fn, thisArg, ...args) => contextStorage.run(ctx, () => fn.call(thisArg, ...args)),
+  bind: (_ctx, target) => target,
+  enable() {
+    return this;
+  },
+  disable() {
+    return this;
+  },
+};
+
+const w3cExtractPropagator: TextMapPropagator = {
+  inject: () => {},
+  extract(ctx, carrier, getter) {
+    const header = getter.get(carrier, "traceparent");
+    const value = Array.isArray(header) ? (header[0] ?? "") : (header ?? "");
+    const match = TRACEPARENT_RE.exec(value);
+    if (!match) return ctx;
+    return trace.setSpanContext(ctx, {
+      traceId: match[1],
+      spanId: match[2],
+      traceFlags: parseInt(match[3], 16),
+      isRemote: true,
+    });
+  },
+  fields: () => ["traceparent"],
+};
+
+describe("scheduled-task-fire: trace propagation", () => {
+  beforeAll(() => {
+    otelContext.setGlobalContextManager(alsContextManager);
+    propagation.setGlobalPropagator(w3cExtractPropagator);
+  });
+
+  afterAll(() => {
+    otelContext.disable();
+    propagation.disable();
+  });
+
+  function observeTraceIdViaRowLookup(): { traceId: () => string | undefined } {
+    let observed: string | undefined;
+    // First thing `runFire` does inside the span is the row lookup — capture
+    // the active trace id there, return null so the rest short-circuits.
+    hoisted.getScheduledTask.mockImplementationOnce(async () => {
+      observed = trace.getActiveSpan()?.spanContext().traceId;
+      return null;
+    });
+    return { traceId: () => observed };
+  }
+
+  it("runs the handler under the parent trace when the payload carries traceparent", async () => {
+    const observed = observeTraceIdViaRowLookup();
+    await scheduledTaskFire.handle(
+      {
+        taskId: "task-1",
+        targetIso: "2026-04-23T13:00:00.000Z",
+        traceparent: PARENT_TRACEPARENT,
+      },
+      asAPI(createMockAPI()),
+    );
+    expect(observed.traceId()).toBe(PARENT_TRACE_ID);
+  });
+
+  it("opens a fresh root span when the payload has no traceparent", async () => {
+    const observed = observeTraceIdViaRowLookup();
+    await scheduledTaskFire.handle(
+      { taskId: "task-1", targetIso: "2026-04-23T13:00:00.000Z" },
+      asAPI(createMockAPI()),
+    );
+    expect(observed.traceId()).toBeDefined();
+    expect(observed.traceId()).not.toBe(PARENT_TRACE_ID);
+  });
+
+  it("does not propagate traceparent through a checkpoint-hop re-enqueue", async () => {
+    const targetIso = "2026-05-03T13:00:00.000Z";
+    vi.setSystemTime(new Date("2026-04-29T13:00:00.000Z"));
+    hoisted.getScheduledTask.mockResolvedValueOnce(makeRow({ nextRunAt: targetIso }));
+
+    await scheduledTaskFire.handle(
+      { taskId: "task-1", targetIso, traceparent: PARENT_TRACEPARENT },
+      asAPI(createMockAPI()),
+    );
+
+    expect(hoisted.sendScheduledFire).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendScheduledFire.mock.calls[0]).toHaveLength(3);
+  });
+
+  it("does not propagate traceparent through a recurring re-enqueue", async () => {
+    hoisted.getScheduledTask.mockResolvedValueOnce(
+      makeRow({
+        scheduleType: ScheduleType.Recurring,
+        runAt: null,
+        cron: "0 9 * * *",
+        timezone: null,
+      }),
+    );
+
+    await scheduledTaskFire.handle(
+      { taskId: "task-1", targetIso: "2026-04-23T13:00:00.000Z", traceparent: PARENT_TRACEPARENT },
+      asAPI(createMockAPI()),
+    );
+
+    expect(hoisted.sendScheduledFire).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendScheduledFire.mock.calls[0]).toHaveLength(3);
   });
 });

--- a/src/lib/tasks/queue/handlers/scheduled-task-fire.ts
+++ b/src/lib/tasks/queue/handlers/scheduled-task-fire.ts
@@ -9,7 +9,7 @@ import { MessageRenderer } from "@/lib/ai/message-renderer.ts";
 import { streamTurn } from "@/lib/ai/streaming.ts";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDistribution } from "@/lib/metrics";
-import { withSpan } from "@/lib/otel/tracing";
+import { withSpanFromParent } from "@/lib/otel/tracing";
 import { DEFAULT_TIMEZONE } from "@/lib/tasks/constants";
 import { nextOccurrence } from "@/lib/tasks/cron";
 import { claimFire, getScheduledTask, updateScheduledTask } from "@/lib/tasks/db";
@@ -29,9 +29,11 @@ export const scheduledTaskFire = defineTask({
   schema: z.object({
     taskId: z.string(),
     targetIso: z.string(),
+    traceparent: z.string().optional(),
   }),
-  async handle({ taskId, targetIso }, discord) {
-    return withSpan(
+  async handle({ taskId, targetIso, traceparent }, discord) {
+    return withSpanFromParent(
+      traceparent,
       "scheduled_task.fire",
       { "task.id": taskId, "task.target_iso": targetIso },
       () => runFire({ taskId, targetIso }, discord),
@@ -121,6 +123,8 @@ async function rehydrateCheckpoint(
   logger: Logger,
 ): Promise<void> {
   const remainingSec = Math.floor((targetMs - Date.now()) / 1000);
+  // No traceparent: re-propagating here would chain every checkpoint hop
+  // into one unbounded trace (see ScheduledTaskFirePayload.traceparent).
   const { messageId } = await sendScheduledFire(taskId, new Date(targetMs), remainingSec);
   await updateScheduledTask(taskId, { queueMessageId: messageId });
   countMetric("scheduled_task.checkpoint_hop", { schedule_type: scheduleType });
@@ -184,6 +188,8 @@ async function finalizeFire(
   }
 
   const delaySec = Math.max(0, Math.floor((next.getTime() - Date.now()) / 1000));
+  // No traceparent: a recurring task re-propagating its own trace would
+  // accumulate one trace spanning weeks (see ScheduledTaskFirePayload).
   const { messageId } = await sendScheduledFire(task.id, next, delaySec);
   await updateScheduledTask(task.id, {
     nextRunAt: next.toISOString(),

--- a/src/lib/tasks/queue/schedule-fire.test.ts
+++ b/src/lib/tasks/queue/schedule-fire.test.ts
@@ -59,4 +59,25 @@ describe("sendScheduledFire", () => {
     const [, , options] = hoisted.send.mock.calls[0];
     expect(options.delaySeconds).toBe(59);
   });
+
+  it("includes traceparent in the payload when provided, without changing the idempotency key", async () => {
+    const target = new Date("2026-06-01T12:00:00.000Z");
+    const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    await sendScheduledFire("task-11", target, 60, traceparent);
+
+    const [, envelope, options] = hoisted.send.mock.calls[0];
+    expect(envelope.payload).toEqual({
+      taskId: "task-11",
+      targetIso: "2026-06-01T12:00:00.000Z",
+      traceparent,
+    });
+    expect(options.idempotencyKey).toBe("task-11:2026-06-01T12:00:00.000Z");
+  });
+
+  it("omits the traceparent key entirely when not provided", async () => {
+    await sendScheduledFire("task-12", new Date("2026-06-01T12:00:00.000Z"), 60);
+
+    const [, envelope] = hoisted.send.mock.calls[0];
+    expect("traceparent" in envelope.payload).toBe(false);
+  });
 });

--- a/src/lib/tasks/queue/schedule-fire.ts
+++ b/src/lib/tasks/queue/schedule-fire.ts
@@ -27,11 +27,14 @@ export async function sendScheduledFire(
   taskId: string,
   target: Date,
   delaySec: number,
+  traceparent?: string,
 ): Promise<{ messageId: string | null }> {
   const targetIso = target.toISOString();
+  const payload: ScheduledTaskFirePayload = { taskId, targetIso };
+  if (traceparent) payload.traceparent = traceparent;
   const envelope: TaskEnvelope = {
     task: SCHEDULED_TASK_FIRE_TASK,
-    payload: { taskId, targetIso } satisfies ScheduledTaskFirePayload,
+    payload,
   };
   return send<TaskEnvelope>(TASK_TOPIC, envelope, {
     delaySeconds: clamp(Math.floor(delaySec), 0, CHECKPOINT_SECONDS),

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -53,4 +53,12 @@ export interface ScheduledTaskFirePayload {
   taskId: string;
   /** Original ISO target; unchanged across checkpoint hops. */
   targetIso: string;
+  /**
+   * W3C traceparent of the creating tool call. Set ONLY at task creation,
+   * never on internal re-enqueues (checkpoint hops / recurring): the fire
+   * handler joins this trace via `withSpanFromParent`, which preserves the
+   * trace ID — re-propagating on re-enqueue would accumulate one unbounded
+   * trace spanning weeks for a recurring task.
+   */
+  traceparent?: string;
 }

--- a/src/server/routes/crons.ts
+++ b/src/server/routes/crons.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { Hono } from "hono";
 
 import type { CronHandler } from "@/bot/crons/types";
@@ -32,16 +33,23 @@ route.get("/crons/:name", async (c) => {
 
   const startTime = Date.now();
   try {
-    await runInstrumented(
-      {
-        op: "cron.execute",
-        spanAttrs: { "cron.name": name },
-        loggerContext: { cron: { name } },
-      },
-      async () => {
-        await cron.handle(createDiscordAPI());
-        countMetric("cron.completed", { name });
-      },
+    // One withMonitor at the dispatch chokepoint covers every registered
+    // cron handler; the monitor slug is the cron name.
+    await Sentry.withMonitor(
+      name,
+      () =>
+        runInstrumented(
+          {
+            op: "cron.execute",
+            spanAttrs: { "cron.name": name },
+            loggerContext: { cron: { name } },
+          },
+          async () => {
+            await cron.handle(createDiscordAPI());
+            countMetric("cron.completed", { name });
+          },
+        ),
+      { schedule: { type: "crontab", value: cron.schedule } },
     );
     return c.json({ ok: true, cron: name });
   } catch (err) {

--- a/src/server/routes/gateway/index.ts
+++ b/src/server/routes/gateway/index.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { Redis } from "@upstash/redis";
 import { waitUntil } from "@vercel/functions";
 import { getVercelOidcTokenSync } from "@vercel/functions/oidc";
@@ -12,7 +13,7 @@ import type { Packet } from "@/lib/protocol/types";
 import { env } from "@/env";
 import { createWideLogger } from "@/lib/logging/wide";
 import { countMetric, recordDuration } from "@/lib/metrics";
-import { withSpan } from "@/lib/otel/tracing";
+import { captureTraceparent, withDetachedRootSpan } from "@/lib/otel/tracing";
 import { PacketCodec } from "@/lib/protocol/packets";
 import { isTextChannel } from "@/lib/protocol/utils";
 import { send } from "@/lib/tasks/queue/client";
@@ -38,14 +39,17 @@ end`;
 const ulid = monotonicFactory();
 
 async function relay(packet: Packet, oidcToken: string): Promise<void> {
-  return withSpan("gateway.relay", { "packet.type": packet.type }, async () => {
+  return withDetachedRootSpan("gateway.relay", { "packet.type": packet.type }, async () => {
     const logger = createWideLogger({
       op: "gateway.relay",
       event: { type: packet.type },
     });
     const startTime = Date.now();
     try {
-      await send(DISCORD_EVENT_TOPIC, PacketCodec.encode(packet), { oidcToken });
+      const traceparent = captureTraceparent();
+      await send(DISCORD_EVENT_TOPIC, PacketCodec.encode({ ...packet, traceparent }), {
+        oidcToken,
+      });
       countMetric("gateway.packet.relayed", { type: packet.type });
       logger.emit({ outcome: "ok", duration_ms: Date.now() - startTime });
     } catch (err) {
@@ -409,7 +413,11 @@ route.get("/gateway", async (c) => {
 
   let hold: Promise<void>;
   try {
-    ({ hold } = await startGatewayListener(client));
+    // The bot's single ingestion point: a missed check-in here means the bot
+    // is deaf. The crontab mirrors the keepalive schedule in vercel.ts.
+    ({ hold } = await Sentry.withMonitor("discord-gateway", () => startGatewayListener(client), {
+      schedule: { type: "crontab", value: "*/9 * * * *" },
+    }));
   } catch {
     return c.json({ error: "gateway failed to become ready" }, 500);
   }


### PR DESCRIPTION
## Why

The o11y scaffolding (122 metric sites, 34 wide-event ops, traceparent helpers) was solid, but four pipelines silently dead-ended: errors never became Sentry issues, traces broke at both queue boundaries, the AI-span integration never registered against the bundled `ai` package, and cron monitoring was configured via an option that reads a `vercel.json` that doesn't exist. This implements Plan 05 end-to-end so the upcoming refactors are measurable.

Before:

```
- zero captureException in src/ (queue swallows handler errors before onRequestError)
- every Discord event nested under one stale 10-minute gateway request trace,
  inheriting its 0.1 sampling; consumer opened a fresh root (no join)
- vercelAIIntegration require-hook never fired → no gen_ai spans, no AI Agents Insights
- automaticVercelMonitors: true → no monitors (Pages-Router-only, reads missing vercel.json)
- wide events: stdout only; cachedInputTokens read nowhere; cost unattributable
```

After:

```
- one error pipeline: createWideLogger().error() → captureException (every op covered);
  consumer errors fingerprinted by packet type, dead-letter attempts tagged queue.terminal
- one trace spans relay → queue consume → workflow → orchestrator → subagent → tool;
  relay roots are detached from the stale request context (fixes the live defect)
- gen_ai spans via vercelAIIntegration({force: true}) + tiered tracesSampler
  (keepalive 0.01, event-pipeline roots 1.0, parentSampled passthrough, default 0.1)
- withMonitor check-ins for every cron (slug = name) + discord-gateway
- wide events land in Sentry Logs, joined to traces by trace.id
- ai.turn.cost_usd / ai.subagent.cost_usd with {domain, model} attrs and
  input/output/cached splits; user ids only as 16-way hash buckets
- reactions on bot replies → ai.feedback metric, joined to the exact turn via
  a Redis message-id → {chat_id, trace_id, domains} index (7d TTL)
```

## What changed

- `src/lib/logging/wide.ts`: `.error()` forwards to `Sentry.captureException` — the single error-capture mechanism (do not add bare `captureException` next to `logger.error`)
- `src/lib/otel/tracing.ts`: new `withDetachedRootSpan`; `relay()` uses it, captures `traceparent` onto all 7 packet schemas (optional → rollout-safe); consumer joins via `withSpanFromParent`
- Scheduled tasks: `traceparent` set only at the creating tool call; checkpoint/recurring re-enqueues intentionally omit it (unbounded-trace trap, commented at both sites)
- `sentry.server.config.ts`: `force: true` + `recordInputs/Outputs`, `consoleLoggingIntegration`, tiered `tracesSampler`; `next.config.ts`: removed inert `automaticVercelMonitors`
- `src/server/routes/crons.ts` + gateway route: `Sentry.withMonitor` check-ins
- `src/lib/ai/pricing.ts` (new): static price table → cost metrics in `subagent.ts`/`streaming.ts`; `TurnUsageTracker` now carries per-delegation model + token splits incl. `cachedInputTokens`
- `src/bot/turn-message-store.ts` + `src/bot/handlers/events/feedback/` (new): finalize-time message-id index (non-fatal on Redis failure) + reaction feedback handler where the store lookup is the bot-authored filter
- `docs/observability.md` (new): pipelines, dashboard queries, one-time alert click-paths

## Test plan

- `bun run validate` — typecheck, lint, 1117 unit tests, all green
- `bun run test:coverage` — 99.4% stmts / 98.9% branches / 100% funcs (thresholds 90/85/90)
- 61 new tests: detached-root semantics, packet traceparent round-trip + legacy decode, wide.error forwarding (exactly once), re-enqueues omitting traceparent, pricing math incl. cached discount, user-bucket determinism, feedback store-miss filter, non-fatal persistence
- Prod-only acceptance (post-deploy): gen_ai spans visible in AI Agents Insights; one trace spanning relay→consume→workflow→agent→tool; cron monitors checking in

## Notes

- **Merge order**: #130 (plan 02) shares `src/server/routes/gateway/index.ts` + `src/app/api/discord/events/route.ts` and should land first per the plan; this branch takes the rebase.
- Missed-check-in alerts are one-time Sentry UI setup — click-paths in `docs/observability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)