### PR TITLE
refactor(approvals): remove dead wrapApprovalTools

### DIFF
--- a/src/lib/ai/approvals/index.ts
+++ b/src/lib/ai/approvals/index.ts
@@ -20,7 +20,7 @@ export function hasApprovalMarker(t: unknown): boolean {
   return getApprovalOptions(t) !== null;
 }
 
-export { wrapApprovalTools, wrapToolWithApproval } from "./runtime.ts";
+export { wrapToolWithApproval } from "./runtime.ts";
 export { ApprovalStore } from "./store.ts";
 export {
   buildApprovalComponents,

--- a/src/lib/ai/approvals/runtime.test.ts
+++ b/src/lib/ai/approvals/runtime.test.ts
@@ -1,4 +1,4 @@
-import { tool } from "ai";
+import { tool, type Tool, type ToolSet } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
@@ -6,9 +6,31 @@ import { SUBAGENT_PREAMBLE, SYSTEM_PROMPT } from "@/lib/ai/constants";
 import { AgentContext } from "@/lib/ai/context";
 import { createMemoryRedis, messagePacket } from "@/lib/test/fixtures";
 
-import { approval } from "./index.ts";
-import { wrapApprovalTools } from "./runtime.ts";
+import type { WrapApprovalOptions } from "./types.ts";
+
+import { approval, getApprovalOptions } from "./index.ts";
+import { wrapToolWithApproval } from "./runtime.ts";
 import { ApprovalStore } from "./store.ts";
+
+// Test driver. Production wraps tools via applyPolicy -> wrapToolWithApproval;
+// this maps a ToolSet the same way (reading the approval() marker the fixtures
+// set) so the scenarios below exercise the live wrapToolWithApproval flow that
+// `wrapApprovalTools` (removed as dead) used to provide.
+function wrapApprovalTools(tools: ToolSet, opts: WrapApprovalOptions): ToolSet {
+  const out: ToolSet = {};
+  for (const [name, t] of Object.entries(tools)) {
+    const markerOpts = getApprovalOptions(t);
+    out[name] = markerOpts
+      ? wrapToolWithApproval(
+          t as Tool,
+          name,
+          { confirmMode: "self", risk: "write", reason: markerOpts.reason },
+          opts,
+        )
+      : t;
+  }
+  return out;
+}
 
 // Mock the third-party Discord REST client at the module level so the wrapper
 // exercises its real `discord.post(...)` / `discord.patch(...)` paths

--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -1,4 +1,4 @@
-import { tool, type Tool, type ToolSet } from "ai";
+import { tool, type Tool } from "ai";
 import { Routes } from "discord-api-types/v10";
 import { log } from "evlog";
 import { z } from "zod";
@@ -15,38 +15,12 @@ import type {
 
 import { discord } from "../tools/discord/client.ts";
 import { buildApprovalComponents, buildApprovalEmbed, buildDecisionEmbed } from "./helpers.ts";
-import { getApprovalOptions } from "./index.ts";
 import { ApprovalStore } from "./store.ts";
 
 const DEFAULT_TIMEOUT_MS = 240_000;
 const TTL_BUFFER_SECONDS = 60;
 
 type RuntimeExecuteFn = (input: unknown, runtime: unknown) => unknown;
-
-/**
- * Wrap every tool in a ToolSet that carries the approval marker. Unmarked
- * tools pass through unchanged. Pass `delegateName` from subagent call sites
- * so the approval prompt renders the full `delegate_<name>.<tool>(...)`
- * signature; omit it at the orchestrator layer.
- *
- * Legacy entry point — `applyPolicy` resolves an `access()` descriptor into
- * an `ApprovalPolicy` and calls `wrapToolWithApproval` directly.
- */
-export function wrapApprovalTools(tools: ToolSet, opts: WrapApprovalOptions): ToolSet {
-  const out: ToolSet = {};
-  for (const [name, t] of Object.entries(tools)) {
-    const markerOpts = getApprovalOptions(t);
-    out[name] = markerOpts
-      ? wrapToolWithApproval(
-          t as Tool,
-          name,
-          { confirmMode: "self", risk: "write", reason: markerOpts.reason },
-          opts,
-        )
-      : t;
-  }
-  return out;
-}
 
 // The approval protocol is stated once in the agent preambles (SYSTEM_PROMPT /
 // SUBAGENT_PREAMBLE); per-tool text is kept to a short marker + reason hint so

--- a/src/lib/ai/approvals/types.ts
+++ b/src/lib/ai/approvals/types.ts
@@ -55,7 +55,7 @@ export interface WaitForOptions {
 }
 
 /**
- * Injection points for `wrapApprovalTools()`. The `store` slot exists so tests
+ * Injection points for `wrapToolWithApproval()`. The `store` slot exists so tests
  * can swap in an `ApprovalStore` constructed against the in-memory Redis
  * fixture — Discord REST is mocked separately via `@discordjs/rest`.
  */
@@ -70,7 +70,7 @@ export interface WrapApprovalOptions {
 }
 
 /**
- * Minimal surface `wrapApprovalTools` needs from the store, so the concrete
+ * Minimal surface `wrapToolWithApproval` needs from the store, so the concrete
  * class can live in a non-types file without creating a cycle.
  */
 export interface ApprovalStoreLike {

--- a/src/lib/ai/policy/apply.ts
+++ b/src/lib/ai/policy/apply.ts
@@ -16,9 +16,8 @@ import { AuditLog } from "./audit.ts";
 import { decide } from "./decide.ts";
 
 /**
- * The single enforcement point between a built ToolSet and the model.
- * Collapses the old `filterAdmin` + `wrapApprovalTools` pair: for each tool,
- * `decide()` is evaluated once and its outcome applied —
+ * The single enforcement point between a built ToolSet and the model. For each
+ * tool, `decide()` is evaluated once and its outcome applied —
  *
  * - deny (role):   the tool is omitted entirely (deny-by-absence — the model
  *                  never sees tools above the subject's role, so it can't


### PR DESCRIPTION
## What

A deep full-codebase audit (16 parallel dimensions: subsystem deep-reads, cross-system seam traces, per-plan completeness) found the post-consolidation codebase is in good shape — **the only genuinely-dead symbol left by the plan-09/10 migration is `wrapApprovalTools`** (9 of the 16 dimensions independently flagged it).

It was the old ToolSet-level approval wrapper that read the `approval()` marker. Now `applyPolicy` resolves each tool's `AccessSpec` and calls `wrapToolWithApproval` directly, so `wrapApprovalTools` has **zero production callers**.

- Removed from production: the function + its now-orphaned `getApprovalOptions`/`ToolSet` imports + the `index.ts` export.
- Scrubbed stale doc-comment mentions (`policy/apply.ts`, `approvals/types.ts`) — also drops a reference to `filterAdmin`, which never existed in this tree.
- **Kept `runtime.test.ts`**, re-pointed via a small local test driver. Those tests exercise the *live* `wrapToolWithApproval` (the human-in-the-loop approval gate) — they just drove it through `wrapApprovalTools`. Deleting them would have dropped `approvals/runtime.ts` to 56% branch coverage.

`wrapToolWithApproval`, `getApprovalOptions`, and the `approval()`/`access()` test markers all stay (the markers are intentional test fixtures per plan 09).

## Verification

Coverage **99.27%** (restored); typecheck, lint, knip all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)