### PR TITLE
fix(policy): distinct prompt_failed audit decision + drop redundant casts

### DIFF
--- a/src/lib/ai/approvals/runtime.ts
+++ b/src/lib/ai/approvals/runtime.ts
@@ -179,8 +179,10 @@ export function wrapToolWithApproval(
       const promptError = await postApprovalPrompt({ state, store, ttlSeconds, timeoutMs });
       if (promptError) {
         // Terminal row so the `requested` entry doesn't dangle unresolved —
-        // the user never saw a prompt and the tool never ran.
-        await audit?.record({ ...auditBase, decision: "failed" });
+        // the user never saw a prompt and the tool never ran. Distinct from
+        // "failed" (a tool that ran and threw) so the audit trail can tell
+        // "couldn't ask" apart from "ran and failed".
+        await audit?.record({ ...auditBase, decision: "prompt_failed" });
         yield promptError;
         return;
       }

--- a/src/lib/ai/policy/apply.test.ts
+++ b/src/lib/ai/policy/apply.test.ts
@@ -238,7 +238,7 @@ describe("applyPolicy — confirmation wrapping", () => {
 });
 
 describe("applyPolicy — confirmation wrapping, prompt send failure", () => {
-  it("records a terminal 'failed' row and never runs the tool when the Discord prompt can't send", async () => {
+  it("records a terminal 'prompt_failed' row and never runs the tool when the Discord prompt can't send", async () => {
     const { tool: t, spy } = makeTool();
     const tools = { nuke: access({ risk: "destructive" }, t) };
     const { store } = fakeStore("approved", "user-1");
@@ -250,7 +250,8 @@ describe("applyPolicy — confirmation wrapping, prompt send failure", () => {
 
     expect(spy).not.toHaveBeenCalled();
     expect(String(out.at(-1))).toContain("NOT run");
-    expect(entries.map((e) => e.decision)).toEqual(["requested", "failed"]);
+    // Distinct from execution "failed": the prompt couldn't be delivered.
+    expect(entries.map((e) => e.decision)).toEqual(["requested", "prompt_failed"]);
   });
 });
 

--- a/src/lib/ai/policy/constants.ts
+++ b/src/lib/ai/policy/constants.ts
@@ -43,6 +43,9 @@ export const AuditDecision = {
   Timeout: "timeout",
   Executed: "executed",
   Failed: "failed",
+  /** The approval prompt could not be delivered, so the tool never ran — kept
+   *  distinct from `Failed` (the tool ran and threw) for the audit trail. */
+  PromptFailed: "prompt_failed",
 } as const;
 
 // eslint-disable-next-line @factory/constants-file-organization, @factory/types-file-organization

--- a/src/lib/ai/tools/audit/index.ts
+++ b/src/lib/ai/tools/audit/index.ts
@@ -4,9 +4,8 @@ import { z } from "zod";
 import { getDb } from "@/lib/db/index.ts";
 import { actionAudit } from "@/lib/db/schemas/action-audit.ts";
 
+import { AuditDecision } from "../../policy/constants.ts";
 import { defineTool } from "../_shared/define-tool.ts";
-
-const DECISIONS = ["requested", "approved", "denied", "timeout", "executed", "failed"] as const;
 
 export const list_audit_log = defineTool({
   name: "list_audit_log",
@@ -20,9 +19,11 @@ export const list_audit_log = defineTool({
     user_id: z.string().optional().describe("Filter by the acting Discord user ID"),
     tool_name: z.string().optional().describe("Filter by tool name (e.g. 'delete_project')"),
     decision: z
-      .enum(DECISIONS)
+      // Derived from the AuditDecision source of truth so the filter can't drift
+      // out of sync with what's written (e.g. it includes `prompt_failed`).
+      .enum(AuditDecision)
       .optional()
-      .describe("Filter by lifecycle stage (e.g. 'denied', 'executed')"),
+      .describe("Filter by lifecycle stage (e.g. 'denied', 'executed', 'prompt_failed')"),
     limit: z.number().int().min(1).max(100).optional().describe("Max rows to return (default 25)"),
   }),
   execute: async ({ user_id, tool_name, decision, limit }) => {

--- a/src/lib/ai/tools/github/actions.ts
+++ b/src/lib/ai/tools/github/actions.ts
@@ -72,7 +72,7 @@ export const list_workflow_runs = defineTool({
         repo,
         workflow_id,
         branch,
-        status: status as any,
+        status: status,
         per_page: per_page ?? 10,
         page: page ?? 1,
       });
@@ -95,7 +95,7 @@ export const list_workflow_runs = defineTool({
       owner: env.GITHUB_ORG,
       repo,
       branch,
-      status: status as any,
+      status: status,
       per_page: per_page ?? 10,
       page: page ?? 1,
     });


### PR DESCRIPTION
The genuinely-actionable remainder of the deep audit (most of its "remaining" findings turned out to be false positives — noted below).

## Changes

- **Distinct `prompt_failed` audit decision.** The approval audit trail recorded `decision:"failed"` for two different failures: a prompt that couldn't be **delivered** (so the tool never ran) and a tool that **ran and threw**. Added `AuditDecision.PromptFailed = "prompt_failed"` for the undeliverable-prompt case (`runtime.ts`), so audit-log analysis can tell "couldn't ask" from "ran and failed." `action_audit.decision` is free text — no migration. Test updated.
- **Dropped 2 redundant `as any` casts** in `github/actions.ts` (`z.enum` already narrows the value; verified by typecheck).

## Verified non-issues (no change)

- The **7 linear `as any` casts** are load-bearing — the Linear SDK uses nominal GraphQL enums (`InitiativeStatus`, `UserRoleType`, …), so the `z.enum` string isn't assignable without the cast (removing them fails typecheck).
- **`ApprovalStore.waitFor`** already short-circuits on a null/throwing Redis (`if (!state) return syntheticTimeout`); the poll loop only runs in the legitimate still-pending case. No 160-poll runaway.
- **`AuditLog` already has DI** (`constructor(db?)` + `opts.audit: AuditLogLike`), and apply.test injects a fake on every call — fully hermetic.
- **Snapshot persistence already lean** — `persistSnapshot` writes only `StoredContextSnapshot`; `model`/`systemPrompt`/`tools` are derived at read time.

## Verification
Full suite green; typecheck, lint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)