### PR TITLE
fix(streaming): surface trailing tool failures in finalize()

### DIFF
--- a/src/lib/ai/message-renderer.test.ts
+++ b/src/lib/ai/message-renderer.test.ts
@@ -397,6 +397,28 @@ describe("MessageRenderer: finalize", () => {
     expect(body.content).toContain("-# 1.0s · 100 tokens");
   });
 
+  it("finalize surfaces a trailing tool failure instead of the empty-turn message", async () => {
+    const discord = createMockAPI();
+    const renderer = new MessageRenderer(asAPI(discord), "ch-1");
+    await renderer.init();
+    // Turn ends on a tool-error with no text after it: showToolFailed sets the
+    // activity line and nothing clears it. finalize must not blank it.
+    await renderer.showToolFailed("bash");
+
+    const meta: FooterMeta = {
+      elapsedMs: 1000,
+      totalTokens: 100,
+      toolCallCount: 1,
+      stepCount: 1,
+    };
+    await renderer.finalize(meta);
+
+    const edits = discord.callsTo("channels.editMessage");
+    const body = edits[edits.length - 1][2] as { content: string };
+    expect(body.content).toContain("`bash` failed.");
+    expect(body.content).not.toContain("I didn't have anything to say.");
+  });
+
   it("finalize creates additional messages for long text", async () => {
     const discord = createMockAPI();
     const renderer = new MessageRenderer(asAPI(discord), "ch-1");

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -280,7 +280,6 @@ export class MessageRenderer {
     }
   }
 
-  /** Compose components into a single Discord message string (mid-stream). */
   /**
    * Assemble the visible body from activity + subagent previews + text, in the
    * same order the live stream shows them. No fallback or truncation — callers
@@ -296,6 +295,7 @@ export class MessageRenderer {
     return parts.join("\n\n");
   }
 
+  /** The live-stream view: body() plus the "Thinking..." placeholder and length cap. */
   private render(): string {
     const body = this.body() || "> Thinking...";
     return body.length > MAX_LENGTH ? body.slice(0, MAX_LENGTH - 1) + "…" : body;

--- a/src/lib/ai/message-renderer.ts
+++ b/src/lib/ai/message-renderer.ts
@@ -140,7 +140,10 @@ export class MessageRenderer {
     let footer = MessageRenderer.formatFooter(meta);
     if (this.taskId) footer += `\n-# Task: ${this.taskId}`;
 
-    const finalText = this.text || "I didn't have anything to say.";
+    // Fall back through the assembled body (e.g. a trailing `tool` failure line
+    // or a subagent preview) before the empty-turn message, so a turn that ends
+    // on a tool-error with no text isn't silently blanked.
+    const finalText = this.body() || "I didn't have anything to say.";
     const chunks = MessageRenderer.splitWithFooter(finalText, footer);
 
     // Edit the original message with the first chunk
@@ -278,14 +281,23 @@ export class MessageRenderer {
   }
 
   /** Compose components into a single Discord message string (mid-stream). */
-  private render(): string {
+  /**
+   * Assemble the visible body from activity + subagent previews + text, in the
+   * same order the live stream shows them. No fallback or truncation — callers
+   * supply the empty-state text and any length handling.
+   */
+  private body(): string {
     const parts: string[] = [];
     if (this.activity) parts.push(`-# ${this.activity}`);
     for (const preview of this.subagentPreviews.values()) {
       parts.push(`> ${preview.replaceAll("\n", "\n> ")}`);
     }
     if (this.text) parts.push(this.text);
-    const body = parts.join("\n\n") || "> Thinking...";
+    return parts.join("\n\n");
+  }
+
+  private render(): string {
+    const body = this.body() || "> Thinking...";
     return body.length > MAX_LENGTH ? body.slice(0, MAX_LENGTH - 1) + "…" : body;
   }
 }


### PR DESCRIPTION
## Bug (audit finding: message-renderer finalize/render divergence)

`MessageRenderer.finalize()` fell back to *"I didn't have anything to say."* whenever `this.text` was empty — ignoring the `activity` / subagent-preview content that `render()` shows live. So a turn that **ended on a tool-error with no trailing text** (`showToolFailed` sets `activity = "<tool> failed."` and nothing clears it) was finalized as an empty-turn message, **silently dropping the failure** the user saw streaming.

## Fix

Factor the body assembly `render()` already uses into a private `body()`, and have `finalize()` fall back through it before the empty-turn message. Now a trailing `` `<tool>` failed. `` line (or a subagent preview) survives finalization. Regression test added (no test covered tool-error-as-final-with-no-text).

## Note on the second audit finding

The "subagent step-exhaustion clobbered for the code domain" finding was a **false positive** — verified against the code:
- subagent.ts passes `...capOutcome` (`{hitStepCap, exhausted}`) into `postFinish`,
- `codePostFinish` prepends *"⚠️ The coding agent hit its step cap — the work below may be incomplete."* to every message including the PR URL,
- and `exhaustionMessage` only fires when there is **no** `postFinish` (if/else), so there's no clobber.

No change needed there.

## Verification
987 tests pass; typecheck, lint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)