### PR TITLE
feat(simulator): dev-only Discord chat simulator on the real agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# AI Gateway (model auth)
+# The orchestrator runs models (e.g. anthropic/claude-sonnet-4.6) through the
+# Vercel AI Gateway. @ai-sdk/gateway reads AI_GATEWAY_API_KEY first, then falls
+# back to VERCEL_OIDC_TOKEN (short-lived; refreshed by `vercel env pull`). Set
+# AI_GATEWAY_API_KEY for a durable local key. Required to run the agent locally
+# (including the dev-only simulator's live turns).
+AI_GATEWAY_API_KEY=
+
 # Discord
 DISCORD_BOT_TOKEN=
 DISCORD_BOT_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,7 @@ src/lib/ai/skills/generated/
 
 # workflow devkit generated routes
 src/app/.well-known/
+
+# Local simulator SQLite DB (dev-only)
+.sim/
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,3 @@ src/app/.well-known/
 
 # Local simulator SQLite DB (dev-only)
 .sim/
-.env*

--- a/knip.json
+++ b/knip.json
@@ -3,12 +3,14 @@
   "tags": ["-lintignore"],
   "entry": [
     "src/app/**/route.ts",
+    "src/app/**/page.tsx",
+    "src/app/**/layout.tsx",
     "src/server/**/*.ts",
     "src/bot/handlers/**/*.ts",
     "scripts/*.ts",
     "vercel.ts"
   ],
-  "project": ["src/**/*.ts", "scripts/**/*.ts"],
+  "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
   "ignoreExportsUsedInFile": true,
   "ignore": ["src/lib/ai/tools/**"],
   "drizzle": false

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,119 @@
+/* Discord dark-theme tokens + a light reset. Surface/text/accent values mirror
+   the real client so the simulator reads as a faithful channel. */
+
+:root {
+  /* Surfaces — modern (2025) high-contrast dark theme: darker, with the
+     rail/titlebar near-black and chat a touch lighter than the sidebar. */
+  --surface-titlebar: #161719;
+  --surface-rail: #161719;
+  --surface-sidebar: #1e1f22;
+  --surface-channel: #27292d;
+  --surface-input: #313338;
+  --surface-hover: #2c2e33;
+  --surface-active: #3b3e45;
+  --surface-userpanel: #121315;
+  --surface-message-hover: #2a2c31;
+  --surface-code: #1c1d20;
+  --surface-embed: #1c1d20;
+  --border-subtle: #2c2e33;
+
+  /* Brand + status */
+  --brand: #5865f2;
+  --status-online: #23a55a;
+
+  /* Channel-list text tiers */
+  --text-channel: #949ba4;
+  --text-faint: #80848e;
+
+  /* Text */
+  --text-normal: #dbdee1;
+  --text-muted: #949ba4;
+  --text-link: #00a8fc;
+  --text-bright: #f2f3f5;
+  --text-on-accent: #ffffff;
+
+  /* Mentions */
+  --mention-bg: #3c4270;
+  --mention-text: #c9cdfb;
+  --mention-hover-bg: #5865f2;
+
+  /* Buttons */
+  --btn-green: #248046;
+  --btn-green-hover: #1a6334;
+  --btn-red: #da373c;
+  --btn-red-hover: #a12828;
+  --btn-grey: #4e5058;
+  --btn-grey-hover: #6d6f78;
+
+  /* Embed accents */
+  --accent-amber: #ffaa00;
+  --accent-green: #34d399;
+  --accent-red: #ef4444;
+  --accent-grey: #9ca3af;
+
+  /* Misc */
+  --spoiler-bg: #1e1f22;
+  --app-badge-bg: #5865f2;
+
+  --font-gg: "gg sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:
+    "gg mono", Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console",
+    "Lucida Sans Typewriter", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+body {
+  background: var(--surface-channel);
+  color: var(--text-normal);
+  font-family: var(--font-gg);
+  font-size: 16px;
+  line-height: 1.375;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+input,
+textarea {
+  font-family: inherit;
+}
+
+a {
+  color: var(--text-link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+::-webkit-scrollbar {
+  width: 16px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--surface-rail);
+  border: 4px solid transparent;
+  background-clip: padding-box;
+  border-radius: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: transparent;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+import "./globals.css";
+
+export function generateMetadata() {
+  return {
+    title: "Wack Hack · Discord Simulator",
+    description: "A faithful Discord dark-theme channel for iterating on bot message UX.",
+  };
+}
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" className="dark">
+      <body>
+        {/* Discord ships "gg sans" (proprietary); Noto Sans is its documented
+            fallback and the closest free match. React 19 hoists these to <head>. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap"
+        />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/simulator/avatar.ts
+++ b/src/app/simulator/avatar.ts
@@ -1,0 +1,13 @@
+// Discord assigns each user a colored default avatar; mirror that so the
+// channel doesn't read as a wall of identical blurple circles.
+const PALETTE = ["#5865f2", "#3ba55d", "#e67e22", "#ed4245", "#eb459e", "#9b59b6", "#11806a"];
+
+export function avatarColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1) hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  return PALETTE[hash % PALETTE.length];
+}
+
+export function initials(name: string): string {
+  return name.slice(0, 1).toUpperCase();
+}

--- a/src/app/simulator/components/ActionRow.tsx
+++ b/src/app/simulator/components/ActionRow.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { SimActionRow } from "@/lib/simulator/types";
+
+import { Button } from "./Button.tsx";
+import styles from "./components.module.css";
+
+interface ActionRowProps {
+  row: SimActionRow;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+}
+
+export function ActionRow({ row, onDecide }: ActionRowProps) {
+  return (
+    <div className={styles.actionRow}>
+      {row.components.map((button, idx) => (
+        <Button key={button.custom_id ?? button.url ?? idx} button={button} onDecide={onDecide} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/simulator/components/Button.tsx
+++ b/src/app/simulator/components/Button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+import type { SimButton } from "@/lib/simulator/types";
+
+import styles from "./components.module.css";
+
+interface ButtonProps {
+  button: SimButton;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+}
+
+const STYLE_CLASS: Record<number, string> = {
+  1: styles.buttonPrimary,
+  2: styles.buttonSecondary,
+  3: styles.buttonSuccess,
+  4: styles.buttonDanger,
+  5: styles.buttonLink,
+};
+
+/** Parse a `tool-approval:<decision>:<id>` custom_id, or null if not one. */
+function parseApproval(
+  customId: string | undefined,
+): { decision: "approve" | "deny"; approvalId: string } | null {
+  if (!customId) return null;
+  const parts = customId.split(":");
+  if (parts.length !== 3 || parts[0] !== "tool-approval") return null;
+  if (parts[1] !== "approve" && parts[1] !== "deny") return null;
+  return { decision: parts[1], approvalId: parts[2] };
+}
+
+export function Button({ button, onDecide }: ButtonProps) {
+  const [clicked, setClicked] = useState(false);
+  const approval = parseApproval(button.custom_id);
+  const className = `${styles.button} ${STYLE_CLASS[button.style] ?? styles.buttonSecondary}`;
+  const disabled = button.disabled || clicked;
+
+  const handleClick = (): void => {
+    if (!approval || disabled) return;
+    setClicked(true);
+    onDecide(approval.decision, approval.approvalId);
+  };
+
+  if (button.style === 5 && button.url) {
+    return (
+      <a className={className} href={button.url} target="_blank" rel="noreferrer noopener">
+        {button.emoji?.name ? `${button.emoji.name} ` : ""}
+        {button.label}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" className={className} disabled={disabled} onClick={handleClick}>
+      {button.emoji?.name ? `${button.emoji.name} ` : ""}
+      {button.label}
+    </button>
+  );
+}

--- a/src/app/simulator/components/ChatColumn.tsx
+++ b/src/app/simulator/components/ChatColumn.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { SimMessage } from "@/lib/simulator/types";
+
+import type { MentionResolver } from "../types.ts";
+
+import styles from "../simulator.module.css";
+import { Composer } from "./Composer.tsx";
+import { MessageList } from "./MessageList.tsx";
+
+interface ChatColumnProps {
+  channelName: string;
+  isThread: boolean;
+  parentName?: string;
+  parentId?: string;
+  messages: SimMessage[];
+  resolver: MentionResolver;
+  busy: boolean;
+  onSend: (content: string) => void;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+  onSelectChannel: (id: string) => void;
+}
+
+function ThreadGlyph() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 4v6a4 4 0 0 0 4 4h9" />
+    </svg>
+  );
+}
+
+/** The single chat/thread column: breadcrumb header + messages + composer. */
+export function ChatColumn({
+  channelName,
+  isThread,
+  parentName,
+  parentId,
+  messages,
+  resolver,
+  busy,
+  onSend,
+  onDecide,
+  onSelectChannel,
+}: ChatColumnProps) {
+  return (
+    <main className={styles.chat}>
+      <header className={styles.crumbBar}>
+        {isThread && parentId ? (
+          <>
+            <button
+              type="button"
+              className={styles.crumbLink}
+              onClick={() => onSelectChannel(parentId)}
+            >
+              # {parentName}
+            </button>
+            <span className={styles.crumbSep}>›</span>
+            <span className={styles.crumbGlyph}>
+              <ThreadGlyph />
+            </span>
+            <span>{channelName}</span>
+          </>
+        ) : (
+          <>
+            <span className={styles.crumbGlyph}>#</span>
+            <span>{channelName}</span>
+          </>
+        )}
+      </header>
+      <MessageList
+        messages={messages}
+        resolver={resolver}
+        channelName={channelName}
+        onDecide={onDecide}
+      />
+      <Composer channelName={channelName} disabled={busy} resolver={resolver} onSend={onSend} />
+    </main>
+  );
+}

--- a/src/app/simulator/components/CodeBlock.tsx
+++ b/src/app/simulator/components/CodeBlock.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import styles from "./code-block.module.css";
+
+interface CodeBlockProps {
+  lang?: string;
+  code: string;
+}
+
+/**
+ * Extracted code-block renderer — the message-construction iteration seam. The
+ * markdown parser stays decoupled (it just hands {lang, code}), so experiments
+ * like live sandbox-output streaming or syntax highlighting are a one-file
+ * change here behind this contract.
+ */
+export function CodeBlock({ lang, code }: CodeBlockProps) {
+  return (
+    <div className={styles.block}>
+      {lang ? <div className={styles.header}>{lang}</div> : null}
+      <pre className={styles.pre}>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/app/simulator/components/Composer.tsx
+++ b/src/app/simulator/components/Composer.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useRef, useState, type KeyboardEvent } from "react";
+
+import type { MentionResolver } from "../types.ts";
+
+import { avatarColor, initials } from "../avatar.ts";
+import { EmojiIcon, GiftIcon, StickerIcon } from "../icons.tsx";
+import styles from "./composer.module.css";
+
+interface ComposerProps {
+  channelName: string;
+  disabled: boolean;
+  resolver: MentionResolver;
+  onSend: (content: string) => void;
+}
+
+interface Suggestion {
+  id: string;
+  insert: string;
+  label: string;
+  detail?: string;
+  color?: string;
+  glyph?: string;
+  imageUrl?: string;
+}
+
+interface ActiveToken {
+  kind: "@" | "#" | ":";
+  query: string;
+  start: number;
+}
+
+const TITLES: Record<ActiveToken["kind"], string> = {
+  "@": "Members",
+  "#": "Channels",
+  ":": "Emoji",
+};
+
+const STATIC_EMOJI: { name: string; char: string }[] = [
+  { name: "tada", char: "🎉" },
+  { name: "fire", char: "🔥" },
+  { name: "rocket", char: "🚀" },
+  { name: "eyes", char: "👀" },
+  { name: "heart", char: "❤️" },
+  { name: "joy", char: "😂" },
+  { name: "thumbsup", char: "👍" },
+  { name: "wave", char: "👋" },
+  { name: "sparkles", char: "✨" },
+  { name: "pray", char: "🙏" },
+];
+
+function detectToken(text: string, caret: number): ActiveToken | null {
+  const before = text.slice(0, caret);
+  const match = before.match(/(?:^|\s)([@#:])([\w-]*)$/);
+  if (!match) return null;
+  const query = match[2];
+  return { kind: match[1] as ActiveToken["kind"], query, start: caret - query.length - 1 };
+}
+
+function buildSuggestions(token: ActiveToken, resolver: MentionResolver): Suggestion[] {
+  const q = token.query.toLowerCase();
+  if (token.kind === "@") {
+    return Object.values(resolver.members)
+      .filter(
+        (m) => m.displayName.toLowerCase().includes(q) || m.username.toLowerCase().includes(q),
+      )
+      .slice(0, 8)
+      .map((m) => ({
+        id: m.id,
+        insert: `<@${m.id}>`,
+        label: m.displayName,
+        detail: m.username,
+        color: avatarColor(m.id),
+        glyph: initials(m.displayName),
+        imageUrl: m.avatarUrl,
+      }));
+  }
+  if (token.kind === "#") {
+    return Object.values(resolver.channels)
+      .filter((c) => c.kind === "channel" && c.name.toLowerCase().includes(q))
+      .slice(0, 8)
+      .map((c) => ({ id: c.id, insert: `<#${c.id}>`, label: c.name, glyph: "#" }));
+  }
+  const custom = Object.values(resolver.emojis)
+    .filter((e) => e.name.toLowerCase().includes(q))
+    .map((e) => ({
+      id: e.id,
+      insert: `<${e.animated ? "a" : ""}:${e.name}:${e.id}>`,
+      label: e.name,
+      imageUrl: e.url,
+    }));
+  const unicode = STATIC_EMOJI.filter((e) => e.name.includes(q)).map((e) => ({
+    id: `u-${e.name}`,
+    insert: e.char,
+    label: e.name,
+    glyph: e.char,
+  }));
+  return [...custom, ...unicode].slice(0, 8);
+}
+
+export function Composer({ channelName, disabled, resolver, onSend }: ComposerProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [value, setValue] = useState("");
+  const [token, setToken] = useState<ActiveToken | null>(null);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [selected, setSelected] = useState(0);
+
+  const open = token !== null && suggestions.length > 0;
+
+  const refresh = (text: string, caret: number): void => {
+    const next = detectToken(text, caret);
+    const list = next ? buildSuggestions(next, resolver) : [];
+    setToken(list.length > 0 ? next : null);
+    setSuggestions(list);
+    setSelected(0);
+  };
+
+  const submit = (): void => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setValue("");
+    setToken(null);
+    setSuggestions([]);
+  };
+
+  const applyInsert = (suggestion: Suggestion): void => {
+    const textarea = ref.current;
+    if (!textarea || !token) return;
+    const caret = textarea.selectionStart;
+    const before = value.slice(0, token.start);
+    const after = value.slice(caret);
+    const inserted = `${before}${suggestion.insert} ${after}`;
+    setValue(inserted);
+    setToken(null);
+    setSuggestions([]);
+    const pos = before.length + suggestion.insert.length + 1;
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(pos, pos);
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (open) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSelected((s) => (s + 1) % suggestions.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSelected((s) => (s - 1 + suggestions.length) % suggestions.length);
+        return;
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        applyInsert(suggestions[selected]);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setToken(null);
+        setSuggestions([]);
+        return;
+      }
+    }
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className={styles.composer}>
+      {open ? (
+        <div className={styles.autocomplete}>
+          <div className={styles.autocompleteHeader}>{TITLES[token.kind]}</div>
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              className={`${styles.suggestion} ${index === selected ? styles.suggestionActive : ""}`}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                applyInsert(suggestion);
+              }}
+            >
+              {suggestion.imageUrl ? (
+                <img
+                  className={styles.suggestionImg}
+                  src={suggestion.imageUrl}
+                  alt=""
+                  draggable={false}
+                />
+              ) : (
+                <span
+                  className={styles.suggestionGlyph}
+                  style={suggestion.color ? { background: suggestion.color } : undefined}
+                >
+                  {suggestion.glyph}
+                </span>
+              )}
+              <span className={styles.suggestionLabel}>{suggestion.label}</span>
+              {suggestion.detail ? (
+                <span className={styles.suggestionDetail}>@{suggestion.detail}</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <div className={styles.inputWrap}>
+        <button type="button" className={styles.plus} title="Upload">
+          +
+        </button>
+        <textarea
+          ref={ref}
+          className={styles.input}
+          rows={1}
+          value={value}
+          disabled={disabled}
+          placeholder={`Message #${channelName}`}
+          onChange={(event) => {
+            setValue(event.target.value);
+            refresh(event.target.value, event.target.selectionStart);
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        <div className={styles.actions}>
+          <button type="button" className={styles.actionBtn} title="Gift Nitro">
+            <GiftIcon />
+          </button>
+          <button type="button" className={styles.actionBtn} title="GIF">
+            GIF
+          </button>
+          <button type="button" className={styles.actionBtn} title="Sticker">
+            <StickerIcon />
+          </button>
+          <button type="button" className={styles.actionBtn} title="Emoji">
+            <EmojiIcon />
+          </button>
+          <button type="button" className={styles.actionBtn} title="Apps">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <circle cx="7" cy="7" r="2" />
+              <circle cx="17" cy="7" r="2" />
+              <circle cx="7" cy="17" r="2" />
+              <circle cx="17" cy="17" r="2" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/simulator/components/ContextInspector.tsx
+++ b/src/app/simulator/components/ContextInspector.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import type { SimContextSnapshot } from "@/lib/simulator/types";
+
+import styles from "./inspector.module.css";
+
+interface ContextInspectorProps {
+  snapshot?: SimContextSnapshot;
+}
+
+function tok(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+/**
+ * Renders the {@link SimContextSnapshot} — exactly what the model saw this turn
+ * (built backend-side from the real `buildContextSnapshot`/`breakdownFromSnapshot`,
+ * so it matches `/inspect-context`). The point is to *deeply* see the context:
+ * budget by category, the live system prompt, the tool set, and the running
+ * conversation, all in one scrollable panel.
+ */
+export function ContextInspector({ snapshot }: ContextInspectorProps) {
+  if (!snapshot) {
+    return <p className={styles.empty}>Run a turn to capture the context the model sees.</p>;
+  }
+  const { model, estimatedInputTokens, categories, totalUsage, totalCostUsd } = snapshot;
+  const { systemPrompt, tools, messages, context, turnCount } = snapshot;
+  const maxCat = Math.max(1, ...categories.map((c) => c.estimatedTokens));
+
+  return (
+    <div className={styles.body}>
+      <dl className={styles.kvGrid}>
+        <dt className={styles.k}>Model</dt>
+        <dd className={styles.v}>{model}</dd>
+        <dt className={styles.k}>Next-turn input</dt>
+        <dd className={styles.v}>~{tok(estimatedInputTokens)} tok</dd>
+        <dt className={styles.k}>Cumulative</dt>
+        <dd className={styles.v}>
+          {tok(totalUsage.inputTokens)} in · {tok(totalUsage.outputTokens)} out
+        </dd>
+        <dt className={styles.k}>Turns</dt>
+        <dd className={styles.v}>{turnCount}</dd>
+        {totalCostUsd ? (
+          <>
+            <dt className={styles.k}>Cost</dt>
+            <dd className={styles.v}>${totalCostUsd.total.toFixed(4)}</dd>
+          </>
+        ) : null}
+      </dl>
+
+      <h3 className={styles.h3}>Context budget</h3>
+      <ul className={styles.bars}>
+        {categories.map((cat) => (
+          <li key={cat.label} className={styles.barRow}>
+            <div className={styles.barHead}>
+              <span>{cat.label}</span>
+              <span className={styles.barNum}>{tok(cat.estimatedTokens)}</span>
+            </div>
+            <div className={styles.barTrack}>
+              <div
+                className={styles.barFill}
+                style={{ width: `${(cat.estimatedTokens / maxCat) * 100}%` }}
+              />
+            </div>
+            {cat.items && cat.items.length > 0 ? (
+              <ul className={styles.subItems}>
+                {cat.items.map((item) => (
+                  <li key={item.name}>
+                    <span>{item.name}</span>
+                    <span className={styles.barNum}>{tok(item.estimatedTokens)}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+
+      <h3 className={styles.h3}>Execution context</h3>
+      <dl className={styles.kvGrid}>
+        <dt className={styles.k}>User</dt>
+        <dd className={styles.v}>
+          {context.nickname} (@{context.username})
+        </dd>
+        <dt className={styles.k}>Channel</dt>
+        <dd className={styles.v}>#{context.channel.name}</dd>
+        {context.thread ? (
+          <>
+            <dt className={styles.k}>Thread</dt>
+            <dd className={styles.v}>{context.thread.name}</dd>
+          </>
+        ) : null}
+        {context.memberRoles && context.memberRoles.length > 0 ? (
+          <>
+            <dt className={styles.k}>Roles</dt>
+            <dd className={styles.v}>{context.memberRoles.join(", ")}</dd>
+          </>
+        ) : null}
+        <dt className={styles.k}>Lead-in</dt>
+        <dd className={styles.v}>{context.recentMessages?.length ?? 0} recent msg</dd>
+      </dl>
+
+      <details className={styles.details}>
+        <summary className={styles.summary}>
+          System prompt <span className={styles.count}>{tok(systemPrompt.length)} chars</span>
+        </summary>
+        <pre className={styles.pre}>{systemPrompt}</pre>
+      </details>
+
+      <details className={styles.details}>
+        <summary className={styles.summary}>
+          Tools <span className={styles.count}>{tools.length}</span>
+        </summary>
+        <ul className={styles.toolList}>
+          {tools.map((t) => (
+            <li key={t.name} className={styles.toolItem}>
+              <code className={styles.toolName}>{t.name}</code>
+              <span className={styles.toolDesc}>{t.description}</span>
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      <details className={styles.details} open>
+        <summary className={styles.summary}>
+          Conversation <span className={styles.count}>{messages.length}</span>
+        </summary>
+        <ol className={styles.msgList}>
+          {messages.map((m, i) => (
+            <li key={`${i}-${m.role}`} className={styles.msgRow}>
+              <span
+                className={`${styles.roleTag} ${m.role === "assistant" ? styles.roleAssistant : styles.roleUser}`}
+              >
+                {m.role}
+              </span>
+              <pre className={styles.msgContent}>{m.content}</pre>
+            </li>
+          ))}
+        </ol>
+      </details>
+    </div>
+  );
+}

--- a/src/app/simulator/components/ControlPanel.tsx
+++ b/src/app/simulator/components/ControlPanel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { UserRole } from "@/lib/ai/constants";
+
+import type { SimConfig } from "../types.ts";
+
+import styles from "./control-panel.module.css";
+
+interface ControlPanelProps {
+  config: SimConfig;
+  status: "idle" | "streaming" | "done" | "error";
+  onChange: (patch: Partial<SimConfig>) => void;
+}
+
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: UserRole.Public, label: "Public" },
+  { value: UserRole.Organizer, label: "Organizer" },
+  { value: UserRole.Admin, label: "Admin" },
+];
+
+interface TextFieldProps {
+  label: string;
+  value: string;
+  onInput: (value: string) => void;
+}
+
+function TextField({ label, value, onInput }: TextFieldProps) {
+  return (
+    <label className={styles.field}>
+      <span className={styles.label}>{label}</span>
+      <input
+        className={styles.input}
+        value={value}
+        onChange={(event) => onInput(event.target.value)}
+      />
+    </label>
+  );
+}
+
+interface CheckboxProps {
+  label: string;
+  checked: boolean;
+  onToggle: (checked: boolean) => void;
+}
+
+function Checkbox({ label, checked, onToggle }: CheckboxProps) {
+  return (
+    <label className={styles.checkboxRow}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onToggle(event.target.checked)}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+export function ControlPanel({ config, status, onChange }: ControlPanelProps) {
+  return (
+    <aside className={styles.panel}>
+      <div className={styles.statusRow}>
+        <span className={`${styles.statusDot} ${styles[`status_${status}`]}`} />
+        <span className={styles.statusLabel}>{status}</span>
+      </div>
+
+      <label className={styles.field}>
+        <span className={styles.label}>Role</span>
+        <select
+          className={styles.select}
+          value={config.role}
+          onChange={(event) => onChange({ role: event.target.value as UserRole })}
+        >
+          {ROLE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <TextField
+        label="Username"
+        value={config.username}
+        onInput={(username) => onChange({ username })}
+      />
+      <TextField
+        label="Nickname"
+        value={config.nickname}
+        onInput={(nickname) => onChange({ nickname })}
+      />
+      <TextField
+        label="Channel"
+        value={config.channelName}
+        onInput={(channelName) => onChange({ channelName })}
+      />
+
+      <Checkbox
+        label="Open a thread for channel replies"
+        checked={config.openThread}
+        onToggle={(openThread) => onChange({ openThread })}
+      />
+
+      <Checkbox
+        label="Approve as 2nd organizer"
+        checked={config.approveAsSecond}
+        onToggle={(approveAsSecond) => onChange({ approveAsSecond })}
+      />
+
+      <p className={styles.hint}>
+        Runs the real agent. The bot only replies when you @mention it (type <code>@</code> to
+        autocomplete), or inside a thread it started.
+      </p>
+    </aside>
+  );
+}

--- a/src/app/simulator/components/Embed.tsx
+++ b/src/app/simulator/components/Embed.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { SimEmbed } from "@/lib/simulator/types";
+
+import type { MentionResolver } from "../types.ts";
+
+import { renderMarkdown } from "../discord-markdown.tsx";
+import styles from "./components.module.css";
+
+interface EmbedProps {
+  embed: SimEmbed;
+  resolver: MentionResolver;
+}
+
+/** A Discord int color → CSS hex, falling back to the grey accent. */
+function colorHex(color: number | undefined): string {
+  if (color === undefined) return "var(--accent-grey)";
+  return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+export function Embed({ embed, resolver }: EmbedProps) {
+  return (
+    <div className={styles.embed}>
+      <div className={styles.embedAccent} style={{ background: colorHex(embed.color) }} />
+      <div className={styles.embedBody}>
+        {embed.author ? (
+          <div className={styles.embedAuthor}>
+            {embed.author.icon_url ? (
+              <img
+                className={styles.embedAuthorIcon}
+                src={embed.author.icon_url}
+                alt=""
+                draggable={false}
+              />
+            ) : null}
+            <span>{embed.author.name}</span>
+          </div>
+        ) : null}
+
+        {embed.title ? <div className={styles.embedTitle}>{embed.title}</div> : null}
+
+        {embed.description ? (
+          <div className={styles.embedDescription}>
+            {renderMarkdown(embed.description, resolver)}
+          </div>
+        ) : null}
+
+        {embed.fields && embed.fields.length > 0 ? (
+          <div className={styles.embedFields}>
+            {embed.fields.map((field, idx) => (
+              <div key={`${field.name}-${idx}`} className={styles.embedField}>
+                <div className={styles.embedFieldName}>{field.name}</div>
+                <div className={styles.embedFieldValue}>
+                  {renderMarkdown(field.value, resolver)}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {embed.footer ? (
+          <div className={styles.embedFooter}>
+            <span>{embed.footer.text}</span>
+            {embed.timestamp ? (
+              <span className={styles.embedTimestamp}>
+                {new Date(embed.timestamp).toLocaleString("en-US", {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/simulator/components/InspectorPanel.tsx
+++ b/src/app/simulator/components/InspectorPanel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import type { SimContextSnapshot } from "@/lib/simulator/types";
+
+import type { SimConfig, SimTraceEntry } from "../types.ts";
+
+import styles from "../simulator.module.css";
+import { ContextInspector } from "./ContextInspector.tsx";
+import { ControlPanel } from "./ControlPanel.tsx";
+import { TraceInspector } from "./TraceInspector.tsx";
+
+interface InspectorPanelProps {
+  config: SimConfig;
+  status: "idle" | "streaming" | "done" | "error";
+  onChange: (patch: Partial<SimConfig>) => void;
+  snapshot?: SimContextSnapshot;
+  trace: SimTraceEntry[];
+}
+
+const TABS: { id: "controls" | "context" | "trace"; label: string }[] = [
+  { id: "controls", label: "Controls" },
+  { id: "context", label: "Context" },
+  { id: "trace", label: "Trace" },
+];
+
+/**
+ * The right-hand dev surface: a tabbed playground (tweak the session config) +
+ * two read-only inspectors over the latest run — the context the model saw and
+ * its execution trace. This is where simulator-only visualization lives so the
+ * chat column stays a faithful Discord view.
+ */
+export function InspectorPanel({ config, status, onChange, snapshot, trace }: InspectorPanelProps) {
+  const [tab, setTab] = useState<"controls" | "context" | "trace">("controls");
+  return (
+    <aside className={styles.inspector}>
+      <div className={styles.tabBar}>
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            className={`${styles.tab} ${tab === t.id ? styles.tabActive : ""}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+            {t.id === "trace" && trace.length > 0 ? (
+              <span className={styles.tabCount}>{trace.length}</span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+      <div className={styles.tabBody}>
+        {tab === "controls" ? (
+          <ControlPanel config={config} status={status} onChange={onChange} />
+        ) : null}
+        {tab === "context" ? <ContextInspector snapshot={snapshot} /> : null}
+        {tab === "trace" ? <TraceInspector trace={trace} /> : null}
+      </div>
+    </aside>
+  );
+}

--- a/src/app/simulator/components/Message.tsx
+++ b/src/app/simulator/components/Message.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { SimMessage, SimReaction } from "@/lib/simulator/types";
+
+import type { MentionResolver } from "../types.ts";
+
+import { renderMarkdown } from "../discord-markdown.tsx";
+import { ActionRow } from "./ActionRow.tsx";
+import styles from "./components.module.css";
+import { Embed } from "./Embed.tsx";
+
+interface MessageProps {
+  message: SimMessage;
+  resolver: MentionResolver;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+}
+
+function Reactions({ reactions }: { reactions: SimReaction[] }) {
+  if (reactions.length === 0) return null;
+  return (
+    <div className={styles.reactions}>
+      {reactions.map((reaction) => (
+        <span
+          key={reaction.emoji}
+          className={`${styles.reaction} ${reaction.me ? styles.reactionMine : ""}`}
+        >
+          <span>{reaction.emoji}</span>
+          <span className={styles.reactionCount}>{reaction.count}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function Message({ message, resolver, onDecide }: MessageProps) {
+  return (
+    <div className={styles.message}>
+      {message.content ? (
+        <div className={styles.messageContent}>
+          {renderMarkdown(message.content, resolver)}
+          {message.editedAt ? <span className={styles.editedTag}>(edited)</span> : null}
+        </div>
+      ) : null}
+
+      {message.embeds.map((embed, idx) => (
+        <Embed key={idx} embed={embed} resolver={resolver} />
+      ))}
+
+      {message.components.map((row, idx) => (
+        <ActionRow key={idx} row={row} onDecide={onDecide} />
+      ))}
+
+      <Reactions reactions={message.reactions} />
+    </div>
+  );
+}

--- a/src/app/simulator/components/MessageGroup.tsx
+++ b/src/app/simulator/components/MessageGroup.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { SimMessage, VirtualMember } from "@/lib/simulator/types";
+
+import type { MentionResolver } from "../types.ts";
+
+import { avatarColor, initials } from "../avatar.ts";
+import styles from "./components.module.css";
+import { Message } from "./Message.tsx";
+
+interface MessageGroupProps {
+  messages: SimMessage[];
+  resolver: MentionResolver;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+}
+
+function authorOf(resolver: MentionResolver, message: SimMessage): VirtualMember | undefined {
+  return resolver.members[message.authorId];
+}
+
+function displayName(member: VirtualMember | undefined, message: SimMessage): string {
+  if (member) return member.displayName;
+  return message.authorKind === "bot" ? "Wack Hack" : "User";
+}
+
+/** Highest role color for the author, used to tint the username like Discord. */
+function roleColor(
+  member: VirtualMember | undefined,
+  resolver: MentionResolver,
+): string | undefined {
+  for (const id of member?.roles ?? []) {
+    const role = resolver.roles[id];
+    if (role?.color) return role.color;
+  }
+  return undefined;
+}
+
+function formatStamp(iso: string): string {
+  const date = new Date(iso);
+  const today = new Date();
+  const sameDay =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  const time = date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return sameDay ? `Today at ${time}` : `${date.toLocaleDateString("en-US")} ${time}`;
+}
+
+export function MessageGroup({ messages, resolver, onDecide }: MessageGroupProps) {
+  const head = messages[0];
+  const member = authorOf(resolver, head);
+  const name = displayName(member, head);
+  const isBot = head.authorKind === "bot" || Boolean(member?.bot);
+  const color = roleColor(member, resolver);
+
+  return (
+    <div className={styles.group}>
+      <div className={styles.hoverToolbar}>
+        <button type="button" className={styles.hoverBtn} title="Add Reaction">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="12" cy="12" r="9" />
+            <path d="M8.5 14a4 4 0 0 0 7 0" strokeLinecap="round" />
+            <circle cx="9" cy="10" r="0.6" fill="currentColor" stroke="none" />
+            <circle cx="15" cy="10" r="0.6" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
+        <button type="button" className={styles.hoverBtn} title="Reply">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M9 7 4 12l5 5" />
+            <path d="M4 12h10a5 5 0 0 1 5 5v1" />
+          </svg>
+        </button>
+        <button type="button" className={styles.hoverBtn} title="More">
+          ⋯
+        </button>
+      </div>
+      <div className={styles.avatar} style={{ background: avatarColor(head.authorId) }}>
+        {member?.avatarUrl ? (
+          <img className={styles.avatarImg} src={member.avatarUrl} alt="" draggable={false} />
+        ) : (
+          initials(name)
+        )}
+      </div>
+      <div className={styles.groupBody}>
+        <div className={styles.groupHeader}>
+          <span className={styles.authorName} style={color ? { color } : undefined}>
+            {name}
+          </span>
+          {isBot ? (
+            <span className={styles.appBadge}>
+              <span className={styles.appBadgeCheck}>✓</span>App
+            </span>
+          ) : null}
+          <span className={styles.timestampMeta}>{formatStamp(head.createdAt)}</span>
+        </div>
+        {messages.map((message) => (
+          <Message key={message.id} message={message} resolver={resolver} onDecide={onDecide} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/simulator/components/MessageList.tsx
+++ b/src/app/simulator/components/MessageList.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Fragment, useEffect, useRef } from "react";
+
+import type { SimMessage } from "@/lib/simulator/types";
+
+import type { MentionResolver } from "../types.ts";
+
+import { PencilIcon } from "../icons.tsx";
+import styles from "./message-list.module.css";
+import { MessageGroup } from "./MessageGroup.tsx";
+
+function dayKey(iso: string): string {
+  return new Date(iso).toDateString();
+}
+
+function dateLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+interface MessageListProps {
+  messages: SimMessage[];
+  resolver: MentionResolver;
+  channelName: string;
+  onDecide: (decision: "approve" | "deny", approvalId: string) => void;
+}
+
+const GROUP_GAP_MS = 7 * 60 * 1000;
+
+/** Split a flat message list into author-grouped runs (<7min gap, same author). */
+function groupMessages(messages: SimMessage[]): SimMessage[][] {
+  const groups: SimMessage[][] = [];
+  for (const message of messages) {
+    const current = groups[groups.length - 1];
+    const last = current?.[current.length - 1];
+    const continues =
+      last !== undefined &&
+      last.authorId === message.authorId &&
+      new Date(message.createdAt).getTime() - new Date(last.createdAt).getTime() < GROUP_GAP_MS;
+    if (continues) current.push(message);
+    else groups.push([message]);
+  }
+  return groups;
+}
+
+export function MessageList({ messages, resolver, channelName, onDecide }: MessageListProps) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+  const groups = groupMessages(messages);
+
+  // Keep the newest message in view as the bot streams.
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages]);
+
+  return (
+    <div className={styles.list}>
+      {messages.length === 0 ? (
+        <div className={styles.empty}>
+          <div className={styles.emptyIcon}>#</div>
+          <div className={styles.emptyTitle}>Welcome to #{channelName}!</div>
+          <div className={styles.emptyBody}>This is the start of the #{channelName} channel.</div>
+          <a className={styles.emptyEdit} href="#" onClick={(event) => event.preventDefault()}>
+            <PencilIcon />
+            Edit Channel
+          </a>
+        </div>
+      ) : (
+        groups.map((group, index) => {
+          const head = group[0];
+          const previous = groups[index - 1];
+          const showDivider = !previous || dayKey(previous[0].createdAt) !== dayKey(head.createdAt);
+          return (
+            <Fragment key={head.id}>
+              {showDivider ? (
+                <div className={styles.dateDivider}>
+                  <span className={styles.dateDividerLabel}>{dateLabel(head.createdAt)}</span>
+                </div>
+              ) : null}
+              <MessageGroup messages={group} resolver={resolver} onDecide={onDecide} />
+            </Fragment>
+          );
+        })
+      )}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/src/app/simulator/components/TraceInspector.tsx
+++ b/src/app/simulator/components/TraceInspector.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { SimTraceEntry } from "../types.ts";
+
+import styles from "./inspector.module.css";
+
+interface TraceInspectorProps {
+  trace: SimTraceEntry[];
+}
+
+/**
+ * A vertical timeline of the current turn's events — the stream, tool calls
+ * (with durations), approval prompts/decisions, and how it finished. Built from
+ * the same SSE events the chat renders, so it's a faithful "what happened, in
+ * what order" view alongside the message UX.
+ */
+export function TraceInspector({ trace }: TraceInspectorProps) {
+  if (trace.length === 0) {
+    return <p className={styles.empty}>Run a turn to see its execution trace.</p>;
+  }
+  const start = trace[0].ts;
+  return (
+    <ol className={styles.timeline}>
+      {trace.map((entry) => (
+        <li key={`${entry.seq}-${entry.ref ?? entry.kind}`} className={styles.tlRow}>
+          <span
+            className={`${styles.tlDot} ${styles[`tl_${entry.kind.replace("-", "_")}`] ?? ""}`}
+          />
+          <span className={styles.tlTime}>+{((entry.ts - start) / 1000).toFixed(1)}s</span>
+          <div className={styles.tlBody}>
+            <div className={styles.tlLabel}>
+              <span>{entry.label}</span>
+              {typeof entry.durationMs === "number" ? (
+                <span className={styles.tlDur}>{(entry.durationMs / 1000).toFixed(1)}s</span>
+              ) : null}
+            </div>
+            {entry.detail ? <div className={styles.tlDetail}>{entry.detail}</div> : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/simulator/components/code-block.module.css
+++ b/src/app/simulator/components/code-block.module.css
@@ -1,0 +1,30 @@
+.block {
+  margin: 0.25rem 0;
+  background: var(--surface-code);
+  border: 1px solid var(--surface-rail);
+  border-radius: 4px;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.header {
+  padding: 2px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var(--surface-rail);
+}
+
+.pre {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.pre code {
+  font-family: inherit;
+}

--- a/src/app/simulator/components/components.module.css
+++ b/src/app/simulator/components/components.module.css
@@ -1,0 +1,304 @@
+/* Shared styles for the message/embed/button tree. */
+
+/* ---- Buttons ---- */
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 2px 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: var(--text-on-accent);
+  transition: background-color 0.15s ease;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.buttonSuccess {
+  background: var(--btn-green);
+}
+
+.buttonSuccess:not(:disabled):hover {
+  background: var(--btn-green-hover);
+}
+
+.buttonDanger {
+  background: var(--btn-red);
+}
+
+.buttonDanger:not(:disabled):hover {
+  background: var(--btn-red-hover);
+}
+
+.buttonSecondary,
+.buttonPrimary {
+  background: var(--btn-grey);
+}
+
+.buttonPrimary {
+  background: #5865f2;
+}
+
+.buttonSecondary:not(:disabled):hover {
+  background: var(--btn-grey-hover);
+}
+
+.buttonLink {
+  background: var(--btn-grey);
+}
+
+/* ---- Embeds ---- */
+.embed {
+  display: grid;
+  grid-template-columns: 4px 1fr;
+  max-width: 520px;
+  margin-top: 4px;
+  background: var(--surface-embed);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.embedAccent {
+  background: var(--accent-grey);
+}
+
+.embedBody {
+  padding: 8px 16px 16px 12px;
+  min-width: 0;
+}
+
+.embedAuthor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.embedAuthorIcon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.embedTitle {
+  margin: 8px 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.embedDescription {
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: var(--text-normal);
+}
+
+.embedFields {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.embedField {
+  min-width: 0;
+}
+
+.embedFieldName {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 2px;
+}
+
+.embedFieldValue {
+  font-size: 0.875rem;
+  color: var(--text-normal);
+}
+
+.embedFooter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.embedTimestamp::before {
+  content: "•";
+  margin-right: 8px;
+}
+
+/* ---- Reactions ---- */
+.reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.reaction {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 6px;
+  min-height: 22px;
+  background: var(--surface-rail);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.reactionMine {
+  background: var(--mention-bg);
+  border-color: #5865f2;
+  color: var(--mention-text);
+}
+
+.reactionCount {
+  font-weight: 500;
+  font-size: 0.8125rem;
+}
+
+/* ---- Message / group ---- */
+.group {
+  position: relative;
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  padding: 2px 16px;
+  margin-top: 17px;
+}
+
+.group:hover {
+  background: var(--surface-message-hover);
+}
+
+.hoverToolbar {
+  position: absolute;
+  top: -16px;
+  right: 16px;
+  display: none;
+  align-items: center;
+  background: var(--surface-channel);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.group:hover .hoverToolbar {
+  display: flex;
+}
+
+.hoverBtn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hoverBtn:hover {
+  color: var(--text-normal);
+}
+
+.avatar {
+  grid-column: 1;
+  grid-row: 1 / span 99;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-top: 2px;
+  background: #5865f2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--text-on-accent);
+  overflow: hidden;
+}
+
+.avatarImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.groupBody {
+  grid-column: 2;
+  min-width: 0;
+}
+
+.groupHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  line-height: 1.375;
+}
+
+.authorName {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-bright);
+}
+
+.appBadge {
+  display: inline-flex;
+  align-items: center;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: var(--app-badge-bg);
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--text-on-accent);
+}
+
+.appBadgeCheck {
+  font-size: 0.5rem;
+  margin-right: 2px;
+}
+
+.timestampMeta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.message {
+  position: relative;
+  padding: 1px 0;
+}
+
+.messageContent {
+  font-size: 1rem;
+  color: var(--text-normal);
+}
+
+.editedTag {
+  margin-left: 4px;
+  font-size: 0.625rem;
+  color: var(--text-muted);
+}

--- a/src/app/simulator/components/composer.module.css
+++ b/src/app/simulator/components/composer.module.css
@@ -1,0 +1,154 @@
+.composer {
+  position: relative;
+  padding: 0 16px 24px;
+  flex-shrink: 0;
+}
+
+.inputWrap {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  background: var(--surface-input);
+  border-radius: 8px;
+  padding: 0 16px;
+}
+
+.plus {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 24px;
+  height: 24px;
+  margin-right: 4px;
+  border: none;
+  border-radius: 50%;
+  background: var(--text-muted);
+  color: var(--surface-input);
+  font-size: 1.25rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plus:hover {
+  background: var(--text-normal);
+}
+
+.input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  resize: none;
+  padding: 11px 8px;
+  max-height: 200px;
+  font-size: 1rem;
+  line-height: 1.375;
+  color: var(--text-normal);
+}
+
+.input::placeholder {
+  color: var(--text-faint);
+}
+
+.input:disabled {
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  height: 44px;
+}
+
+.actionBtn {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.actionBtn:hover {
+  color: var(--text-normal);
+}
+
+/* ----------------------------------------------------------- autocomplete */
+.autocomplete {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: calc(100% - 16px);
+  background: var(--surface-rail);
+  border-radius: 8px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.24);
+  overflow: hidden;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.autocompleteHeader {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 8px 12px 4px;
+}
+
+.suggestion {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  text-align: left;
+  color: var(--text-channel);
+}
+
+.suggestionActive {
+  background: var(--brand);
+  color: var(--text-bright);
+}
+
+.suggestionGlyph {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  background: var(--surface-hover);
+}
+
+.suggestionImg {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.suggestionLabel {
+  font-weight: 500;
+}
+
+.suggestionDetail {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.suggestionActive .suggestionDetail {
+  color: var(--mention-text);
+}

--- a/src/app/simulator/components/control-panel.module.css
+++ b/src/app/simulator/components/control-panel.module.css
@@ -1,0 +1,89 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  padding: 16px;
+  background: var(--surface-sidebar);
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.statusDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.status_idle {
+  background: var(--text-muted);
+}
+
+.status_streaming {
+  background: var(--accent-amber);
+}
+
+.status_done {
+  background: var(--accent-green);
+}
+
+.status_error {
+  background: var(--accent-red);
+}
+
+.statusLabel {
+  font-size: 0.8125rem;
+  text-transform: capitalize;
+  color: var(--text-normal);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.select,
+.input {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--surface-rail);
+  border: 1px solid #1e1f22;
+  border-radius: 4px;
+  color: var(--text-normal);
+  font-size: 0.875rem;
+}
+
+.select:focus,
+.input:focus {
+  outline: none;
+  border-color: #5865f2;
+}
+
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--text-normal);
+}
+
+.hint {
+  margin: 4px 0 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}

--- a/src/app/simulator/components/inspector.module.css
+++ b/src/app/simulator/components/inspector.module.css
@@ -1,0 +1,311 @@
+/* Shared styling for the read-only inspector tabs (Context + Trace). */
+
+.empty {
+  padding: 24px 16px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.body {
+  padding: 12px 14px 32px;
+  font-size: 0.8125rem;
+  color: var(--text-normal);
+}
+
+/* ----------------------------------------------------------- key/value grid */
+.kvGrid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 0 0 12px;
+}
+
+.k {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.v {
+  margin: 0;
+  color: var(--text-bright);
+  word-break: break-word;
+}
+
+.h3 {
+  margin: 16px 0 6px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-faint);
+}
+
+/* ---------------------------------------------------------- context budget */
+.bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.barRow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.barHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.barNum {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.barTrack {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--surface-rail);
+  overflow: hidden;
+}
+
+.barFill {
+  height: 100%;
+  border-radius: 3px;
+  background: var(--brand);
+}
+
+.subItems {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.subItems li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* -------------------------------------------------------------- collapsibles */
+.details {
+  margin-top: 12px;
+  border: 1px solid var(--surface-rail);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.summary {
+  padding: 8px 10px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-bright);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+
+.summary:hover {
+  background: var(--surface-hover);
+}
+
+.count {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.pre {
+  margin: 0;
+  padding: 10px;
+  max-height: 360px;
+  overflow: auto;
+  border-top: 1px solid var(--surface-rail);
+  background: var(--surface-code);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* -------------------------------------------------------------------- tools */
+.toolList {
+  list-style: none;
+  margin: 0;
+  padding: 6px 10px;
+  border-top: 1px solid var(--surface-rail);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.toolItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toolName {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent-green);
+}
+
+.toolDesc {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+/* ------------------------------------------------------------- conversation */
+.msgList {
+  list-style: none;
+  margin: 0;
+  padding: 8px 10px;
+  border-top: 1px solid var(--surface-rail);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.msgRow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.roleTag {
+  align-self: flex-start;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.roleUser {
+  background: rgba(88, 101, 242, 0.18);
+  color: #c4caff;
+}
+
+.roleAssistant {
+  background: rgba(52, 211, 153, 0.16);
+  color: #8ee9c4;
+}
+
+.msgContent {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-normal);
+}
+
+/* --------------------------------------------------------------- trace timeline */
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 12px 14px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tlRow {
+  display: grid;
+  grid-template-columns: 12px 44px 1fr;
+  gap: 8px;
+  align-items: start;
+  padding: 4px 0;
+}
+
+.tlDot {
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.tl_turn {
+  background: var(--brand);
+}
+
+.tl_tool {
+  background: var(--accent-amber, #ffaa00);
+}
+
+.tl_tool_done {
+  background: var(--accent-green);
+}
+
+.tl_tool_error,
+.tl_error {
+  background: #ef4444;
+}
+
+.tl_approval {
+  background: #ffaa00;
+}
+
+.tl_decision {
+  background: #9ca3af;
+}
+
+.tl_finish {
+  background: var(--accent-green);
+}
+
+.tlTime {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-faint);
+  text-align: right;
+}
+
+.tlBody {
+  min-width: 0;
+}
+
+.tlLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8125rem;
+  color: var(--text-bright);
+  word-break: break-word;
+}
+
+.tlDur {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  background: var(--surface-rail);
+  border-radius: 3px;
+  padding: 0 5px;
+}
+
+.tlDetail {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  word-break: break-word;
+}

--- a/src/app/simulator/components/message-list.module.css
+++ b/src/app/simulator/components/message-list.module.css
@@ -1,0 +1,67 @@
+.list {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding-bottom: 24px;
+}
+
+.empty {
+  padding: 16px 16px 24px;
+  margin-top: auto;
+}
+
+.emptyIcon {
+  width: 80px;
+  height: 80px;
+  border-radius: 28px;
+  background: var(--surface-active);
+  color: var(--text-bright);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  font-weight: 400;
+  margin-bottom: 8px;
+}
+
+.emptyTitle {
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--text-bright);
+  line-height: 1.25;
+}
+
+.emptyBody {
+  margin-top: 4px;
+  font-size: 1rem;
+  color: var(--text-muted);
+  max-width: 440px;
+}
+
+.emptyEdit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  font-size: 0.95rem;
+  color: var(--text-link);
+}
+
+.dateDivider {
+  display: flex;
+  align-items: center;
+  margin: 24px 16px 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.dateDividerLabel {
+  margin: 0 auto;
+  transform: translateY(-50%);
+  padding: 0 8px;
+  background: var(--surface-channel);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}

--- a/src/app/simulator/discord-markdown.module.css
+++ b/src/app/simulator/discord-markdown.module.css
@@ -1,0 +1,121 @@
+.markdown {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.paragraph {
+  margin: 0;
+}
+
+.paragraph + .paragraph {
+  margin-top: 0.25rem;
+}
+
+.subtext {
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  color: var(--text-muted);
+}
+
+.h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.375;
+  margin: 0.5rem 0 0;
+  color: var(--text-bright);
+}
+
+.h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.375;
+  margin: 0.5rem 0 0;
+  color: var(--text-bright);
+}
+
+.h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.375;
+  margin: 0.5rem 0 0;
+  color: var(--text-bright);
+}
+
+.blockquote {
+  margin: 0.125rem 0;
+  padding: 0 0.75rem;
+  border-left: 4px solid #4e5058;
+  color: var(--text-normal);
+}
+
+.inlineCode {
+  background: var(--surface-rail);
+  border-radius: 4px;
+  padding: 0.1em 0.3em;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  white-space: pre-wrap;
+}
+
+.list {
+  margin: 0.125rem 0;
+  padding-left: 1.5rem;
+}
+
+.list li {
+  margin: 0.0625rem 0;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.mention {
+  background: var(--mention-bg);
+  color: var(--mention-text);
+  border-radius: 4px;
+  padding: 0 2px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.mention:hover {
+  background: var(--mention-hover-bg);
+  color: var(--text-on-accent);
+}
+
+.roleMention {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 4px;
+  padding: 0 2px;
+  font-weight: 500;
+}
+
+.timestamp {
+  background: var(--mention-bg);
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
+.emoji {
+  width: 1.375em;
+  height: 1.375em;
+  vertical-align: bottom;
+  object-fit: contain;
+}
+
+.spoiler {
+  background: var(--spoiler-bg);
+  border-radius: 4px;
+  padding: 0 2px;
+  cursor: pointer;
+  color: transparent;
+  transition: color 0.1s ease;
+}
+
+.spoiler:hover,
+.spoiler:focus,
+.spoiler[data-revealed="true"] {
+  color: var(--text-normal);
+}

--- a/src/app/simulator/discord-markdown.test.ts
+++ b/src/app/simulator/discord-markdown.test.ts
@@ -1,0 +1,106 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { VirtualMember } from "@/lib/simulator/types";
+
+import { SIM_USER_ID } from "@/lib/simulator/constants";
+
+import type { MentionResolver } from "./types.ts";
+
+import { renderMarkdown } from "./discord-markdown.tsx";
+
+const EMPTY: MentionResolver = { members: {}, channels: {}, roles: {}, emojis: {} };
+
+function html(content: string, resolver: MentionResolver = EMPTY): string {
+  return renderToStaticMarkup(renderMarkdown(content, resolver));
+}
+
+describe("renderMarkdown", () => {
+  it("renders -# as muted subtext, not a heading", () => {
+    const out = html("-# foo");
+    expect(out).toContain("subtext");
+    expect(out).not.toContain("<h1");
+    expect(out).not.toContain("<h2");
+    expect(out).not.toContain("<h3");
+    expect(out).toContain("foo");
+  });
+
+  it("renders __x__ as underline, not bold", () => {
+    const out = html("__x__");
+    expect(out).toContain("underline");
+    expect(out).not.toContain("<strong>");
+  });
+
+  it("renders **x** as bold", () => {
+    expect(html("**x**")).toContain("<strong>");
+  });
+
+  it("renders the bot footer line as small subtext", () => {
+    const out = html("-# `abc` · 3.2s · 1,423 tokens");
+    expect(out).toContain("subtext");
+    expect(out).toContain("3.2s");
+    expect(out).toContain("1,423 tokens");
+    // The inline code inside the footer still renders as code.
+    expect(out).toContain("<code");
+    expect(out).toContain("abc");
+  });
+
+  it("groups consecutive > lines into one blockquote", () => {
+    const out = html("> quote line one\n> quote line two");
+    expect(out).toContain("<blockquote");
+    expect(out).toContain("quote line one");
+    expect(out).toContain("quote line two");
+    // One blockquote, not two.
+    expect(out.match(/<blockquote/g)?.length).toBe(1);
+  });
+
+  it("resolves a user mention to the member display name", () => {
+    const member: VirtualMember = {
+      id: SIM_USER_ID,
+      username: "rayhan",
+      displayName: "Ray",
+      roles: [],
+    };
+    const resolver: MentionResolver = {
+      ...EMPTY,
+      members: { [SIM_USER_ID]: member },
+    };
+    const out = html(`hello <@${SIM_USER_ID}>`, resolver);
+    expect(out).toContain("@Ray");
+    expect(out).not.toContain(SIM_USER_ID);
+  });
+
+  it("renders headings capped at h3", () => {
+    expect(html("# Big")).toContain("<h1");
+    expect(html("## Mid")).toContain("<h2");
+    expect(html("### Small")).toContain("<h3");
+  });
+
+  it("renders a fenced code block literally", () => {
+    const out = html("```py\ncreate_channel(\n    name=demo,\n)\n```");
+    expect(out).toContain("<pre");
+    expect(out).toContain("create_channel(");
+    // Inline markdown inside the fence is NOT interpreted.
+    expect(out).not.toContain("<strong>");
+  });
+
+  it("renders a spoiler span", () => {
+    expect(html("||secret||")).toContain("spoiler");
+  });
+
+  it("renders a custom emoji as a CDN image", () => {
+    const out = html("<:wave:12345>");
+    expect(out).toContain("https://cdn.discordapp.com/emojis/12345.png");
+    expect(out).toContain('alt=":wave:"');
+  });
+
+  it("renders an animated custom emoji as a gif", () => {
+    expect(html("<a:dance:67890>")).toContain("https://cdn.discordapp.com/emojis/67890.gif");
+  });
+
+  it("renders a masked link", () => {
+    const out = html("[Docs](https://example.com)");
+    expect(out).toContain('href="https://example.com"');
+    expect(out).toContain(">Docs<");
+  });
+});

--- a/src/app/simulator/discord-markdown.tsx
+++ b/src/app/simulator/discord-markdown.tsx
@@ -1,0 +1,473 @@
+import { type ReactNode, useState } from "react";
+
+import type { MentionResolver } from "./types.ts";
+
+import { CodeBlock } from "./components/CodeBlock.tsx";
+import styles from "./discord-markdown.module.css";
+
+/**
+ * A hand-rolled subset of Discord's message markdown. We do NOT reuse an HTML
+ * pipeline because the real client supports things common libraries miss:
+ * `-#` subtext (rendered muted, NOT a heading), `||spoilers||`, and
+ * `__underline__` (underline, not bold). Block parsing is line-oriented and
+ * ORDER-SENSITIVE; inline parsing is a single left-to-right scan.
+ */
+
+const CDN = "https://cdn.discordapp.com/emojis";
+
+let keySeq = 0;
+function nextKey(prefix: string): string {
+  keySeq += 1;
+  return `${prefix}-${keySeq}`;
+}
+
+// ---------------------------------------------------------------------------
+// Inline pass
+// ---------------------------------------------------------------------------
+
+function resolveMember(resolver: MentionResolver, id: string): string {
+  return resolver.members[id]?.displayName ?? "unknown-user";
+}
+
+function formatTimestamp(unix: number, style: string | undefined): string {
+  const date = new Date(unix * 1000);
+  if (Number.isNaN(date.getTime())) return `<t:${unix}>`;
+  switch (style) {
+    case "t":
+      return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    case "T":
+      return date.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+    case "d":
+      return date.toLocaleDateString("en-US");
+    case "D":
+      return date.toLocaleDateString("en-US", { dateStyle: "long" });
+    case "R":
+      return relativeTime(date);
+    case "F":
+      return date.toLocaleString("en-US", { dateStyle: "full", timeStyle: "short" });
+    default:
+      return date.toLocaleString("en-US", { dateStyle: "long", timeStyle: "short" });
+  }
+}
+
+function relativeTime(date: Date): string {
+  const diffMs = date.getTime() - Date.now();
+  const abs = Math.abs(diffMs);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const fmt = (n: number, unit: string): string => {
+    const rounded = Math.round(n);
+    const plural = rounded === 1 ? unit : `${unit}s`;
+    return diffMs < 0 ? `${rounded} ${plural} ago` : `in ${rounded} ${plural}`;
+  };
+  if (abs < hour) return fmt(abs / minute, "minute");
+  if (abs < day) return fmt(abs / hour, "hour");
+  return fmt(abs / day, "day");
+}
+
+interface InlineToken {
+  /** Regex matched at the scan position. Capture groups feed `render`. */
+  pattern: RegExp;
+  render: (match: RegExpExecArray, resolver: MentionResolver) => ReactNode;
+}
+
+/** Mention + emoji + timestamp tokens (rendered atomically, never recursed). */
+function atomicTokens(): InlineToken[] {
+  return [
+    {
+      pattern: /^<a?:(\w+):(\d+)>/,
+      render: (m) => {
+        const animated = m[0].startsWith("<a:");
+        return (
+          <img
+            key={nextKey("emoji")}
+            className={styles.emoji}
+            src={`${CDN}/${m[2]}.${animated ? "gif" : "png"}`}
+            alt={`:${m[1]}:`}
+            draggable={false}
+          />
+        );
+      },
+    },
+    {
+      pattern: /^<@!?(\d+)>/,
+      render: (m, r) => (
+        <span key={nextKey("um")} className={styles.mention}>
+          @{resolveMember(r, m[1])}
+        </span>
+      ),
+    },
+    {
+      pattern: /^<#(\d+)>/,
+      render: (m, r) => (
+        <span key={nextKey("cm")} className={styles.mention}>
+          #{r.channels[m[1]]?.name ?? "unknown-channel"}
+        </span>
+      ),
+    },
+    {
+      pattern: /^<@&(\d+)>/,
+      render: (m, r) => {
+        const role = r.roles[m[1]];
+        return (
+          <span
+            key={nextKey("rm")}
+            className={styles.roleMention}
+            style={role?.color ? { color: role.color } : undefined}
+          >
+            @{role?.name ?? "unknown-role"}
+          </span>
+        );
+      },
+    },
+    {
+      pattern: /^<t:(-?\d+)(?::([tTdDfFR]))?>/,
+      render: (m) => (
+        <span key={nextKey("ts")} className={styles.timestamp}>
+          {formatTimestamp(Number(m[1]), m[2])}
+        </span>
+      ),
+    },
+  ];
+}
+
+/** Emphasis/wrapper tokens whose inner content is recursively parsed. */
+function wrapperTokens(): InlineToken[] {
+  const recur = (inner: string, r: MentionResolver): ReactNode => renderInline(inner, r);
+  return [
+    {
+      pattern: /^`([^`]+)`/,
+      render: (m) => (
+        <code key={nextKey("code")} className={styles.inlineCode}>
+          {m[1]}
+        </code>
+      ),
+    },
+    {
+      pattern: /^\|\|([\s\S]+?)\|\|/,
+      render: (m, r) => <Spoiler key={nextKey("spoiler")}>{recur(m[1], r)}</Spoiler>,
+    },
+    {
+      pattern: /^\*\*([\s\S]+?)\*\*/,
+      render: (m, r) => <strong key={nextKey("b")}>{recur(m[1], r)}</strong>,
+    },
+    {
+      pattern: /^__([\s\S]+?)__/,
+      render: (m, r) => (
+        <span key={nextKey("u")} className={styles.underline}>
+          {recur(m[1], r)}
+        </span>
+      ),
+    },
+    {
+      pattern: /^~~([\s\S]+?)~~/,
+      render: (m, r) => <s key={nextKey("s")}>{recur(m[1], r)}</s>,
+    },
+    {
+      pattern: /^\*([\s\S]+?)\*/,
+      render: (m, r) => <em key={nextKey("i")}>{recur(m[1], r)}</em>,
+    },
+    {
+      pattern: /^_([^_]+?)_/,
+      render: (m, r) => <em key={nextKey("i")}>{recur(m[1], r)}</em>,
+    },
+    {
+      pattern: /^\[([^\]]+)\]\(([^)\s]+)\)/,
+      render: (m, r) => (
+        <a key={nextKey("a")} href={m[2]} target="_blank" rel="noreferrer noopener">
+          {recur(m[1], r)}
+        </a>
+      ),
+    },
+  ];
+}
+
+const ALL_TOKENS = [...wrapperTokens(), ...atomicTokens()];
+
+/** Left-to-right inline scan: at each position try every token, else take a char. */
+function renderInline(text: string, resolver: MentionResolver): ReactNode[] {
+  const out: ReactNode[] = [];
+  let buffer = "";
+  let i = 0;
+  const flush = (): void => {
+    if (buffer) {
+      out.push(buffer);
+      buffer = "";
+    }
+  };
+  while (i < text.length) {
+    const slice = text.slice(i);
+    let matched = false;
+    for (const token of ALL_TOKENS) {
+      const m = token.pattern.exec(slice);
+      if (m) {
+        flush();
+        out.push(token.render(m, resolver));
+        i += m[0].length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      buffer += text[i];
+      i += 1;
+    }
+  }
+  flush();
+  return out;
+}
+
+interface SpoilerProps {
+  children: ReactNode;
+}
+
+function Spoiler({ children }: SpoilerProps) {
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <span
+      className={styles.spoiler}
+      data-revealed={revealed}
+      role="button"
+      tabIndex={0}
+      onClick={() => setRevealed(true)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") setRevealed(true);
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Block pass
+// ---------------------------------------------------------------------------
+
+type Block =
+  | { kind: "subtext"; text: string }
+  | { kind: "heading"; level: 1 | 2 | 3; text: string }
+  | { kind: "quote"; lines: string[] }
+  | { kind: "code"; lang: string; code: string }
+  | { kind: "list"; ordered: boolean; items: string[] }
+  | { kind: "para"; lines: string[] };
+
+function headingLevel(line: string): 1 | 2 | 3 | null {
+  if (line.startsWith("### ")) return 3;
+  if (line.startsWith("## ")) return 2;
+  if (line.startsWith("# ")) return 1;
+  return null;
+}
+
+function listMarker(line: string): { ordered: boolean; content: string } | null {
+  if (/^[-*] /.test(line)) return { ordered: false, content: line.slice(2) };
+  const ordered = /^(\d+)\. (.*)$/.exec(line);
+  if (ordered) return { ordered: true, content: ordered[2] };
+  return null;
+}
+
+interface Consumed {
+  block: Block;
+  next: number;
+}
+
+/** Try to start a single-line block (fence/subtext/heading) at `i`. */
+function consumeSingleLine(lines: string[], i: number): Consumed | null {
+  const line = lines[i];
+  if (line.startsWith("```")) return consumeFence(lines, i);
+  if (line.startsWith("-# ")) {
+    return { block: { kind: "subtext", text: line.slice(3) }, next: i + 1 };
+  }
+  const level = headingLevel(line);
+  if (level) {
+    return { block: { kind: "heading", level, text: line.slice(level + 1) }, next: i + 1 };
+  }
+  return null;
+}
+
+function isQuoteLine(line: string): boolean {
+  return line.startsWith("> ") || line === ">";
+}
+
+function consumeQuote(lines: string[], start: number): Consumed {
+  const quote: string[] = [];
+  let i = start;
+  while (i < lines.length && isQuoteLine(lines[i])) {
+    quote.push(lines[i] === ">" ? "" : lines[i].slice(2));
+    i += 1;
+  }
+  return { block: { kind: "quote", lines: quote }, next: i };
+}
+
+function consumeList(lines: string[], start: number, first: { ordered: boolean }): Consumed {
+  const items: string[] = [];
+  let ordered = first.ordered;
+  let i = start;
+  while (i < lines.length) {
+    const marker = listMarker(lines[i]);
+    if (!marker) break;
+    ordered = marker.ordered;
+    items.push(marker.content);
+    i += 1;
+  }
+  return { block: { kind: "list", ordered, items }, next: i };
+}
+
+function consumePara(lines: string[], start: number): Consumed {
+  const para: string[] = [];
+  let i = start;
+  while (i < lines.length && !isBlockStart(lines[i]) && lines[i].trim() !== "") {
+    para.push(lines[i]);
+    i += 1;
+  }
+  return { block: { kind: "para", lines: para }, next: i };
+}
+
+/** Consume one block starting at `i`; `null` for a blank line (caller skips). */
+function consumeBlock(lines: string[], i: number): Consumed | null {
+  const single = consumeSingleLine(lines, i);
+  if (single) return single;
+  const line = lines[i];
+  if (isQuoteLine(line)) return consumeQuote(lines, i);
+  const marker = listMarker(line);
+  if (marker) return consumeList(lines, i, marker);
+  if (line.trim() === "") return null;
+  return consumePara(lines, i);
+}
+
+/** Group lines into blocks. Order of checks matters: `-#` before `#` headings. */
+function parseBlocks(content: string): Block[] {
+  const lines = content.split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const consumed = consumeBlock(lines, i);
+    if (!consumed) {
+      i += 1;
+      continue;
+    }
+    blocks.push(consumed.block);
+    i = consumed.next;
+  }
+  return blocks;
+}
+
+function isBlockStart(line: string): boolean {
+  return (
+    line.startsWith("```") ||
+    line.startsWith("-# ") ||
+    headingLevel(line) !== null ||
+    line.startsWith("> ") ||
+    line === ">" ||
+    listMarker(line) !== null
+  );
+}
+
+function consumeFence(lines: string[], start: number): Consumed {
+  const lang = lines[start].slice(3).trim();
+  const body: string[] = [];
+  let i = start + 1;
+  while (i < lines.length && !lines[i].startsWith("```")) {
+    body.push(lines[i]);
+    i += 1;
+  }
+  // Skip the closing fence if present.
+  const next = i < lines.length ? i + 1 : i;
+  return { block: { kind: "code", lang, code: body.join("\n") }, next };
+}
+
+// ---------------------------------------------------------------------------
+// Block → React
+// ---------------------------------------------------------------------------
+
+function renderBlock(block: Block, resolver: MentionResolver): ReactNode {
+  switch (block.kind) {
+    case "subtext":
+      return (
+        <div key={nextKey("sub")} className={styles.subtext}>
+          {renderInline(block.text, resolver)}
+        </div>
+      );
+    case "heading":
+      return renderHeading(block.level, renderInline(block.text, resolver));
+    case "code":
+      return <CodeBlock key={nextKey("pre")} lang={block.lang} code={block.code} />;
+    case "quote":
+      return (
+        <blockquote key={nextKey("q")} className={styles.blockquote}>
+          {renderMultiline(block.lines, resolver)}
+        </blockquote>
+      );
+    case "list":
+      return renderList(block, resolver);
+    case "para":
+      return (
+        <p key={nextKey("p")} className={styles.paragraph}>
+          {renderMultiline(block.lines, resolver)}
+        </p>
+      );
+    default:
+      return null;
+  }
+}
+
+function renderHeading(level: 1 | 2 | 3, children: ReactNode): ReactNode {
+  const key = nextKey("h");
+  if (level === 1)
+    return (
+      <h1 key={key} className={styles.h1}>
+        {children}
+      </h1>
+    );
+  if (level === 2)
+    return (
+      <h2 key={key} className={styles.h2}>
+        {children}
+      </h2>
+    );
+  return (
+    <h3 key={key} className={styles.h3}>
+      {children}
+    </h3>
+  );
+}
+
+function renderList(block: Extract<Block, { kind: "list" }>, resolver: MentionResolver): ReactNode {
+  const items = block.items.map((item) => (
+    <li key={nextKey("li")}>{renderInline(item, resolver)}</li>
+  ));
+  return block.ordered ? (
+    <ol key={nextKey("ol")} className={styles.list}>
+      {items}
+    </ol>
+  ) : (
+    <ul key={nextKey("ul")} className={styles.list}>
+      {items}
+    </ul>
+  );
+}
+
+/** Render lines joined by <br/>, each line inline-parsed. */
+function renderMultiline(lines: string[], resolver: MentionResolver): ReactNode[] {
+  const out: ReactNode[] = [];
+  lines.forEach((line, idx) => {
+    if (idx > 0) out.push(<br key={nextKey("br")} />);
+    out.push(...renderInline(line, resolver));
+  });
+  return out;
+}
+
+/**
+ * Render a Discord-flavored markdown string to React. `resolver` supplies the
+ * lookups for mentions/emoji; pass an empty resolver for plain content.
+ */
+export function renderMarkdown(content: string, resolver: MentionResolver): ReactNode {
+  const blocks = parseBlocks(content);
+  return (
+    <div className={styles.markdown}>{blocks.map((block) => renderBlock(block, resolver))}</div>
+  );
+}

--- a/src/app/simulator/icons.tsx
+++ b/src/app/simulator/icons.tsx
@@ -1,0 +1,49 @@
+// Monochrome chrome icons (currentColor) matching Discord's muted grey
+// composer + user-panel glyphs — colorful emoji would break the Discord look.
+
+const S = {
+  fill: "none" as const,
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export function GiftIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" {...S} aria-hidden="true">
+      <rect x="3" y="9" width="18" height="4" rx="1" />
+      <path d="M5 13v7a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-7M12 9v12" />
+      <path d="M12 9C12 6 10.5 4 8.8 4a2 2 0 0 0 0 5zM12 9c0-3 1.5-5 3.2-5a2 2 0 0 1 0 5z" />
+    </svg>
+  );
+}
+
+export function StickerIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" {...S} aria-hidden="true">
+      <path d="M14 4H6a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8l6-6V6a2 2 0 0 0-2-2z" />
+      <path d="M14 20v-4a2 2 0 0 1 2-2h4" />
+    </svg>
+  );
+}
+
+export function EmojiIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" {...S} aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M8.5 14a4 4 0 0 0 7 0" />
+      <circle cx="9" cy="10" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="10" r="0.7" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function PencilIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" {...S} aria-hidden="true">
+      <path d="M4 20h4L19 9a2 2 0 0 0-3-3L5 17v3z" />
+      <path d="M14.5 6.5l3 3" />
+    </svg>
+  );
+}

--- a/src/app/simulator/layout.tsx
+++ b/src/app/simulator/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { notFound } from "next/navigation";
+
+import { isSimEnabled } from "@/lib/simulator/guard";
+
+/**
+ * Gate the dev-only simulator UI exactly like its API routes (`server/index.ts`):
+ * a deployment runs with `NODE_ENV=production`, so `isSimEnabled()` is false and
+ * the whole `/simulator` segment 404s rather than serving a UI whose backend
+ * isn't mounted. Renders only under local `next dev` with `SIMULATOR_ENABLED=1`.
+ * Server component (no "use client") so it can read the gate's env server-side.
+ */
+export default function SimulatorLayout({ children }: { children: ReactNode }) {
+  if (!isSimEnabled()) notFound();
+  return children;
+}

--- a/src/app/simulator/message-store.test.ts
+++ b/src/app/simulator/message-store.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import type { SimEvent, SimMessage } from "@/lib/simulator/types";
+
+import { SIM_BOT_ID, SIM_USER_ID } from "@/lib/simulator/constants";
+
+import { initialSimState, reduceSim } from "./message-store.ts";
+
+let seq = 0;
+
+function base(): { seq: number; ts: number; runId: string } {
+  return { seq: seq++, ts: Date.now(), runId: "run-1" };
+}
+
+function makeMessage(id: string, overrides: Partial<SimMessage> = {}): SimMessage {
+  return {
+    id,
+    channelId: "chan-1",
+    authorId: SIM_BOT_ID,
+    authorKind: "bot",
+    content: "",
+    embeds: [],
+    components: [],
+    reactions: [],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function create(id: string, overrides?: Partial<SimMessage>): SimEvent {
+  return { ...base(), type: "message.create", message: makeMessage(id, overrides) };
+}
+
+describe("reduceSim", () => {
+  it("starts empty and idle", () => {
+    const state = initialSimState();
+    expect(state.order).toEqual([]);
+    expect(state.byId).toEqual({});
+    expect(state.status).toBe("idle");
+  });
+
+  it("handles create → edit → delete preserving order", () => {
+    let state = initialSimState();
+    state = reduceSim(state, create("a", { content: "> Thinking..." }));
+    state = reduceSim(state, create("b", { content: "second" }));
+
+    expect(state.order).toEqual(["a", "b"]);
+    expect(state.byId["a"].content).toBe("> Thinking...");
+
+    state = reduceSim(state, {
+      ...base(),
+      type: "message.edit",
+      messageId: "a",
+      channelId: "chan-1",
+      content: "Hello world\n\n-# `abc` · 3.2s · 1,423 tokens",
+      editedAt: new Date().toISOString(),
+    });
+
+    expect(state.byId["a"].content).toBe("Hello world\n\n-# `abc` · 3.2s · 1,423 tokens");
+    expect(state.byId["a"].editedAt).toBeDefined();
+    // Order unchanged by an edit.
+    expect(state.order).toEqual(["a", "b"]);
+
+    state = reduceSim(state, {
+      ...base(),
+      type: "message.delete",
+      messageId: "a",
+      channelId: "chan-1",
+    });
+
+    expect(state.order).toEqual(["b"]);
+    expect(state.byId["a"]).toBeUndefined();
+  });
+
+  it("edit only patches provided fields and leaves content intact when omitted", () => {
+    let state = initialSimState();
+    state = reduceSim(state, create("a", { content: "keep me" }));
+    state = reduceSim(state, {
+      ...base(),
+      type: "message.edit",
+      messageId: "a",
+      channelId: "chan-1",
+      components: [],
+      editedAt: new Date().toISOString(),
+    });
+    expect(state.byId["a"].content).toBe("keep me");
+  });
+
+  it("ignores edits and deletes for unknown messages", () => {
+    const start = initialSimState();
+    const afterEdit = reduceSim(start, {
+      ...base(),
+      type: "message.edit",
+      messageId: "ghost",
+      channelId: "chan-1",
+      content: "x",
+      editedAt: new Date().toISOString(),
+    });
+    expect(afterEdit).toBe(start);
+    const afterDelete = reduceSim(start, {
+      ...base(),
+      type: "message.delete",
+      messageId: "ghost",
+      channelId: "chan-1",
+    });
+    expect(afterDelete).toBe(start);
+  });
+
+  it("adds and aggregates reactions immutably", () => {
+    let state = initialSimState();
+    state = reduceSim(state, create("a"));
+    const before = state.byId["a"];
+
+    state = reduceSim(state, {
+      ...base(),
+      type: "reaction.add",
+      messageId: "a",
+      channelId: "chan-1",
+      emoji: "👍",
+      byBot: true,
+    });
+    expect(state.byId["a"].reactions).toEqual([{ emoji: "👍", count: 1, me: false }]);
+    // Did not mutate the previous message object.
+    expect(before.reactions).toEqual([]);
+
+    state = reduceSim(state, {
+      ...base(),
+      type: "reaction.add",
+      messageId: "a",
+      channelId: "chan-1",
+      emoji: "👍",
+      byBot: false,
+    });
+    expect(state.byId["a"].reactions).toEqual([{ emoji: "👍", count: 2, me: true }]);
+  });
+
+  it("removes reactions and drops them at zero", () => {
+    let state = initialSimState();
+    state = reduceSim(state, create("a", { reactions: [{ emoji: "🔥", count: 1, me: true }] }));
+    state = reduceSim(state, {
+      ...base(),
+      type: "reaction.remove",
+      messageId: "a",
+      channelId: "chan-1",
+      emoji: "🔥",
+      byBot: false,
+    });
+    expect(state.byId["a"].reactions).toEqual([]);
+  });
+
+  it("tracks run status transitions", () => {
+    let state = initialSimState();
+    state = reduceSim(state, {
+      ...base(),
+      type: "run.start",
+      turnIndex: 0,
+      channelId: "chan-1",
+    });
+    expect(state.status).toBe("streaming");
+    state = reduceSim(state, {
+      ...base(),
+      type: "run.finish",
+      turnIndex: 0,
+      discordMessageId: "a",
+      model: "claude",
+      text: "done",
+      usage: {
+        totalTokens: 1,
+        inputTokens: 1,
+        outputTokens: 0,
+        toolCallCount: 0,
+        stepCount: 1,
+        toolNames: [],
+      },
+    });
+    expect(state.status).toBe("done");
+    state = reduceSim(state, { ...base(), type: "run.error", message: "boom" });
+    expect(state.status).toBe("error");
+  });
+
+  it("stores the guild snapshot on guild.sync", () => {
+    let state = initialSimState();
+    state = reduceSim(state, {
+      ...base(),
+      type: "guild.sync",
+      guild: {
+        guildId: "g",
+        botUserId: SIM_BOT_ID,
+        channels: [],
+        members: [{ id: SIM_USER_ID, username: "u", displayName: "User", roles: [] }],
+        roles: [],
+        emojis: [],
+        messages: [],
+      },
+    });
+    expect(state.guild?.members[0].id).toBe(SIM_USER_ID);
+  });
+});

--- a/src/app/simulator/message-store.ts
+++ b/src/app/simulator/message-store.ts
@@ -1,0 +1,256 @@
+import type { SimEvent, SimMessage, SimReaction, VirtualChannel } from "@/lib/simulator/types";
+
+import type { SimAction, SimState, SimTraceEntry } from "./types.ts";
+
+export function initialSimState(): SimState {
+  return {
+    order: [],
+    byId: {},
+    channels: {},
+    channelOrder: [],
+    threadStarters: {},
+    trace: [],
+    status: "idle",
+  };
+}
+
+/** Append a message, ignoring duplicate ids (idempotent on replay). */
+function applyCreate(state: SimState, message: SimMessage): SimState {
+  if (state.byId[message.id]) {
+    return { ...state, byId: { ...state.byId, [message.id]: message } };
+  }
+  return {
+    ...state,
+    order: [...state.order, message.id],
+    byId: { ...state.byId, [message.id]: message },
+  };
+}
+
+/** Patch the parts a `message.edit` carries; absent fields are left untouched. */
+function applyEdit(state: SimState, event: Extract<SimEvent, { type: "message.edit" }>): SimState {
+  const existing = state.byId[event.messageId];
+  if (!existing) return state;
+  const next: SimMessage = {
+    ...existing,
+    editedAt: event.editedAt,
+    ...(event.content !== undefined ? { content: event.content } : {}),
+    ...(event.embeds !== undefined ? { embeds: event.embeds } : {}),
+    ...(event.components !== undefined ? { components: event.components } : {}),
+  };
+  return { ...state, byId: { ...state.byId, [event.messageId]: next } };
+}
+
+function applyDelete(state: SimState, messageId: string): SimState {
+  if (!state.byId[messageId]) return state;
+  const byId = { ...state.byId };
+  delete byId[messageId];
+  return { ...state, order: state.order.filter((id) => id !== messageId), byId };
+}
+
+function applyReactionAdd(
+  state: SimState,
+  messageId: string,
+  emoji: string,
+  byBot: boolean,
+): SimState {
+  const existing = state.byId[messageId];
+  if (!existing) return state;
+  const found = existing.reactions.find((r) => r.emoji === emoji);
+  let reactions: SimReaction[];
+  if (found) {
+    reactions = existing.reactions.map((r) =>
+      r.emoji === emoji ? { ...r, count: r.count + 1, me: r.me || !byBot } : r,
+    );
+  } else {
+    reactions = [...existing.reactions, { emoji, count: 1, me: !byBot }];
+  }
+  return { ...state, byId: { ...state.byId, [messageId]: { ...existing, reactions } } };
+}
+
+function applyReactionRemove(
+  state: SimState,
+  messageId: string,
+  emoji: string,
+  byBot: boolean,
+): SimState {
+  const existing = state.byId[messageId];
+  if (!existing) return state;
+  const reactions = existing.reactions
+    .map((r) => (r.emoji === emoji ? { ...r, count: r.count - 1, me: byBot ? r.me : false } : r))
+    .filter((r) => r.count > 0);
+  return { ...state, byId: { ...state.byId, [messageId]: { ...existing, reactions } } };
+}
+
+/** Register a channel/thread if new, preserving sidebar order. */
+function registerChannel(state: SimState, channel: VirtualChannel): SimState {
+  if (state.channels[channel.id]) {
+    return { ...state, channels: { ...state.channels, [channel.id]: channel } };
+  }
+  return {
+    ...state,
+    channels: { ...state.channels, [channel.id]: channel },
+    channelOrder: [...state.channelOrder, channel.id],
+  };
+}
+
+function applyGuildSync(
+  state: SimState,
+  event: Extract<SimEvent, { type: "guild.sync" }>,
+): SimState {
+  let next: SimState = { ...state, guild: event.guild };
+  for (const channel of event.guild.channels) next = registerChannel(next, channel);
+  if (!next.activeChannelId) {
+    const firstChannel = next.channelOrder.find((id) => next.channels[id]?.kind === "channel");
+    next = { ...next, activeChannelId: firstChannel ?? next.channelOrder[0] };
+  }
+  return next;
+}
+
+function applyChannelCreate(
+  state: SimState,
+  event: Extract<SimEvent, { type: "channel.create" }>,
+): SimState {
+  let next = registerChannel(state, {
+    id: event.channelId,
+    name: event.name,
+    kind: event.kind,
+    parentId: event.parentId,
+  });
+  if (event.kind === "thread") {
+    // Auto-open the new thread, the way Discord jumps you into one, and record
+    // the parent-channel message it branched from so the thread can show it.
+    next = { ...next, activeChannelId: event.channelId };
+    if (event.starterMessageId) {
+      next = {
+        ...next,
+        threadStarters: { ...next.threadStarters, [event.channelId]: event.starterMessageId },
+      };
+    }
+  }
+  return next;
+}
+
+function pushTrace(state: SimState, entry: SimTraceEntry): SimState {
+  return { ...state, trace: [...state.trace, entry] };
+}
+
+/** Tool start opens a timeline row; result/error closes the matching row with a duration. */
+function applyTraceTool(
+  state: SimState,
+  event: Extract<SimEvent, { type: "trace.tool" }>,
+): SimState {
+  const label = event.delegateName ? `delegate › ${event.delegateName}` : event.toolName;
+  if (event.phase === "start") {
+    return pushTrace(state, {
+      seq: event.seq,
+      ts: event.ts,
+      kind: "tool",
+      label,
+      ref: event.toolCallId,
+    });
+  }
+  const trace = state.trace.map((entry) =>
+    entry.ref === event.toolCallId && entry.kind === "tool"
+      ? {
+          ...entry,
+          kind: event.phase === "error" ? ("tool-error" as const) : ("tool-done" as const),
+          durationMs: event.ts - entry.ts,
+        }
+      : entry,
+  );
+  return { ...state, trace };
+}
+
+/**
+ * Fold one event/action into the session view. Always returns a fresh
+ * `SimState` (or the same reference for a no-op) so React equality checks stay
+ * honest.
+ */
+export function reduceSim(state: SimState, action: SimAction): SimState {
+  switch (action.type) {
+    case "ui.selectChannel":
+      return { ...state, activeChannelId: action.channelId };
+    case "guild.sync":
+      return applyGuildSync(state, action);
+    case "channel.create":
+      return applyChannelCreate(state, action);
+    case "run.start":
+      return {
+        ...state,
+        status: "streaming",
+        activeChannelId: action.channelId,
+        trace: [
+          { seq: action.seq, ts: action.ts, kind: "turn", label: `Turn ${action.turnIndex}` },
+        ],
+      };
+    case "run.finish":
+      return pushTrace(
+        { ...state, status: "done" },
+        {
+          seq: action.seq,
+          ts: action.ts,
+          kind: "finish",
+          label: "Finished",
+          detail: `${action.usage.totalTokens.toLocaleString("en-US")} tok · ${action.usage.toolCallCount} tool · ${action.usage.stepCount} steps`,
+        },
+      );
+    case "run.error":
+      return pushTrace(
+        { ...state, status: "error" },
+        {
+          seq: action.seq,
+          ts: action.ts,
+          kind: "error",
+          label: "Error",
+          detail: action.message,
+        },
+      );
+    case "message.create":
+      return applyCreate(state, action.message);
+    case "message.edit":
+      return applyEdit(state, action);
+    case "message.delete":
+      return applyDelete(state, action.messageId);
+    case "reaction.add":
+      return applyReactionAdd(state, action.messageId, action.emoji, action.byBot);
+    case "reaction.remove":
+      return applyReactionRemove(state, action.messageId, action.emoji, action.byBot);
+    case "context.snapshot":
+      return { ...state, contextSnapshot: action.snapshot };
+    case "trace.tool":
+      return applyTraceTool(state, action);
+    case "approval.prompt":
+      return pushTrace(state, {
+        seq: action.seq,
+        ts: action.ts,
+        kind: "approval",
+        label: `Approval · ${action.toolName}`,
+        detail: action.reason,
+      });
+    case "approval.decision":
+      return pushTrace(state, {
+        seq: action.seq,
+        ts: action.ts,
+        kind: "decision",
+        label: `Approval ${action.status}`,
+        detail: action.decidedByUserId ? `by ${action.decidedByUserId}` : undefined,
+      });
+    default:
+      return state;
+  }
+}
+
+/**
+ * Messages belonging to one channel/thread, in arrival order. For a thread,
+ * the parent-channel message it branched from is prepended as the starter
+ * (mirroring how Discord shows the originating message atop a thread).
+ */
+export function messagesForChannel(state: SimState, channelId: string | undefined): SimMessage[] {
+  if (!channelId) return [];
+  const own = state.order
+    .map((id) => state.byId[id])
+    .filter((message) => message.channelId === channelId && !message.ephemeral);
+  const starterId = state.threadStarters[channelId];
+  const starter = starterId ? state.byId[starterId] : undefined;
+  return starter ? [starter, ...own] : own;
+}

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import type {
+  SimChatRequest,
+  VirtualChannel,
+  VirtualGuildSnapshot,
+  VirtualMember,
+} from "@/lib/simulator/types";
+
+import { UserRole } from "@/lib/ai/constants";
+import {
+  SIM_BOT_ID,
+  SIM_DEFAULT_CHANNEL,
+  SIM_REVIEWER_ID,
+  SIM_USER_ID,
+} from "@/lib/simulator/constants";
+
+import type { MentionResolver, SimConfig } from "./types.ts";
+
+import { ChatColumn } from "./components/ChatColumn.tsx";
+import { InspectorPanel } from "./components/InspectorPanel.tsx";
+import { messagesForChannel } from "./message-store.ts";
+import styles from "./simulator.module.css";
+import { useSimulatorStream } from "./use-simulator-stream.ts";
+
+const PENDING_CHANNEL = "__pending__";
+
+// Built from the fallback-aware member/channel lists (not just `state.guild`)
+// so @/# autocomplete works even before the first turn populates the guild.
+function buildResolver(
+  members: VirtualMember[],
+  channels: VirtualChannel[],
+  guild: VirtualGuildSnapshot | undefined,
+): MentionResolver {
+  const resolver: MentionResolver = { members: {}, channels: {}, roles: {}, emojis: {} };
+  for (const member of members) resolver.members[member.id] = member;
+  for (const channel of channels) resolver.channels[channel.id] = channel;
+  for (const role of guild?.roles ?? []) resolver.roles[role.id] = role;
+  for (const emoji of guild?.emojis ?? []) resolver.emojis[emoji.id] = emoji;
+  return resolver;
+}
+
+function initialConfig(): SimConfig {
+  return {
+    role: UserRole.Organizer,
+    username: "ray",
+    nickname: "Ray",
+    channelName: SIM_DEFAULT_CHANNEL,
+    openThread: true,
+    approveAsSecond: false,
+  };
+}
+
+export default function SimulatorPage() {
+  const sessionRef = useRef<string>(crypto.randomUUID());
+  const sessionId = sessionRef.current;
+  const [config, setConfig] = useState<SimConfig>(initialConfig);
+  const { state, status, startTurn, decideApproval, selectChannel } = useSimulatorStream(sessionId);
+
+  // The chat shows whichever channel/thread is active; before the first turn we
+  // synthesize a single placeholder channel so the composer has somewhere to post.
+  const channels: VirtualChannel[] = useMemo(() => {
+    if (state.channelOrder.length > 0) return state.channelOrder.map((id) => state.channels[id]);
+    return [
+      { id: PENDING_CHANNEL, name: config.channelName || SIM_DEFAULT_CHANNEL, kind: "channel" },
+    ];
+  }, [state.channelOrder, state.channels, config.channelName]);
+
+  const activeChannelId = state.activeChannelId ?? channels[0].id;
+  const activeChannel =
+    state.channels[activeChannelId] ??
+    channels.find((c) => c.id === activeChannelId) ??
+    channels[0];
+  const isThread = activeChannel.kind === "thread";
+  const parentName =
+    isThread && activeChannel.parentId ? state.channels[activeChannel.parentId]?.name : undefined;
+
+  const messages = useMemo(
+    () => messagesForChannel(state, activeChannelId),
+    [state, activeChannelId],
+  );
+
+  const members: VirtualMember[] = useMemo(() => {
+    if (state.guild && state.guild.members.length > 0) return state.guild.members;
+    return [
+      { id: SIM_BOT_ID, username: "wack-hacker", displayName: "Wack Hacker", bot: true, roles: [] },
+      {
+        id: SIM_USER_ID,
+        username: config.username || "ray",
+        displayName: config.nickname || config.username || "Ray",
+        roles: [],
+      },
+    ];
+  }, [state.guild, config.username, config.nickname]);
+
+  const resolver = useMemo(
+    () => buildResolver(members, channels, state.guild),
+    [members, channels, state.guild],
+  );
+
+  const patchConfig = useCallback((patch: Partial<SimConfig>) => {
+    setConfig((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const handleSend = useCallback(
+    (content: string) => {
+      const inThreadView = activeChannel.kind === "thread";
+      const req: SimChatRequest = {
+        sessionId,
+        content,
+        role: config.role,
+        username: config.username || undefined,
+        nickname: config.nickname || undefined,
+        channelName: config.channelName || undefined,
+        // In a thread → keep replying there; in a channel → open a thread per config.
+        ...(inThreadView ? { threadId: activeChannel.id } : { openThread: config.openThread }),
+      };
+      void startTurn(req);
+    },
+    [config, sessionId, startTurn, activeChannel],
+  );
+
+  const handleDecide = useCallback(
+    (decision: "approve" | "deny", approvalId: string) => {
+      const opts = config.approveAsSecond ? { asUserId: SIM_REVIEWER_ID } : undefined;
+      void decideApproval(approvalId, decision, opts);
+    },
+    [config.approveAsSecond, decideApproval],
+  );
+
+  return (
+    <div className={styles.app}>
+      <ChatColumn
+        channelName={activeChannel.name}
+        isThread={isThread}
+        parentName={parentName}
+        parentId={activeChannel.parentId}
+        messages={messages}
+        resolver={resolver}
+        busy={status === "streaming"}
+        onSend={handleSend}
+        onDecide={handleDecide}
+        onSelectChannel={selectChannel}
+      />
+      <InspectorPanel
+        config={config}
+        status={status}
+        onChange={patchConfig}
+        snapshot={state.contextSnapshot}
+        trace={state.trace}
+      />
+    </div>
+  );
+}

--- a/src/app/simulator/simulator.module.css
+++ b/src/app/simulator/simulator.module.css
@@ -1,0 +1,124 @@
+/* Two-pane simulator shell: a high-fidelity Discord chat column on the left,
+   a tabbed dev inspector (controls / context / trace) on the right. The full
+   Discord client chrome (server rail, channel sidebar, member list) is gone on
+   purpose — this is a message-UX + context playground, not a Discord clone. */
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--inspector-w, 420px);
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  background: var(--surface-channel);
+}
+
+/* ----------------------------------------------------------------- chat pane */
+.chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+  background: var(--surface-channel);
+}
+
+/* breadcrumb header: `# parent › ⟂ thread`, with a clickable parent crumb */
+.crumbBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 48px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--surface-rail);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.crumbGlyph {
+  color: var(--text-faint);
+  display: flex;
+  align-items: center;
+}
+
+.crumbLink {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-muted);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.crumbLink:hover {
+  color: var(--text-bright);
+  text-decoration: underline;
+}
+
+.crumbSep {
+  color: var(--text-faint);
+  font-weight: 400;
+}
+
+/* ------------------------------------------------------------ inspector pane */
+.inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--surface-sidebar);
+  border-left: 1px solid var(--surface-rail);
+}
+
+.tabBar {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--surface-rail);
+}
+
+.tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 8px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tab:hover {
+  color: var(--text-normal);
+  background: var(--surface-hover);
+}
+
+.tabActive {
+  color: var(--text-bright);
+  border-bottom-color: var(--brand);
+}
+
+.tabCount {
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--surface-rail);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 16px;
+  text-align: center;
+}
+
+.tabBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}

--- a/src/app/simulator/types.ts
+++ b/src/app/simulator/types.ts
@@ -1,0 +1,71 @@
+import type { UserRole } from "@/lib/ai/constants";
+import type {
+  SimContextSnapshot,
+  SimEvent,
+  SimMessage,
+  VirtualChannel,
+  VirtualEmoji,
+  VirtualGuildSnapshot,
+  VirtualMember,
+  VirtualRole,
+} from "@/lib/simulator/types";
+
+/** One row in the inspector's "Trace" timeline, derived from the event stream. */
+export interface SimTraceEntry {
+  seq: number;
+  ts: number;
+  kind: "turn" | "tool" | "tool-done" | "tool-error" | "approval" | "decision" | "finish" | "error";
+  label: string;
+  detail?: string;
+  durationMs?: number;
+  /** toolCallId, used to match a tool's start to its result/error row. */
+  ref?: string;
+}
+
+/** The reduced, render-ready view of one simulator session. */
+export interface SimState {
+  /** Message ids in arrival order — the source of truth for rendering order. */
+  order: string[];
+  byId: Record<string, SimMessage>;
+  /** Channels + threads, by id (seeded from guild.sync, grown by channel.create). */
+  channels: Record<string, VirtualChannel>;
+  channelOrder: string[];
+  /** Thread id → the parent message that started it (for the thread's header). */
+  threadStarters: Record<string, string>;
+  /** The channel/thread currently shown in the main view. */
+  activeChannelId?: string;
+  guild?: VirtualGuildSnapshot;
+  /** Latest context snapshot (inspector "Context" tab). */
+  contextSnapshot?: SimContextSnapshot;
+  /** Current turn's event timeline (inspector "Trace" tab), reset each turn. */
+  trace: SimTraceEntry[];
+  status: "idle" | "streaming" | "done" | "error";
+}
+
+/** Reducer input: wire events plus client-only UI actions (channel switching). */
+export type SimAction = SimEvent | { type: "ui.selectChannel"; channelId: string };
+
+/**
+ * Flat lookup tables the markdown renderer uses to turn `<@id>` / `<#id>` /
+ * `<@&id>` / `<a:name:id>` tokens into rich pills. Built once per guild
+ * snapshot (see {@link buildMentionResolver}) and threaded through the message
+ * tree so every `renderMarkdown` call shares the same maps.
+ */
+export interface MentionResolver {
+  members: Record<string, VirtualMember>;
+  channels: Record<string, VirtualChannel>;
+  roles: Record<string, VirtualRole>;
+  emojis: Record<string, VirtualEmoji>;
+}
+
+/** The simulator's editable session config, owned by the page. */
+export interface SimConfig {
+  role: UserRole;
+  username: string;
+  nickname: string;
+  channelName: string;
+  /** Open a thread for the bot's reply to a channel message (the real bot's default). */
+  openThread: boolean;
+  /** When set, approval clicks come from a second organizer (not the requester). */
+  approveAsSecond: boolean;
+}

--- a/src/app/simulator/use-simulator-stream.ts
+++ b/src/app/simulator/use-simulator-stream.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import { useCallback, useReducer, useRef, useState } from "react";
+
+import type { SimApproveRequest, SimChatRequest, SimEvent } from "@/lib/simulator/types";
+
+import type { SimState } from "./types.ts";
+
+import { initialSimState, reduceSim } from "./message-store.ts";
+
+const CHAT_URL = "/api/simulator/chat";
+const APPROVE_URL = "/api/simulator/approve";
+
+interface DecideOptions {
+  asUserId?: string;
+  asRoles?: string[];
+}
+
+interface SimulatorStream {
+  state: SimState;
+  status: SimState["status"];
+  startTurn: (req: SimChatRequest) => Promise<void>;
+  decideApproval: (
+    approvalId: string,
+    decision: "approve" | "deny",
+    opts?: DecideOptions,
+  ) => Promise<void>;
+  selectChannel: (channelId: string) => void;
+}
+
+/** What draining the SSE buffer needs to do per parsed event. */
+interface FrameSink {
+  onEvent: (event: SimEvent) => void;
+}
+
+/** Parse one SSE frame's `data:` lines into a `SimEvent`, or null if none. */
+function parseFrame(frame: string): SimEvent | null {
+  const dataLines = frame
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart());
+  if (dataLines.length === 0) return null;
+  try {
+    return JSON.parse(dataLines.join("\n")) as SimEvent;
+  } catch {
+    return null;
+  }
+}
+
+/** Emit every complete `\n\n`-delimited frame, returning the unconsumed tail. */
+function drainFrames(buffer: string, sink: FrameSink): string {
+  let rest = buffer;
+  let boundary = rest.indexOf("\n\n");
+  while (boundary !== -1) {
+    const frame = rest.slice(0, boundary);
+    rest = rest.slice(boundary + 2);
+    const event = parseFrame(frame);
+    if (event) sink.onEvent(event);
+    boundary = rest.indexOf("\n\n");
+  }
+  return rest;
+}
+
+/**
+ * Drives one simulator session. `startTurn` opens a fetch-POST SSE stream
+ * (browser `EventSource` is GET-only) and folds every parsed `SimEvent` into
+ * the reducer as it arrives — edits are NOT throttled client-side; the backend
+ * already paces them at ~1.5s so each `message.edit` is rendered verbatim,
+ * letting you watch the reply grow.
+ */
+export function useSimulatorStream(sessionId: string): SimulatorStream {
+  const [state, dispatch] = useReducer(reduceSim, undefined, initialSimState);
+  const [status, setStatus] = useState<SimState["status"]>("idle");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const startTurn = useCallback(async (req: SimChatRequest) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStatus("streaming");
+
+    let response: Response;
+    try {
+      response = await fetch(CHAT_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(req),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (!controller.signal.aborted) setStatus("error");
+      throw err;
+    }
+
+    if (!response.ok || !response.body) {
+      setStatus("error");
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const sink: FrameSink = {
+      onEvent: (event) => {
+        dispatch(event);
+        if (event.type === "run.finish") setStatus("done");
+        else if (event.type === "run.error") setStatus("error");
+      },
+    };
+    let buffer = "";
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        buffer = drainFrames(buffer, sink);
+      }
+    } catch (err) {
+      if (!controller.signal.aborted) setStatus("error");
+      throw err;
+    }
+  }, []);
+
+  const selectChannel = useCallback((channelId: string) => {
+    dispatch({ type: "ui.selectChannel", channelId });
+  }, []);
+
+  const decideApproval = useCallback(
+    async (approvalId: string, decision: "approve" | "deny", opts?: DecideOptions) => {
+      const body: SimApproveRequest = {
+        sessionId,
+        approvalId,
+        decision,
+        ...(opts?.asUserId ? { clickerUserId: opts.asUserId } : {}),
+        ...(opts?.asRoles ? { clickerRoles: opts.asRoles } : {}),
+      };
+      await fetch(APPROVE_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    },
+    [sessionId],
+  );
+
+  return { state, status, startTurn, decideApproval, selectChannel };
+}

--- a/src/bot/handlers/events/mention/index.ts
+++ b/src/bot/handlers/events/mention/index.ts
@@ -6,6 +6,7 @@ import type { HandlerContext } from "@/bot/types";
 import type { RecentMessage } from "@/lib/ai/types";
 import type { MessageCreatePacketType } from "@/lib/protocol/types";
 import type { ChatHookEvent } from "@/workflows/chat";
+import type { ChatPayload } from "@/workflows/chat";
 
 import { stripBotMention } from "@/bot/mention";
 import { fetchRecentMessages, fetchReferencedMessageContext } from "@/bot/recent-messages";
@@ -17,6 +18,16 @@ import { chatWorkflow } from "@/workflows/chat";
 
 type MessageData = MessageCreatePacketType["data"];
 type WideLogger = ReturnType<typeof createWideLogger>;
+
+const EMPTY_MENTION_REPLY = "Hey! What can I help you with?";
+
+/**
+ * Reply to a bare @mention that carried no content. Extracted so the chat
+ * simulator answers empty mentions through the exact same bot code path.
+ */
+export async function replyEmptyMention(discord: API, channelId: string): Promise<void> {
+  await discord.channels.createMessage(channelId, { content: EMPTY_MENTION_REPLY });
+}
 
 async function fetchLeadInMessages(
   discord: API,
@@ -161,9 +172,7 @@ export async function handleMention(
 
       if (!content) {
         countMetric("chat.mention.empty");
-        await ctx.discord.channels.createMessage(sourceChannelId, {
-          content: "Hey! What can I help you with?",
-        });
+        await replyEmptyMention(ctx.discord, sourceChannelId);
         logger.emit({ outcome: "empty", duration_ms: Date.now() - startTime });
         return;
       }
@@ -192,19 +201,20 @@ export async function handleMention(
 }
 
 /**
- * Start a fresh chat workflow for a mention that didn't have a live resume
- * target. Creates a thread (best-effort), fetches lead-in context, kicks off
- * `chatWorkflow`, and emits the final wide event.
+ * Run the Discord-side prep for a fresh mention turn: create the thread
+ * (best-effort), fetch lead-in context, pre-create the "> Thinking..."
+ * placeholder, and build the serialized `AgentContext`. Returns the payload
+ * the chat workflow runs on. Exported so the chat simulator drives the exact
+ * same plumbing instead of reimplementing thread/placeholder/lead-in logic.
  */
-async function startFreshWorkflow(args: {
+export async function prepareFreshTurn(args: {
   packet: MessageCreatePacketType;
   ctx: HandlerContext;
   content: string;
   routing: MentionRouting;
   logger: WideLogger;
-  startTime: number;
-}): Promise<void> {
-  const { packet, ctx, content, routing, logger, startTime } = args;
+}): Promise<ChatPayload> {
+  const { packet, ctx, content, routing, logger } = args;
   const { data } = packet;
   // Thread creation and lead-in fetch are independent — they only converge
   // when we build turnContext below. Parallelizing saves one Discord RTT on
@@ -228,22 +238,39 @@ async function startFreshWorkflow(args: {
       return undefined;
     });
 
-  const turnContext = AgentContext.fromPacket(packet, {
+  const context = AgentContext.fromPacket(packet, {
     threadOverride: createdThread,
     recentMessages,
     referencedContext,
   }).toJSON();
 
-  const run = await start(chatWorkflow, [
-    {
-      channelId: conversationChannelId,
-      threadId: conversationThreadId,
-      content,
-      context: turnContext,
-      traceparent: captureTraceparent(),
-      placeholderMessageId: placeholder?.id,
-    },
-  ]);
+  return {
+    channelId: conversationChannelId,
+    threadId: conversationThreadId,
+    content,
+    context,
+    traceparent: captureTraceparent(),
+    placeholderMessageId: placeholder?.id,
+  };
+}
+
+/**
+ * Start a fresh chat workflow for a mention that didn't have a live resume
+ * target. Runs the Discord-side prep, kicks off `chatWorkflow`, and emits the
+ * final wide event.
+ */
+async function startFreshWorkflow(args: {
+  packet: MessageCreatePacketType;
+  ctx: HandlerContext;
+  content: string;
+  routing: MentionRouting;
+  logger: WideLogger;
+  startTime: number;
+}): Promise<void> {
+  const { ctx, routing, logger, startTime } = args;
+  const payload = await prepareFreshTurn(args);
+
+  const run = await start(chatWorkflow, [payload]);
 
   setActiveSpanAttributes({ "chat.id": run.runId });
   countMetric("chat.workflow.started");
@@ -251,7 +278,7 @@ async function startFreshWorkflow(args: {
   await ctx.store.set({
     workflowRunId: run.runId,
     channelId: routing.sourceChannelId,
-    threadId: conversationThreadId,
+    threadId: payload.threadId,
     startedAt: new Date().toISOString(),
   });
 
@@ -260,8 +287,8 @@ async function startFreshWorkflow(args: {
     duration_ms: Date.now() - startTime,
     chat: {
       id: run.runId,
-      lead_in_count: recentMessages?.length ?? 0,
-      referenced_count: referencedContext?.length ?? 0,
+      lead_in_count: payload.context.recentMessages?.length ?? 0,
+      referenced_count: payload.context.referencedContext?.length ?? 0,
     },
   });
 }

--- a/src/lib/ai/constants.ts
+++ b/src/lib/ai/constants.ts
@@ -71,6 +71,15 @@ Canonical raw IDs (including UUIDs) are REQUIRED in this block even where they a
 /** Tool-name prefix for delegation tools, e.g. `delegate_github`. */
 export const DELEGATE_PREFIX = "delegate_";
 
+/**
+ * Followup turns past this count drop the scraped lead-in blocks from the
+ * system prompt — by then the model has real conversation history and the
+ * lead-in is just pinned token weight. Dropping it changes the prompt once
+ * (one cache miss at the boundary turn), after which it is stable again.
+ * Shared by `workflows/chat.ts` and the chat simulator's turn loop.
+ */
+export const LEADIN_TURN_LIMIT = 3;
+
 export const SUBAGENT_MODEL = "openai/gpt-5.4-mini";
 
 export const ORCHESTRATOR_MODEL = "anthropic/claude-sonnet-4.6";

--- a/src/lib/ai/conversation-turn.test.ts
+++ b/src/lib/ai/conversation-turn.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "./types.ts";
+
+import { capHistory, stampCurrentTime, truncateForHistory } from "./conversation-turn.ts";
+
+/** Alternating user/assistant turns (even index = user). */
+function makeHistory(n: number): ChatMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: `m${i}`,
+  }));
+}
+
+describe("truncateForHistory", () => {
+  it("returns text under the cap unchanged", () => {
+    expect(truncateForHistory("short")).toBe("short");
+  });
+
+  it("clips longer text with a marker", () => {
+    const out = truncateForHistory("x".repeat(5000));
+    expect(out.endsWith("\n[truncated]")).toBe(true);
+    expect(out.length).toBeLessThan(5000);
+  });
+});
+
+describe("stampCurrentTime", () => {
+  it("appends the instant when present", () => {
+    expect(stampCurrentTime("hey", "2026-06-15T12:00:00Z")).toBe(
+      "hey\n\n[current time: 2026-06-15T12:00:00Z]",
+    );
+  });
+
+  it("returns content unchanged when the instant is absent", () => {
+    expect(stampCurrentTime("hey", undefined)).toBe("hey");
+  });
+});
+
+describe("capHistory", () => {
+  it("no-ops when under the cap", async () => {
+    const msgs = makeHistory(10);
+    const before = [...msgs];
+    await capHistory(msgs, async () => "SUMMARY");
+    expect(msgs).toEqual(before);
+  });
+
+  it("replaces the dropped prefix with one summary message, keeping the latest exchange", async () => {
+    const msgs = makeHistory(60);
+    await capHistory(msgs, async () => "SUMMARY");
+    expect(msgs.length).toBeLessThan(60);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[0].content).toContain("SUMMARY");
+    expect(msgs.at(-1)?.content).toBe("m59");
+  });
+
+  it("falls back to plain dropping (no summary message) when summarize throws", async () => {
+    const msgs = makeHistory(60);
+    await capHistory(msgs, async () => {
+      throw new Error("summary model down");
+    });
+    expect(msgs.length).toBeLessThan(60);
+    expect(msgs.some((m) => m.content.startsWith("[Summary"))).toBe(false);
+    expect(msgs.at(-1)?.content).toBe("m59");
+  });
+});

--- a/src/lib/ai/conversation-turn.test.ts
+++ b/src/lib/ai/conversation-turn.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ChatMessage } from "./types.ts";
 
-import { capHistory, stampCurrentTime, truncateForHistory } from "./conversation-turn.ts";
+import {
+  capHistory,
+  stampCurrentTime,
+  summarizeDroppedHistory,
+  truncateForHistory,
+} from "./conversation-turn.ts";
+
+const generateText = vi.hoisted(() =>
+  vi.fn(async (_opts: { model: string; prompt: string }) => ({ text: "MODEL SUMMARY" })),
+);
+vi.mock("ai", () => ({ generateText }));
 
 /** Alternating user/assistant turns (even index = user). */
 function makeHistory(n: number): ChatMessage[] {
@@ -61,5 +71,31 @@ describe("capHistory", () => {
     expect(msgs.length).toBeLessThan(60);
     expect(msgs.some((m) => m.content.startsWith("[Summary"))).toBe(false);
     expect(msgs.at(-1)?.content).toBe("m59");
+  });
+
+  it("advances past a non-user tail to the cap, never dropping the latest exchange", async () => {
+    // All-assistant turns: the user-boundary scan walks all the way to the cap
+    // (the degenerate-tail guard) instead of finding a user message to stop at.
+    const msgs: ChatMessage[] = Array.from({ length: 60 }, (_, i) => ({
+      role: "assistant",
+      content: `a${i}`,
+    }));
+    await capHistory(msgs, async () => "SUMMARY");
+    expect(msgs.at(-1)?.content).toBe("a59");
+    expect(msgs.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("summarizeDroppedHistory", () => {
+  it("sends the transcript to the summary model and returns its text", async () => {
+    const out = await summarizeDroppedHistory([
+      { role: "user", content: "ship it?" },
+      { role: "assistant", content: "shipped" },
+    ]);
+    expect(out).toBe("MODEL SUMMARY");
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const { prompt } = generateText.mock.calls[0][0];
+    expect(prompt).toContain("user: ship it?");
+    expect(prompt).toContain("assistant: shipped");
   });
 });

--- a/src/lib/ai/conversation-turn.test.ts
+++ b/src/lib/ai/conversation-turn.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChatMessage } from "./types.ts";
 
@@ -13,6 +13,8 @@ const generateText = vi.hoisted(() =>
   vi.fn(async (_opts: { model: string; prompt: string }) => ({ text: "MODEL SUMMARY" })),
 );
 vi.mock("ai", () => ({ generateText }));
+
+beforeEach(() => generateText.mockClear());
 
 /** Alternating user/assistant turns (even index = user). */
 function makeHistory(n: number): ChatMessage[] {
@@ -71,6 +73,13 @@ describe("capHistory", () => {
     expect(msgs.length).toBeLessThan(60);
     expect(msgs.some((m) => m.content.startsWith("[Summary"))).toBe(false);
     expect(msgs.at(-1)?.content).toBe("m59");
+  });
+
+  it("defaults to summarizeDroppedHistory when no summarizer is injected", async () => {
+    const msgs = makeHistory(60);
+    await capHistory(msgs); // exercises the default-parameter path
+    expect(msgs[0].content).toContain("MODEL SUMMARY");
+    expect(generateText).toHaveBeenCalled();
   });
 
   it("advances past a non-user tail to the cap, never dropping the latest exchange", async () => {

--- a/src/lib/ai/conversation-turn.ts
+++ b/src/lib/ai/conversation-turn.ts
@@ -1,0 +1,85 @@
+import { generateText } from "ai";
+
+import { countMetric } from "@/lib/metrics";
+
+import type { ChatMessage } from "./types.ts";
+
+/** Cap on accumulated user+assistant turns — 25 exchanges. */
+const MAX_HISTORY_MESSAGES = 50;
+
+/**
+ * Stored assistant turns are clipped to this many chars. The full text was
+ * already delivered to Discord; history only needs enough for continuity.
+ */
+const MAX_STORED_ASSISTANT_CHARS = 4000;
+
+/** Cheap model that compacts dropped history into one summary message. */
+const HISTORY_SUMMARY_MODEL = "openai/gpt-5.4-mini";
+
+export function truncateForHistory(text: string): string {
+  if (text.length <= MAX_STORED_ASSISTANT_CHARS) return text;
+  return `${text.slice(0, MAX_STORED_ASSISTANT_CHARS)}\n[truncated]`;
+}
+
+/**
+ * Compact a dropped history prefix into one summary string. A plain async
+ * function (no workflow step directive) so non-workflow callers — the chat
+ * simulator — can reuse it directly; the workflow wraps it in a `"use step"`
+ * for durability (see `summarizeHistory` in `workflows/chat.ts`).
+ */
+export async function summarizeDroppedHistory(dropped: ChatMessage[]): Promise<string> {
+  const transcript = dropped.map((m) => `${m.role}: ${m.content}`).join("\n\n");
+  const { text } = await generateText({
+    model: HISTORY_SUMMARY_MODEL,
+    prompt:
+      "Summarize this conversation excerpt in under 200 words. Preserve concrete facts, decisions, names, links, and any commitments the assistant made. Write it as context the assistant will rely on to continue the conversation.\n\n" +
+      transcript,
+  });
+  return text;
+}
+
+/**
+ * Keep history under the cap by replacing the dropped prefix with one
+ * cheap-model summary message. Falls back to plain dropping when the summary
+ * fails — losing old context beats failing the conversation.
+ *
+ * `summarize` is injected so the workflow can pass its durable `"use step"`
+ * wrapper while the simulator passes the plain {@link summarizeDroppedHistory}.
+ */
+export async function capHistory(
+  messages: ChatMessage[],
+  summarize: (dropped: ChatMessage[]) => Promise<string> = summarizeDroppedHistory,
+): Promise<void> {
+  if (messages.length <= MAX_HISTORY_MESSAGES) return;
+  // +1 reserves room for the summary message itself; then advance to the next
+  // user message so the retained history starts with a user turn. (The
+  // summary is also user-role, so the model may see two consecutive user
+  // messages — the AI SDK provider conversion merges those into one.) Never
+  // drop the latest exchange, even on a degenerate non-alternating tail —
+  // otherwise a failed summary could wipe the entire history.
+  const maxDrop = messages.length - 2;
+  let dropCount = Math.min(messages.length - MAX_HISTORY_MESSAGES + 1, maxDrop);
+  while (dropCount < maxDrop && messages[dropCount].role !== "user") dropCount += 1;
+  const dropped = messages.slice(0, dropCount);
+  try {
+    const summary = await summarize(dropped);
+    messages.splice(0, dropCount, {
+      role: "user",
+      content: `[Summary of ${dropped.length} earlier messages, compacted to save space]\n${summary}`,
+    });
+  } catch {
+    countMetric("workflow.chat.history_summary_failed");
+    messages.splice(0, dropCount);
+  }
+}
+
+/**
+ * Append the turn's wall-clock time to a followup user message. The system
+ * prompt's `{{NOW_ISO}}`/`{{DATE}}` are pinned to the first turn so the
+ * prompt stays byte-stable across turns; this stamp is how later turns learn
+ * the real current time. It is persisted into conversation history so the
+ * replayed prefix stays byte-stable too.
+ */
+export function stampCurrentTime(content: string, nowISO: string | undefined): string {
+  return nowISO ? `${content}\n\n[current time: ${nowISO}]` : content;
+}

--- a/src/lib/ai/tools/discord/client.ts
+++ b/src/lib/ai/tools/discord/client.ts
@@ -7,12 +7,14 @@ let active: REST = realRest;
 
 /**
  * Dev/simulator-only: swap the Discord REST transport that every Discord tool
- * and the approval runtime call through. No-ops in production. Pass `null` to
- * restore the real client. The exported `discord` is a Proxy over the active
- * client, so the tool modules that `import { discord }` need no changes.
+ * and the approval runtime call through. Gated on the same condition as the
+ * simulator route mount (`isSimEnabled`) so it can't swap the transport on a
+ * non-production preview/staging deploy. Pass `null` to restore the real
+ * client. The exported `discord` is a Proxy over the active client, so the
+ * tool modules that `import { discord }` need no changes.
  */
 export function __setDiscordRestForSimulation(rest: REST | null): void {
-  if (process.env.NODE_ENV === "production") return;
+  if (process.env.NODE_ENV === "production" || process.env.SIMULATOR_ENABLED !== "1") return;
   active = rest ?? realRest;
 }
 

--- a/src/lib/ai/tools/discord/client.ts
+++ b/src/lib/ai/tools/discord/client.ts
@@ -2,4 +2,27 @@ import { REST } from "@discordjs/rest";
 
 import { env } from "../../../../env.ts";
 
-export const discord = new REST().setToken(env.DISCORD_BOT_TOKEN);
+const realRest = new REST().setToken(env.DISCORD_BOT_TOKEN);
+let active: REST = realRest;
+
+/**
+ * Dev/simulator-only: swap the Discord REST transport that every Discord tool
+ * and the approval runtime call through. No-ops in production. Pass `null` to
+ * restore the real client. The exported `discord` is a Proxy over the active
+ * client, so the tool modules that `import { discord }` need no changes.
+ */
+export function __setDiscordRestForSimulation(rest: REST | null): void {
+  if (process.env.NODE_ENV === "production") return;
+  active = rest ?? realRest;
+}
+
+const restProxyHandler: ProxyHandler<REST> = {
+  get(_target, prop) {
+    const value = (active as unknown as Record<PropertyKey, unknown>)[prop];
+    return typeof value === "function"
+      ? (value as (...args: unknown[]) => unknown).bind(active)
+      : value;
+  },
+};
+
+export const discord: REST = new Proxy(active, restProxyHandler);

--- a/src/lib/redis/client.test.ts
+++ b/src/lib/redis/client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { __resetRedisForTests, createRedis } from "./client";
+import type { RedisClient } from "./types";
+
+import { __resetRedisForTests, __setRedisForSimulation, createRedis } from "./client";
 
 vi.mock("@upstash/redis", () => ({
   Redis: { fromEnv: vi.fn(() => ({ tag: "fromEnv" })) },
@@ -21,5 +23,27 @@ describe("createRedis", () => {
     const after = createRedis();
     // Different object identity since the mock returns a fresh object each call.
     expect(after).not.toBe(before);
+  });
+});
+
+describe("__setRedisForSimulation", () => {
+  const prevFlag = process.env.SIMULATOR_ENABLED;
+  afterEach(() => {
+    __resetRedisForTests();
+    if (prevFlag === undefined) delete process.env.SIMULATOR_ENABLED;
+    else process.env.SIMULATOR_ENABLED = prevFlag;
+  });
+
+  it("overrides createRedis only when the simulator is enabled", () => {
+    const sim = { tag: "sim" } as unknown as RedisClient;
+    process.env.SIMULATOR_ENABLED = "1";
+    __setRedisForSimulation(sim);
+    expect(createRedis()).toBe(sim);
+
+    // Gated off (the route never mounts here) → the swap no-ops, so the prior
+    // override stays in place rather than the env-backed client taking over.
+    delete process.env.SIMULATOR_ENABLED;
+    __setRedisForSimulation({ tag: "ignored" } as unknown as RedisClient);
+    expect(createRedis()).toBe(sim);
   });
 });

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -22,11 +22,12 @@ export function createRedis(): RedisClient {
 
 /**
  * Dev/simulator-only: route every `createRedis()` consumer at an injected
- * client — e.g. `createMemoryRedis()`. No-ops in production. Pass `null` to
- * restore the env-backed client.
+ * client — e.g. `createMemoryRedis()`. Gated on the same condition as the
+ * simulator route mount (`isSimEnabled`) so it can't override Redis on a
+ * non-production preview/staging deploy. Pass `null` to restore the env client.
  */
 export function __setRedisForSimulation(client: RedisClient | null): void {
-  if (process.env.NODE_ENV === "production") return;
+  if (process.env.NODE_ENV === "production" || process.env.SIMULATOR_ENABLED !== "1") return;
   override = client ?? undefined;
 }
 

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -5,17 +5,33 @@ import type { RedisClient } from "./types";
 export type { RedisClient } from "./types";
 
 let cached: RedisClient | undefined;
+let override: RedisClient | undefined;
 
 /**
  * Return a process-wide Redis client built from `UPSTASH_REDIS_REST_*` env
  * vars. Mirrors `createDiscordAPI()` in shape. Memoized so repeated calls
  * inside store constructors don't re-parse the env and rebuild a client.
+ *
+ * When a simulation override is installed, every consumer (budget, approval
+ * and conversation stores) resolves to that client instead.
  */
 export function createRedis(): RedisClient {
+  if (override) return override;
   return (cached ??= Redis.fromEnv() as unknown as RedisClient);
+}
+
+/**
+ * Dev/simulator-only: route every `createRedis()` consumer at an injected
+ * client — e.g. `createMemoryRedis()`. No-ops in production. Pass `null` to
+ * restore the env-backed client.
+ */
+export function __setRedisForSimulation(client: RedisClient | null): void {
+  if (process.env.NODE_ENV === "production") return;
+  override = client ?? undefined;
 }
 
 /** Reset the memoized client. Tests only — production paths must not call this. */
 export function __resetRedisForTests(): void {
   cached = undefined;
+  override = undefined;
 }

--- a/src/lib/simulator/bootstrap.ts
+++ b/src/lib/simulator/bootstrap.ts
@@ -1,0 +1,57 @@
+import { ConversationStore } from "@/bot/store";
+import { TurnMessageStore } from "@/bot/turn-message-store";
+import { ApprovalStore } from "@/lib/ai/approvals/store";
+import { __setDiscordRestForSimulation } from "@/lib/ai/tools/discord/client";
+import { DISCORD_IDS } from "@/lib/protocol/constants";
+import { __setRedisForSimulation } from "@/lib/redis/client";
+import { createMemoryRedis } from "@/lib/redis/fakes";
+
+import { SIM_BOT_ID, SIM_DEFAULT_CHANNEL, SIM_GUILD_ID } from "./constants.ts";
+import { SimConversation } from "./conversation.ts";
+import { SimEventBus } from "./event-bus.ts";
+import { createFakeCoreAPI } from "./fake-core-api.ts";
+import { createFakeRest } from "./fake-rest.ts";
+import { assertSimEnabled } from "./guard.ts";
+import { VirtualGuild } from "./virtual-guild.ts";
+
+/**
+ * Wire a fresh simulator session: build the virtual guild + event bus, install
+ * the process-global fakes (memory Redis, virtual Discord REST), and construct
+ * the conversation over them. Gated — refuses to run outside a dev simulator
+ * process. The Redis/REST swaps are global, so a process serves one active
+ * session at a time (see {@link getOrCreateSession}).
+ */
+export function bootstrapSimulator(sessionId: string): SimConversation {
+  assertSimEnabled();
+
+  const guild = new VirtualGuild({
+    guildId: SIM_GUILD_ID,
+    botUserId: SIM_BOT_ID,
+    channels: [{ name: SIM_DEFAULT_CHANNEL }],
+    members: [
+      { id: SIM_BOT_ID, username: "wack-hacker", displayName: "Wack Hacker", bot: true, roles: [] },
+    ],
+    roles: [
+      { id: DISCORD_IDS.roles.ORGANIZER, name: "organizer", color: "#5865f2" },
+      { id: DISCORD_IDS.roles.ADMIN, name: "admin", color: "#eb459e" },
+    ],
+  });
+  const bus = new SimEventBus(sessionId);
+
+  // Install globals BEFORE constructing the stores so they resolve to the
+  // memory Redis (the approval wrapper also builds `new ApprovalStore()`
+  // internally — it must hit this same instance).
+  const redis = createMemoryRedis();
+  __setRedisForSimulation(redis);
+  __setDiscordRestForSimulation(createFakeRest(guild, bus));
+
+  return new SimConversation({
+    id: sessionId,
+    guild,
+    bus,
+    coreApi: createFakeCoreAPI(guild, bus),
+    store: new ConversationStore(),
+    approvalStore: new ApprovalStore(),
+    turnMessageStore: new TurnMessageStore(),
+  });
+}

--- a/src/lib/simulator/constants.ts
+++ b/src/lib/simulator/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Stable identities for the simulator's virtual server. Digit-only strings so
+ * they render correctly inside Discord mentions (`<@id>` / `<#id>`), and below
+ * `Number.MAX_SAFE_INTEGER` so id minting can do plain arithmetic.
+ */
+export const SIM_GUILD_ID = "920000000000000001";
+export const SIM_BOT_ID = "920000000000000002";
+export const SIM_USER_ID = "920000000000000010";
+
+/** Default second-party reviewer used when the UI doesn't specify a clicker. */
+export const SIM_REVIEWER_ID = "920000000000000011";
+
+/** Mirrors the workflow default (`AgentContext`); pinned for prompt stability. */
+export const SIM_DEFAULT_TIMEZONE = "America/New_York";
+
+/** Default channel a fresh simulator session opens in. */
+export const SIM_DEFAULT_CHANNEL = "general";

--- a/src/lib/simulator/constants.ts
+++ b/src/lib/simulator/constants.ts
@@ -10,8 +10,5 @@ export const SIM_USER_ID = "920000000000000010";
 /** Default second-party reviewer used when the UI doesn't specify a clicker. */
 export const SIM_REVIEWER_ID = "920000000000000011";
 
-/** Mirrors the workflow default (`AgentContext`); pinned for prompt stability. */
-export const SIM_DEFAULT_TIMEZONE = "America/New_York";
-
 /** Default channel a fresh simulator session opens in. */
 export const SIM_DEFAULT_CHANNEL = "general";

--- a/src/lib/simulator/context.ts
+++ b/src/lib/simulator/context.ts
@@ -1,0 +1,14 @@
+import type { UserRole } from "@/lib/ai/constants";
+
+import { DISCORD_IDS } from "@/lib/protocol/constants";
+
+/**
+ * Map a role tier to the Discord role IDs that resolve to it, mirroring
+ * `contextForRole` in the test fixtures so policy/approval gating behaves
+ * exactly as in production.
+ */
+export function roleToMemberRoles(role: UserRole): string[] {
+  if (role === "admin") return [DISCORD_IDS.roles.ADMIN];
+  if (role === "organizer") return [DISCORD_IDS.roles.ORGANIZER];
+  return [];
+}

--- a/src/lib/simulator/conversation.test.ts
+++ b/src/lib/simulator/conversation.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  discordRESTClass,
+  linearClientClass,
+  notionClientClass,
+  octokitClass,
+  resendClass,
+} from "@/lib/test/fixtures";
+
+// Neutralize third-party SDK clients so the orchestrator tool chain (pulled in
+// transitively via streamTurn → delegates) imports cleanly without real creds.
+vi.mock("@linear/sdk", () => ({ LinearClient: linearClientClass() }));
+vi.mock("octokit", () => ({ Octokit: octokitClass() }));
+vi.mock("@octokit/auth-app", () => ({ createAppAuth: vi.fn(() => ({})) }));
+vi.mock("@discordjs/rest", () => ({ REST: discordRESTClass() }));
+vi.mock("@notionhq/client", () => ({ Client: notionClientClass() }));
+vi.mock("resend", () => ({ Resend: resendClass() }));
+vi.mock("@vercel/edge-config", () => ({
+  createClient: vi.fn(() => ({ getAll: vi.fn().mockResolvedValue({}) })),
+}));
+
+const { __setDiscordRestForSimulation } = await import("@/lib/ai/tools/discord/client");
+const { __setRedisForSimulation } = await import("@/lib/redis/client");
+const { SIM_BOT_ID } = await import("./constants.ts");
+const { getOrCreateSession, resetSessions } = await import("./run-registry.ts");
+
+const PING = `<@${SIM_BOT_ID}>`;
+
+beforeAll(() => {
+  process.env.SIMULATOR_ENABLED = "1";
+});
+
+afterEach(() => {
+  resetSessions();
+  __setRedisForSimulation(null);
+  __setDiscordRestForSimulation(null);
+});
+
+// These cover the gating that short-circuits BEFORE the model runs (empty
+// mention, no-ping), so they need no provider creds. The streaming reply and
+// approval lifecycle are exercised against the real orchestrator (the tracing
+// wrapper is unit-tested in trace-orchestrator.test.ts; the full approval flow
+// by the live integration path).
+describe("SimConversation.runTurn", () => {
+  it("replies to an empty mention without streaming", async () => {
+    const session = getOrCreateSession("s2");
+    await session.runTurn({ sessionId: "s2", content: PING, role: "public" });
+    const botMsg = session.bus
+      .history()
+      .find((e) => e.type === "message.create" && e.message.authorKind === "bot");
+    expect(botMsg?.type === "message.create" && botMsg.message.content).toBe(
+      "Hey! What can I help you with?",
+    );
+  });
+
+  it("stays silent when the bot is not pinged in a channel", async () => {
+    const session = getOrCreateSession("s2b");
+    await session.runTurn({
+      sessionId: "s2b",
+      content: "just chatting with the room",
+      role: "public",
+    });
+    const history = session.bus.history();
+    // The user's message posts, but the bot never replies or opens a thread.
+    expect(
+      history.some((e) => e.type === "message.create" && e.message.authorKind === "user"),
+    ).toBe(true);
+    expect(history.some((e) => e.type === "message.create" && e.message.authorKind === "bot")).toBe(
+      false,
+    );
+    expect(history.some((e) => e.type === "channel.create")).toBe(false);
+    expect(history.some((e) => e.type === "run.start")).toBe(false);
+  });
+});

--- a/src/lib/simulator/conversation.ts
+++ b/src/lib/simulator/conversation.ts
@@ -1,0 +1,368 @@
+import type { API } from "@discordjs/core/http-only";
+
+import type { ContextSnapshot } from "@/bot/context-snapshot";
+import type { ConversationStore } from "@/bot/store";
+import type { TurnMessageStore } from "@/bot/turn-message-store";
+import type { HandlerContext } from "@/bot/types";
+import type { ApprovalStoreLike } from "@/lib/ai/approvals";
+import type {
+  ChatMessage,
+  ContextBreakdown,
+  SerializedAgentContext,
+  TurnUsage,
+} from "@/lib/ai/types";
+import type { DiscordInteraction, MessageCreatePacketType } from "@/lib/protocol/types";
+
+import { buildToolApprovalHandler } from "@/bot/components/tool-approval";
+import { prepareFreshTurn, replyEmptyMention } from "@/bot/handlers/events/mention";
+import { isBotMention, isReplyToBot, stripBotMention } from "@/bot/mention";
+import { AgentContext } from "@/lib/ai/context";
+import { capHistory, stampCurrentTime, truncateForHistory } from "@/lib/ai/conversation-turn";
+import { breakdownFromSnapshot } from "@/lib/ai/inspect-context";
+import { buildContextSnapshot } from "@/lib/ai/snapshot";
+import { streamTurn } from "@/lib/ai/streaming";
+import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
+import { createWideLogger } from "@/lib/logging/wide";
+
+import type { SimEventBus } from "./event-bus.ts";
+import type {
+  SimApproveRequest,
+  SimChatRequest,
+  SimContextSnapshot,
+  SimUsageSummary,
+  VirtualChannel,
+} from "./types.ts";
+import type { VirtualGuild } from "./virtual-guild.ts";
+
+import { SIM_BOT_ID, SIM_DEFAULT_CHANNEL, SIM_GUILD_ID, SIM_USER_ID } from "./constants.ts";
+import { roleToMemberRoles } from "./context.ts";
+import { createTracingOrchestratorFactory } from "./trace-orchestrator.ts";
+
+interface SimConversationDeps {
+  id: string;
+  guild: VirtualGuild;
+  bus: SimEventBus;
+  coreApi: API;
+  store: ConversationStore;
+  approvalStore: ApprovalStoreLike;
+  turnMessageStore: TurnMessageStore;
+}
+
+const EMPTY_USAGE: SimUsageSummary = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  toolCallCount: 0,
+  stepCount: 0,
+  toolNames: [],
+};
+
+function toSummary(usage: TurnUsage): SimUsageSummary {
+  return {
+    totalTokens: usage.totalTokens,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    toolCallCount: usage.toolCallCount,
+    stepCount: usage.stepCount,
+    toolNames: usage.toolNames,
+  };
+}
+
+/** Flatten the real `/inspect-context` snapshot + breakdown for the wire. */
+function toSimSnapshot(snap: ContextSnapshot, breakdown: ContextBreakdown): SimContextSnapshot {
+  return {
+    model: snap.model,
+    systemPrompt: snap.systemPrompt,
+    tools: snap.tools.map((t) => ({ name: t.name, description: t.description })),
+    context: snap.context,
+    messages: snap.messages,
+    categories: breakdown.categories.map((c) => ({
+      label: c.label,
+      chars: c.chars,
+      estimatedTokens: c.estimatedTokens,
+      items: c.items?.map((i) => ({ name: i.name, estimatedTokens: i.estimatedTokens })),
+    })),
+    estimatedInputTokens: breakdown.estimatedInputTokens,
+    totalUsage: toSummary(snap.totalUsage),
+    turnCount: breakdown.turnCount,
+    totalCostUsd: breakdown.totalCostUsd,
+  };
+}
+
+/**
+ * Construct the Discord `MESSAGE_CREATE` packet the bot's router/handlers would
+ * receive — so the sim drives the REAL mention detection + plumbing rather than
+ * imitating it. A channel message pings via `mentions` + leading mention; an
+ * in-thread message is framed as a reply to the bot so it continues there.
+ */
+function buildPacket(args: {
+  req: SimChatRequest;
+  baseChannel: VirtualChannel;
+  thread: VirtualChannel | undefined;
+  userMessageId: string;
+  username: string;
+  nickname: string;
+  lastBotMessageId: string | undefined;
+}): MessageCreatePacketType {
+  const { req, baseChannel, thread, userMessageId, username, nickname, lastBotMessageId } = args;
+  const pinged =
+    req.content.includes(`<@${SIM_BOT_ID}>`) || req.content.includes(`<@!${SIM_BOT_ID}>`);
+  const data = {
+    id: userMessageId,
+    attachments: [],
+    author: { id: SIM_USER_ID, username, nickname },
+    channel: thread
+      ? { id: thread.id, name: thread.name }
+      : { id: baseChannel.id, name: baseChannel.name },
+    guildId: SIM_GUILD_ID,
+    content: req.content,
+    timestamp: new Date().toISOString(),
+    mentions: pinged ? [SIM_BOT_ID] : [],
+    memberRoles: roleToMemberRoles(req.role),
+    ...(thread
+      ? {
+          thread: {
+            id: thread.id,
+            parentId: thread.parentId ?? baseChannel.id,
+            parentName: baseChannel.name,
+          },
+          reference: { authorId: SIM_BOT_ID, messageId: lastBotMessageId, channelId: thread.id },
+        }
+      : {}),
+  };
+  return { type: "GATEWAY_MESSAGE_CREATE", timestamp: new Date(), data } as MessageCreatePacketType;
+}
+
+/**
+ * A simulator conversation. Builds the real Discord packet + handler context
+ * for each turn and drives the bot's own code — `isBotMention`/`stripBotMention`,
+ * the mention handler's `prepareFreshTurn` (real thread creation, lead-in fetch,
+ * placeholder, `AgentContext`), and `streamTurn` — so the sim exercises the same
+ * plumbing as production rather than reimplementing it. Followup turns reuse the
+ * pinned first-turn context, mirroring the chat workflow's resume path.
+ */
+export class SimConversation {
+  readonly id: string;
+  readonly guild: VirtualGuild;
+  readonly bus: SimEventBus;
+  readonly coreApi: API;
+  readonly approvalStore: ApprovalStoreLike;
+  private readonly store: ConversationStore;
+  private readonly turnMessageStore: TurnMessageStore;
+
+  private messages: ChatMessage[] = [];
+  private turnCount = 0;
+  private totalUsage = emptyTurnUsage();
+  private stableContext: SerializedAgentContext | undefined;
+  private lastBotMessageId: string | undefined;
+
+  constructor(deps: SimConversationDeps) {
+    this.id = deps.id;
+    this.guild = deps.guild;
+    this.bus = deps.bus;
+    this.coreApi = deps.coreApi;
+    this.store = deps.store;
+    this.approvalStore = deps.approvalStore;
+    this.turnMessageStore = deps.turnMessageStore;
+  }
+
+  async runTurn(req: SimChatRequest): Promise<void> {
+    const username = req.username ?? "sim-user";
+    const nickname = req.nickname ?? username;
+    const channel = this.guild.ensureChannel(req.channelName ?? SIM_DEFAULT_CHANNEL);
+    this.guild.addMember({
+      id: SIM_USER_ID,
+      username,
+      displayName: nickname,
+      roles: roleToMemberRoles(req.role),
+    });
+    this.bus.emit({ type: "guild.sync", guild: this.guild.snapshot() });
+
+    const continuingThread = req.threadId ? this.guild.getChannel(req.threadId) : undefined;
+    const inThread = continuingThread?.kind === "thread";
+    const target = inThread ? continuingThread : channel;
+
+    // The user posts their own message — the sim is the "Discord" delivering it.
+    const userMessage = this.guild.createMessage(target.id, {
+      authorId: SIM_USER_ID,
+      authorKind: "user",
+      content: req.content,
+    });
+    this.bus.emit({ type: "message.create", message: userMessage });
+
+    const packet = buildPacket({
+      req,
+      baseChannel: channel,
+      thread: inThread ? continuingThread : undefined,
+      userMessageId: userMessage.id,
+      username,
+      nickname,
+      lastBotMessageId: this.lastBotMessageId,
+    });
+    const ctx: HandlerContext = { discord: this.coreApi, store: this.store, botUserId: SIM_BOT_ID };
+
+    // Real gate: the bot engages only when pinged in a channel, or when the
+    // message replies to it inside its thread (mirrors the router's logic).
+    if (!isBotMention(packet.data, SIM_BOT_ID) && !isReplyToBot(packet.data, SIM_BOT_ID)) {
+      this.emitSilent();
+      return;
+    }
+
+    const content = stripBotMention(req.content, SIM_BOT_ID);
+    if (!content) {
+      await replyEmptyMention(this.coreApi, target.id);
+      this.emitSilent();
+      return;
+    }
+
+    const { channelId, threadId, context, placeholderMessageId } = await this.resolveTurn({
+      packet,
+      ctx,
+      content,
+      channel,
+      continuingThread: inThread ? continuingThread : undefined,
+    });
+
+    this.bus.emit({
+      type: "run.start",
+      turnIndex: this.turnCount + 1,
+      channelId,
+      threadId,
+    });
+
+    const turnContent = this.turnCount === 0 ? content : stampCurrentTime(content, context.nowISO);
+    this.messages.push({ role: "user", content: turnContent });
+
+    try {
+      const result = await streamTurn(this.coreApi, channelId, this.messages, context, {
+        workflowRunId: this.id,
+        turnIndex: this.turnCount + 1,
+        turnMessageStore: this.turnMessageStore,
+        placeholderMessageId,
+        // Run the real orchestrator, teeing its stream into the bus so the
+        // inspector's Trace tab populates as tool calls happen.
+        createAgent: createTracingOrchestratorFactory(this.bus),
+      });
+      this.messages.push({ role: "assistant", content: truncateForHistory(result.text) });
+      this.lastBotMessageId = result.discordMessageId;
+      await capHistory(this.messages);
+      this.turnCount += 1;
+      this.totalUsage = addTurnUsage(this.totalUsage, result.usage);
+      // Inspector "Context" tab: snapshot what the model saw, before the
+      // terminal run.finish frame (the SSE pump stops on run.finish).
+      await this.emitContextSnapshot(context);
+      this.bus.emit({
+        type: "run.finish",
+        turnIndex: this.turnCount,
+        discordMessageId: result.discordMessageId,
+        model: result.model,
+        text: result.text,
+        usage: toSummary(result.usage),
+      });
+    } catch (err) {
+      this.messages.pop();
+      this.bus.emit({
+        type: "run.error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Fresh channel mention → run the bot's real `prepareFreshTurn` (real thread
+   * creation, lead-in fetch, placeholder, AgentContext) and pin its context.
+   * Followup inside a thread → reuse the pinned context, like the workflow's
+   * resume path (no new thread, renderer makes its own placeholder).
+   */
+  private async resolveTurn(args: {
+    packet: MessageCreatePacketType;
+    ctx: HandlerContext;
+    content: string;
+    channel: VirtualChannel;
+    continuingThread: VirtualChannel | undefined;
+  }): Promise<{
+    channelId: string;
+    threadId: string | undefined;
+    context: SerializedAgentContext;
+    placeholderMessageId: string | undefined;
+  }> {
+    const { packet, ctx, content, channel, continuingThread } = args;
+    if (continuingThread) {
+      const context = this.stableContext ?? AgentContext.fromPacket(packet).toJSON();
+      return {
+        channelId: continuingThread.id,
+        threadId: continuingThread.id,
+        context,
+        placeholderMessageId: undefined,
+      };
+    }
+    const logger = createWideLogger({ op: "sim.mention", chat: { channel_id: channel.id } });
+    const routing = {
+      sourceChannelId: channel.id,
+      lookupThreadId: undefined,
+      alreadyInThread: false,
+    };
+    const payload = await prepareFreshTurn({ packet, ctx, content, routing, logger });
+    this.stableContext = payload.context;
+    return {
+      channelId: payload.channelId,
+      threadId: payload.context.thread?.id,
+      context: payload.context,
+      placeholderMessageId: payload.placeholderMessageId,
+    };
+  }
+
+  /**
+   * Drive the REAL Discord approval-button handler (auth rules, ephemeral
+   * rejections, decision-embed swap) against the virtual core API + shared
+   * store. The waiting tool wrapper unblocks on the resulting `store.decide`.
+   */
+  async decide(req: SimApproveRequest): Promise<{ ok: boolean }> {
+    const handler = buildToolApprovalHandler(this.approvalStore);
+    const clickerId = req.clickerUserId ?? SIM_USER_ID;
+    const clickerRoles = req.clickerRoles ?? this.guild.getMember(clickerId)?.roles ?? [];
+    const interaction = {
+      application_id: "sim-app",
+      token: "sim-token",
+      member: { user: { id: clickerId }, roles: clickerRoles },
+    } as unknown as DiscordInteraction;
+    await handler.handle({
+      interaction,
+      discord: this.coreApi,
+      customId: `tool-approval:${req.decision}:${req.approvalId}`,
+    });
+    return { ok: true };
+  }
+
+  /**
+   * Build + emit the real `/inspect-context` snapshot for the conversation so
+   * the inspector can show exactly what the model saw. Best-effort — a snapshot
+   * failure must never break the turn.
+   */
+  private async emitContextSnapshot(context: SerializedAgentContext): Promise<void> {
+    try {
+      const snap = buildContextSnapshot({
+        context: this.stableContext ?? context,
+        messages: this.messages,
+        totalUsage: this.totalUsage,
+        turnCount: this.turnCount,
+      });
+      const breakdown = await breakdownFromSnapshot(snap);
+      this.bus.emit({ type: "context.snapshot", snapshot: toSimSnapshot(snap, breakdown) });
+    } catch {
+      // Inspector data is non-essential; swallow.
+    }
+  }
+
+  /** Terminal event for a silent turn (bot not engaged) so the SSE stream closes. */
+  private emitSilent(): void {
+    this.bus.emit({
+      type: "run.finish",
+      turnIndex: this.turnCount,
+      discordMessageId: "",
+      model: "n/a",
+      text: "",
+      usage: EMPTY_USAGE,
+    });
+  }
+}

--- a/src/lib/simulator/event-bus.ts
+++ b/src/lib/simulator/event-bus.ts
@@ -1,0 +1,110 @@
+import type { EmittableEvent, SimEvent } from "./types.ts";
+
+/**
+ * A single SSE consumer. A promise-queue: `push` either resolves a pending
+ * `next()` or buffers; `close` ends the iterator. Implements the async
+ * iterator protocol so the SSE handler can `for await` over it.
+ */
+class Subscriber implements AsyncIterableIterator<SimEvent> {
+  private queue: SimEvent[] = [];
+  private resolve: ((result: IteratorResult<SimEvent>) => void) | null = null;
+  private done = false;
+  /** Cleanup run when the consumer stops iterating (loop break / return). */
+  onReturn: (() => void) | null = null;
+
+  push(event: SimEvent): void {
+    if (this.done) return;
+    if (this.resolve) {
+      const resolve = this.resolve;
+      this.resolve = null;
+      resolve({ value: event, done: false });
+    } else {
+      this.queue.push(event);
+    }
+  }
+
+  close(): void {
+    this.done = true;
+    if (this.resolve) {
+      const resolve = this.resolve;
+      this.resolve = null;
+      resolve({ value: undefined, done: true });
+    }
+  }
+
+  next(): Promise<IteratorResult<SimEvent>> {
+    if (this.queue.length > 0) {
+      return Promise.resolve({ value: this.queue.shift()!, done: false });
+    }
+    if (this.done) return Promise.resolve({ value: undefined, done: true });
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+
+  // Called automatically when a `for await` loop breaks/returns, so a finished
+  // per-turn SSE consumer is unregistered from the bus instead of leaking.
+  return(): Promise<IteratorResult<SimEvent>> {
+    this.onReturn?.();
+    this.close();
+    return Promise.resolve({ value: undefined, done: true });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<SimEvent> {
+    return this;
+  }
+}
+
+/**
+ * Promise-queue fan-out that bridges synchronous transport calls (a renderer
+ * `flush()`, a tool's REST write) to the SSE async iterator the route awaits.
+ * `emit()` stamps `seq`/`ts`/`runId`, records to a replay buffer, and wakes
+ * every live subscriber. New subscribers replay the full history first so a
+ * reconnect (or a subscribe that races the first emits) loses nothing.
+ */
+export class SimEventBus {
+  private seq = 0;
+  private historyBuffer: SimEvent[] = [];
+  private subscribers = new Set<Subscriber>();
+  private closed = false;
+
+  constructor(readonly runId: string) {}
+
+  emit(event: EmittableEvent): SimEvent {
+    const full = { ...event, seq: this.seq++, ts: Date.now(), runId: this.runId } as SimEvent;
+    this.historyBuffer.push(full);
+    for (const subscriber of this.subscribers) subscriber.push(full);
+    return full;
+  }
+
+  subscribe(
+    opts: { signal?: AbortSignal; replayHistory?: boolean } = {},
+  ): AsyncIterableIterator<SimEvent> {
+    const subscriber = new Subscriber();
+    if (opts.replayHistory ?? true) {
+      for (const event of this.historyBuffer) subscriber.push(event);
+    }
+    if (this.closed) {
+      subscriber.close();
+      return subscriber;
+    }
+    this.subscribers.add(subscriber);
+    subscriber.onReturn = () => this.subscribers.delete(subscriber);
+    const drop = () => {
+      this.subscribers.delete(subscriber);
+      subscriber.close();
+    };
+    opts.signal?.addEventListener("abort", drop, { once: true });
+    return subscriber;
+  }
+
+  history(): SimEvent[] {
+    return [...this.historyBuffer];
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const subscriber of this.subscribers) subscriber.close();
+    this.subscribers.clear();
+  }
+}

--- a/src/lib/simulator/fake-core-api.test.ts
+++ b/src/lib/simulator/fake-core-api.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { MessageRenderer } from "@/lib/ai/message-renderer";
+
+import type { SimEvent } from "./types.ts";
+
+import { SimEventBus } from "./event-bus.ts";
+import { createFakeCoreAPI } from "./fake-core-api.ts";
+import { VirtualGuild } from "./virtual-guild.ts";
+
+function harness() {
+  const guild = new VirtualGuild({
+    guildId: "g1",
+    botUserId: "bot1",
+    channels: [{ name: "general" }],
+  });
+  const bus = new SimEventBus("run1");
+  const api = createFakeCoreAPI(guild, bus);
+  const channelId = guild.ensureChannel("general").id;
+  return { guild, bus, api, channelId };
+}
+
+function creates(events: SimEvent[]): Extract<SimEvent, { type: "message.create" }>[] {
+  return events.filter(
+    (e): e is Extract<SimEvent, { type: "message.create" }> => e.type === "message.create",
+  );
+}
+
+function edits(events: SimEvent[]): Extract<SimEvent, { type: "message.edit" }>[] {
+  return events.filter(
+    (e): e is Extract<SimEvent, { type: "message.edit" }> => e.type === "message.edit",
+  );
+}
+
+describe("createFakeCoreAPI + MessageRenderer", () => {
+  it("posts a `> Thinking...` placeholder on init", async () => {
+    const { bus, api, channelId } = harness();
+    const renderer = new MessageRenderer(api, channelId);
+    await renderer.init();
+
+    const created = creates(bus.history());
+    expect(created).toHaveLength(1);
+    expect(created[0].message.content).toBe("> Thinking...");
+    expect(created[0].message.authorKind).toBe("bot");
+  });
+
+  it("emits an immediate edit on the first streamed text (throttle bypassed)", async () => {
+    const { bus, api, channelId } = harness();
+    const renderer = new MessageRenderer(api, channelId);
+    await renderer.init();
+    const placeholderId = creates(bus.history())[0].message.id;
+
+    await renderer.appendText("Hello world");
+
+    const edited = edits(bus.history());
+    expect(edited).toHaveLength(1);
+    expect(edited[0].messageId).toBe(placeholderId);
+    expect(edited[0].content).toBe("Hello world");
+  });
+
+  it("renders the footer into the finalized message", async () => {
+    const { bus, api, channelId } = harness();
+    const renderer = new MessageRenderer(api, channelId);
+    await renderer.init();
+    await renderer.appendText("Done.");
+
+    await renderer.finalize({ elapsedMs: 3200, totalTokens: 1423, toolCallCount: 4, stepCount: 2 });
+
+    const last = edits(bus.history()).at(-1)!;
+    expect(last.content).toContain("Done.");
+    expect(last.content).toContain("-# ");
+    expect(last.content).toContain("3.2s");
+    expect(last.content).toContain("1,423 tokens");
+    expect(last.content).toContain("4 tool calls");
+  });
+
+  it("splits an over-long reply into overflow messages", async () => {
+    const { bus, api, channelId } = harness();
+    const renderer = new MessageRenderer(api, channelId);
+    await renderer.init();
+    await renderer.appendText("word ".repeat(900)); // ~4500 chars > 1900 cap
+
+    await renderer.finalize({ elapsedMs: 1000, totalTokens: 10, toolCallCount: 0, stepCount: 1 });
+
+    // init create + at least one overflow create; primary edited with chunk[0].
+    const created = creates(bus.history());
+    const edited = edits(bus.history());
+    expect(created.length).toBeGreaterThan(1);
+    expect(edited.length).toBeGreaterThanOrEqual(1);
+    for (const overflow of created.slice(1)) {
+      expect(overflow.message.content.length).toBeLessThanOrEqual(1900);
+    }
+  });
+
+  it("captures bot reactions through addMessageReaction", async () => {
+    const { bus, api, guild, channelId } = harness();
+    const message = guild.createMessage(channelId, {
+      authorId: "u1",
+      authorKind: "user",
+      content: "hi",
+    });
+    await api.channels.addMessageReaction(channelId, message.id, "👍");
+
+    const reaction = bus.history().find((e) => e.type === "reaction.add");
+    expect(reaction).toBeDefined();
+    expect(guild.getMessage(channelId, message.id)?.reactions[0]).toMatchObject({
+      emoji: "👍",
+      count: 1,
+    });
+  });
+});

--- a/src/lib/simulator/fake-core-api.ts
+++ b/src/lib/simulator/fake-core-api.ts
@@ -1,0 +1,149 @@
+import type { API } from "@discordjs/core/http-only";
+
+import type { SimEventBus } from "./event-bus.ts";
+import type { SimActionRow, SimEmbed, SimMessage } from "./types.ts";
+import type { VirtualGuild } from "./virtual-guild.ts";
+
+/** The fields of a Discord message body the agent layer actually sends. */
+interface CoreMessageBody {
+  content?: string;
+  embeds?: SimEmbed[];
+  components?: SimActionRow[];
+}
+
+const EPHEMERAL_FLAG = 64;
+
+// Ephemeral follow-ups have no real channel; pin them to a sentinel so the UI
+// can route them to the active channel view if it chooses.
+const SIM_INTERACTION_CHANNEL = "interaction";
+
+/** Project a virtual message onto the Discord `APIMessage` shape callers read. */
+function buildApiMessage(guild: VirtualGuild, message: SimMessage) {
+  const member = guild.getMember(message.authorId);
+  return {
+    id: message.id,
+    channel_id: message.channelId,
+    content: message.content,
+    timestamp: message.createdAt,
+    embeds: message.embeds,
+    components: message.components,
+    author: {
+      id: message.authorId,
+      username: member?.username ?? (message.authorKind === "bot" ? "wack-hacker" : "user"),
+      global_name: member?.displayName,
+      bot: message.authorKind === "bot",
+    },
+  };
+}
+
+function buildChannels(guild: VirtualGuild, bus: SimEventBus) {
+  return {
+    createMessage: async (channelId: string, body: CoreMessageBody) => {
+      const message = guild.createMessage(channelId, {
+        authorId: guild.botUserId,
+        authorKind: "bot",
+        content: typeof body.content === "string" ? body.content : "",
+        embeds: body.embeds,
+        components: body.components,
+      });
+      bus.emit({ type: "message.create", message });
+      return buildApiMessage(guild, message);
+    },
+
+    editMessage: async (channelId: string, messageId: string, body: CoreMessageBody) => {
+      const message = guild.editMessage(channelId, messageId, {
+        content: body.content,
+        embeds: body.embeds,
+        components: body.components,
+      });
+      bus.emit({
+        type: "message.edit",
+        messageId,
+        channelId,
+        content: message.content,
+        embeds: message.embeds,
+        components: message.components,
+        editedAt: message.editedAt!,
+      });
+      return buildApiMessage(guild, message);
+    },
+
+    getMessage: async (channelId: string, messageId: string) => {
+      const message = guild.getMessage(channelId, messageId);
+      return message ? buildApiMessage(guild, message) : undefined;
+    },
+
+    getMessages: async (channelId: string, query?: { limit?: number }) =>
+      guild.listMessages(channelId, query?.limit ?? 50).map((m) => buildApiMessage(guild, m)),
+
+    createThread: async (channelId: string, body: { name: string }, messageId?: string) => {
+      const thread = guild.createThread(channelId, body.name);
+      bus.emit({
+        type: "channel.create",
+        channelId: thread.id,
+        name: thread.name,
+        kind: "thread",
+        parentId: channelId,
+        starterMessageId: messageId,
+      });
+      return { id: thread.id, name: thread.name };
+    },
+
+    deleteMessage: async (channelId: string, messageId: string) => {
+      guild.deleteMessage(channelId, messageId);
+      bus.emit({ type: "message.delete", messageId, channelId });
+    },
+
+    addMessageReaction: async (channelId: string, messageId: string, emoji: string) => {
+      guild.addReaction(channelId, messageId, emoji, true);
+      bus.emit({ type: "reaction.add", messageId, channelId, emoji, byBot: true });
+    },
+
+    deleteOwnMessageReaction: async (channelId: string, messageId: string, emoji: string) => {
+      guild.removeReaction(channelId, messageId, emoji, true);
+      bus.emit({ type: "reaction.remove", messageId, channelId, emoji, byBot: true });
+    },
+
+    get: async (channelId: string) => {
+      const channel = guild.getChannel(channelId);
+      return { id: channelId, name: channel?.name ?? "unknown-channel" };
+    },
+  };
+}
+
+function buildInteractions(guild: VirtualGuild, bus: SimEventBus) {
+  return {
+    // The approval click handler replies to the interaction with ephemeral
+    // rejections (flags: 64); render those as ephemeral messages.
+    followUp: async (
+      _appId: string,
+      _token: string,
+      body: CoreMessageBody & { flags?: number },
+    ) => {
+      const message = guild.createMessage(SIM_INTERACTION_CHANNEL, {
+        authorId: guild.botUserId,
+        authorKind: "bot",
+        content: typeof body.content === "string" ? body.content : "",
+        ephemeral: (body.flags ?? 0) === EPHEMERAL_FLAG,
+      });
+      bus.emit({ type: "message.create", message });
+      return buildApiMessage(guild, message);
+    },
+  };
+}
+
+/**
+ * A fake `@discordjs/core` `API` that records everything into a
+ * {@link VirtualGuild} and emits {@link SimEventBus} events instead of calling
+ * Discord. This is transport A: the surface `streamTurn` → `MessageRenderer`
+ * uses for the orchestrator's own reply, plus the mention-handler pre-stream
+ * calls (thread create, placeholder) and the approval click handler the
+ * simulator drives. Cast through `unknown` to `API` — only the methods the
+ * agent layer touches are implemented.
+ */
+export function createFakeCoreAPI(guild: VirtualGuild, bus: SimEventBus): API {
+  return {
+    channels: buildChannels(guild, bus),
+    interactions: buildInteractions(guild, bus),
+  } as unknown as API;
+}

--- a/src/lib/simulator/fake-rest.test.ts
+++ b/src/lib/simulator/fake-rest.test.ts
@@ -15,6 +15,9 @@ import { VirtualGuild } from "./virtual-guild.ts";
 
 type ApprovalExecute = (input: unknown, runtime: unknown) => AsyncGenerator<unknown>;
 
+// The REST swap is gated on SIMULATOR_ENABLED (mirrors the route mount).
+process.env.SIMULATOR_ENABLED = "1";
+
 function setup() {
   const guild = new VirtualGuild({ guildId: "g1", botUserId: "bot1" });
   const bus = new SimEventBus("run1");

--- a/src/lib/simulator/fake-rest.test.ts
+++ b/src/lib/simulator/fake-rest.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { wrapToolWithApproval } from "@/lib/ai/approvals/runtime";
+import { ApprovalStore } from "@/lib/ai/approvals/store";
+import { __setDiscordRestForSimulation } from "@/lib/ai/tools/discord/client";
+import { contextForRole, noopTool } from "@/lib/test/fixtures/ai";
+import { createMemoryRedis } from "@/lib/test/fixtures/redis";
+
+import type { SimEvent } from "./types.ts";
+
+import { SIM_REVIEWER_ID } from "./constants.ts";
+import { SimEventBus } from "./event-bus.ts";
+import { createFakeRest } from "./fake-rest.ts";
+import { VirtualGuild } from "./virtual-guild.ts";
+
+type ApprovalExecute = (input: unknown, runtime: unknown) => AsyncGenerator<unknown>;
+
+function setup() {
+  const guild = new VirtualGuild({ guildId: "g1", botUserId: "bot1" });
+  const bus = new SimEventBus("run1");
+  __setDiscordRestForSimulation(createFakeRest(guild, bus));
+  const store = new ApprovalStore(createMemoryRedis());
+  return { guild, bus, store };
+}
+
+async function waitForEvent<T extends SimEvent["type"]>(
+  bus: SimEventBus,
+  type: T,
+): Promise<Extract<SimEvent, { type: T }>> {
+  for (let i = 0; i < 100; i++) {
+    const found = bus.history().find((e) => e.type === type);
+    if (found) return found as Extract<SimEvent, { type: T }>;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`event ${type} never arrived`);
+}
+
+afterEach(() => __setDiscordRestForSimulation(null));
+
+describe("createFakeRest + approval runtime", () => {
+  it("posts an approval prompt and runs the tool once approved", async () => {
+    const { bus, store } = setup();
+    const wrapped = wrapToolWithApproval(
+      noopTool("do_thing"),
+      "do_thing",
+      { risk: "write", confirmMode: "self" },
+      { context: contextForRole("organizer"), store, timeoutMs: 5000 },
+    );
+
+    const collected: unknown[] = [];
+    const pump = (async () => {
+      for await (const value of (wrapped.execute as ApprovalExecute)({ _reason: "need it" }, {})) {
+        collected.push(value);
+      }
+    })();
+
+    const prompt = await waitForEvent(bus, "approval.prompt");
+    expect(prompt.toolName).toBe("do_thing");
+    expect(prompt.embed.color).toBe(0xffaa00);
+
+    const created = bus.history().find((e) => e.type === "message.create");
+    expect(created?.type === "message.create" && created.message.approvalId).toBe(
+      prompt.approvalId,
+    );
+
+    await store.decide(prompt.approvalId, "approved", SIM_REVIEWER_ID);
+    await pump;
+
+    expect(collected).toContain("do_thing");
+  });
+
+  it("converges to a denied decision and does not run the tool", async () => {
+    const { bus, store } = setup();
+    const wrapped = wrapToolWithApproval(
+      noopTool("dangerous"),
+      "dangerous",
+      { risk: "destructive", confirmMode: "second-party" },
+      { context: contextForRole("organizer"), store, timeoutMs: 5000 },
+    );
+
+    const collected: unknown[] = [];
+    const pump = (async () => {
+      for await (const value of (wrapped.execute as ApprovalExecute)({ _reason: "no" }, {})) {
+        collected.push(value);
+      }
+    })();
+
+    const prompt = await waitForEvent(bus, "approval.prompt");
+    await store.decide(prompt.approvalId, "denied", SIM_REVIEWER_ID);
+
+    const decision = await waitForEvent(bus, "approval.decision");
+    expect(decision.status).toBe("denied");
+    expect(decision.decidedByUserId).toBe(SIM_REVIEWER_ID);
+
+    await pump;
+    expect(collected).not.toContain("dangerous");
+    expect(collected.some((v) => typeof v === "string" && v.includes("denied"))).toBe(true);
+  });
+});

--- a/src/lib/simulator/fake-rest.ts
+++ b/src/lib/simulator/fake-rest.ts
@@ -1,0 +1,42 @@
+import type { REST } from "@discordjs/rest";
+
+import type { SimEventBus } from "./event-bus.ts";
+import type { VirtualGuild } from "./virtual-guild.ts";
+
+import { createRouteDispatcher } from "./route-dispatch.ts";
+
+interface FakeRestOptions {
+  /** Real REST to forward non-approval Discord tool calls to (LIVE only). */
+  realRest?: REST;
+  /** Enable passthrough of Discord domain-tool writes to the real server. */
+  passthrough?: boolean;
+}
+
+interface RestRequestOptions {
+  body?: unknown;
+}
+
+/**
+ * A fake `@discordjs/rest` `REST` (transport B) that the swapped
+ * `tools/discord/client.ts` singleton points at during a simulator run. Routes
+ * every verb through {@link createRouteDispatcher}: approval prompts/decisions
+ * and (by default) all Discord tool writes are virtualized onto the
+ * {@link VirtualGuild}; with `realDiscordTools` they pass through to a real REST.
+ */
+export function createFakeRest(
+  guild: VirtualGuild,
+  bus: SimEventBus,
+  options: FakeRestOptions = {},
+): REST {
+  const dispatcher = createRouteDispatcher(guild, bus, options);
+  const verb = (method: string) => (route: string, requestOptions?: RestRequestOptions) =>
+    dispatcher.handle(method, route, requestOptions);
+
+  return {
+    get: verb("GET"),
+    post: verb("POST"),
+    patch: verb("PATCH"),
+    put: verb("PUT"),
+    delete: verb("DELETE"),
+  } as unknown as REST;
+}

--- a/src/lib/simulator/guard.ts
+++ b/src/lib/simulator/guard.ts
@@ -1,0 +1,16 @@
+/**
+ * The simulator installs process-global fakes (Redis override, Discord REST
+ * swap). These must never run in a real bot process, so every entry point is
+ * gated on an explicit dev-only flag.
+ */
+export function isSimEnabled(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.SIMULATOR_ENABLED === "1";
+}
+
+export function assertSimEnabled(): void {
+  if (!isSimEnabled()) {
+    throw new Error(
+      "Simulator is disabled. Set SIMULATOR_ENABLED=1 in a non-production environment.",
+    );
+  }
+}

--- a/src/lib/simulator/route-dispatch.ts
+++ b/src/lib/simulator/route-dispatch.ts
@@ -1,0 +1,230 @@
+import type { REST } from "@discordjs/rest";
+
+import type { SimEventBus } from "./event-bus.ts";
+import type { SimActionRow, SimEmbed } from "./types.ts";
+import type { VirtualGuild } from "./virtual-guild.ts";
+
+interface RestBody {
+  content?: string;
+  embeds?: SimEmbed[];
+  components?: SimActionRow[];
+}
+
+interface RestRequestOptions {
+  body?: unknown;
+}
+
+interface DispatcherOptions {
+  /** Real REST to forward non-approval Discord tool calls to (LIVE only). */
+  realRest?: REST;
+  /** Enable passthrough of Discord domain-tool writes to the real server. */
+  passthrough?: boolean;
+}
+
+interface DispatchCtx {
+  guild: VirtualGuild;
+  bus: SimEventBus;
+  approvalByMessage: Map<string, string>;
+}
+
+const APPROVAL_CUSTOM_ID = /^tool-approval:(?:approve|deny):(.+)$/;
+const CHANNEL_MESSAGES = /^\/channels\/([^/]+)\/messages$/;
+const CHANNEL_MESSAGE = /^\/channels\/([^/]+)\/messages\/([^/?]+)$/;
+const MESSAGE_REACTION = /^\/channels\/([^/]+)\/messages\/([^/]+)\/reactions\/([^/]+)/;
+
+const DECISION_PREFIX = "Wack Hack · Permission ";
+const DECISION_LABELS: Record<string, "approved" | "denied" | "timeout"> = {
+  Approved: "approved",
+  Denied: "denied",
+  "Timed Out": "timeout",
+};
+
+function findApprovalId(components?: SimActionRow[]): string | undefined {
+  for (const row of components ?? []) {
+    for (const button of row.components ?? []) {
+      const match = button.custom_id?.match(APPROVAL_CUSTOM_ID);
+      if (match) return match[1];
+    }
+  }
+  return undefined;
+}
+
+/** Pull `{tool}` / `delegate_{name}.{tool}` out of the python-style call block. */
+function parseToolName(description?: string): { toolName: string; delegateName?: string } {
+  const line = description?.split("\n").find((l) => l.includes("("));
+  const prefix = line?.split("(")[0]?.trim() ?? "";
+  const delegated = prefix.match(/^delegate_([^.]+)\.(.+)$/);
+  if (delegated) return { delegateName: delegated[1], toolName: delegated[2] };
+  return { toolName: prefix || "unknown" };
+}
+
+function fieldValue(embed: SimEmbed | undefined, name: string): string | undefined {
+  return embed?.fields?.find((f) => f.name === name)?.value;
+}
+
+function decisionStatus(embed?: SimEmbed): "approved" | "denied" | "timeout" | undefined {
+  const name = embed?.author?.name ?? "";
+  if (!name.startsWith(DECISION_PREFIX)) return undefined;
+  return DECISION_LABELS[name.slice(DECISION_PREFIX.length)];
+}
+
+function handlePostMessages(ctx: DispatchCtx, channelId: string, body: RestBody): { id: string } {
+  const approvalId = findApprovalId(body.components);
+  const message = ctx.guild.createMessage(channelId, {
+    authorId: ctx.guild.botUserId,
+    authorKind: "bot",
+    content: typeof body.content === "string" ? body.content : "",
+    embeds: body.embeds,
+    components: body.components,
+    approvalId,
+  });
+  ctx.bus.emit({ type: "message.create", message });
+  if (approvalId) {
+    ctx.approvalByMessage.set(message.id, approvalId);
+    const embed = body.embeds?.[0];
+    const { toolName, delegateName } = parseToolName(embed?.description);
+    ctx.bus.emit({
+      type: "approval.prompt",
+      approvalId,
+      messageId: message.id,
+      channelId,
+      toolName,
+      delegateName,
+      reason: fieldValue(embed, "Reason") ?? "(not provided)",
+      embed: embed ?? { description: "" },
+      components: body.components ?? [],
+    });
+  }
+  return { id: message.id };
+}
+
+function handlePatchMessage(
+  ctx: DispatchCtx,
+  channelId: string,
+  messageId: string,
+  body: RestBody,
+): Record<string, never> {
+  const message = ctx.guild.editMessage(channelId, messageId, {
+    content: body.content,
+    embeds: body.embeds,
+    components: body.components,
+  });
+  ctx.bus.emit({
+    type: "message.edit",
+    messageId,
+    channelId,
+    content: message.content,
+    embeds: message.embeds,
+    components: message.components,
+    editedAt: message.editedAt!,
+  });
+  const status = decisionStatus(body.embeds?.[0]);
+  const approvalId = ctx.approvalByMessage.get(messageId);
+  if (status && approvalId) {
+    const decidedBy = fieldValue(body.embeds?.[0], "Decided by")?.match(/<@(\d+)>/)?.[1] ?? null;
+    ctx.bus.emit({
+      type: "approval.decision",
+      approvalId,
+      messageId,
+      channelId,
+      status,
+      decidedByUserId: decidedBy,
+      embed: body.embeds![0],
+    });
+  }
+  return {};
+}
+
+function handleReaction(
+  ctx: DispatchCtx,
+  method: string,
+  channelId: string,
+  messageId: string,
+  rawEmoji: string,
+): Record<string, never> {
+  const emoji = decodeURIComponent(rawEmoji);
+  if (method === "PUT") {
+    ctx.guild.addReaction(channelId, messageId, emoji, true);
+    ctx.bus.emit({ type: "reaction.add", messageId, channelId, emoji, byBot: true });
+  } else if (method === "DELETE") {
+    ctx.guild.removeReaction(channelId, messageId, emoji, true);
+    ctx.bus.emit({ type: "reaction.remove", messageId, channelId, emoji, byBot: true });
+  }
+  return {};
+}
+
+/**
+ * Smart-proxy router for the `@discordjs/rest` surface that every Discord tool
+ * and the approval runtime call through. Approval prompt/decision messages are
+ * always virtualized (rendered in the sim, clickable). Other Discord writes are
+ * virtual by default and forwarded to the real REST only when
+ * `realDiscordTools` is set with a `realRest` (LIVE "real everything").
+ */
+export function createRouteDispatcher(
+  guild: VirtualGuild,
+  bus: SimEventBus,
+  options: DispatcherOptions = {},
+) {
+  const ctx: DispatchCtx = { guild, bus, approvalByMessage: new Map() };
+
+  function passthrough(
+    method: string,
+    route: string,
+    requestOptions?: RestRequestOptions,
+  ): Promise<unknown> | undefined {
+    if (!options.passthrough || !options.realRest) return undefined;
+    const body = (requestOptions?.body ?? {}) as RestBody;
+    // Keep approval prompts and their converge edits virtual no matter what.
+    const collectionMatch = route.match(CHANNEL_MESSAGES);
+    if (collectionMatch && method === "POST" && findApprovalId(body.components)) return undefined;
+    const singleMatch = route.match(CHANNEL_MESSAGE);
+    if (singleMatch && ctx.approvalByMessage.has(singleMatch[2])) return undefined;
+    const rest = options.realRest as unknown as Record<
+      string,
+      (route: string, opts?: RestRequestOptions) => Promise<unknown>
+    >;
+    return rest[method.toLowerCase()]?.call(options.realRest, route, requestOptions);
+  }
+
+  function dispatch(method: string, route: string, body: RestBody): unknown {
+    const collectionMatch = route.match(CHANNEL_MESSAGES);
+    if (collectionMatch && method === "POST")
+      return handlePostMessages(ctx, collectionMatch[1], body);
+
+    const singleMatch = route.match(CHANNEL_MESSAGE);
+    if (singleMatch && method === "PATCH") {
+      return handlePatchMessage(ctx, singleMatch[1], singleMatch[2], body);
+    }
+    if (singleMatch && method === "DELETE") {
+      ctx.guild.deleteMessage(singleMatch[1], singleMatch[2]);
+      ctx.bus.emit({
+        type: "message.delete",
+        messageId: singleMatch[2],
+        channelId: singleMatch[1],
+      });
+      return {};
+    }
+    if (singleMatch && method === "GET") {
+      return ctx.guild.getMessage(singleMatch[1], singleMatch[2]) ?? {};
+    }
+
+    const reaction = route.match(MESSAGE_REACTION);
+    if (reaction) return handleReaction(ctx, method, reaction[1], reaction[2], reaction[3]);
+
+    // Unknown read → empty stub; unknown write → plausible id so the caller continues.
+    if (method === "GET") return {};
+    return { id: guild.nextId() };
+  }
+
+  async function handle(
+    method: string,
+    route: string,
+    requestOptions?: RestRequestOptions,
+  ): Promise<unknown> {
+    const forwarded = passthrough(method, route, requestOptions);
+    if (forwarded) return forwarded;
+    return dispatch(method, route, (requestOptions?.body ?? {}) as RestBody);
+  }
+
+  return { handle };
+}

--- a/src/lib/simulator/run-registry.ts
+++ b/src/lib/simulator/run-registry.ts
@@ -1,0 +1,22 @@
+import type { SimConversation } from "./conversation.ts";
+
+import { bootstrapSimulator } from "./bootstrap.ts";
+
+// The fakes are process-global, so a process holds exactly one active session.
+// Switching session id re-bootstraps (re-installs the globals at the new
+// session's transports) and discards the previous conversation.
+let current: SimConversation | undefined;
+
+export function getOrCreateSession(sessionId: string): SimConversation {
+  if (current?.id !== sessionId) current = bootstrapSimulator(sessionId);
+  return current;
+}
+
+export function getSession(sessionId: string): SimConversation | undefined {
+  return current?.id === sessionId ? current : undefined;
+}
+
+/** Drop the active session (tests / explicit reset). */
+export function resetSessions(): void {
+  current = undefined;
+}

--- a/src/lib/simulator/run-registry.ts
+++ b/src/lib/simulator/run-registry.ts
@@ -8,7 +8,12 @@ import { bootstrapSimulator } from "./bootstrap.ts";
 let current: SimConversation | undefined;
 
 export function getOrCreateSession(sessionId: string): SimConversation {
-  if (current?.id !== sessionId) current = bootstrapSimulator(sessionId);
+  if (current?.id !== sessionId) {
+    // Close the outgoing bus so any lingering SSE subscriber is released
+    // before the new session re-installs the process-global transports.
+    current?.bus.close();
+    current = bootstrapSimulator(sessionId);
+  }
   return current;
 }
 
@@ -18,5 +23,6 @@ export function getSession(sessionId: string): SimConversation | undefined {
 
 /** Drop the active session (tests / explicit reset). */
 export function resetSessions(): void {
+  current?.bus.close();
   current = undefined;
 }

--- a/src/lib/simulator/trace-orchestrator.test.ts
+++ b/src/lib/simulator/trace-orchestrator.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentContext } from "@/lib/ai/context";
+import type { TurnUsageTracker } from "@/lib/ai/turn-usage";
+import type { OrchestratorAgent, OrchestratorFactory } from "@/lib/ai/types";
+
+import {
+  discordRESTClass,
+  linearClientClass,
+  notionClientClass,
+  octokitClass,
+  resendClass,
+} from "@/lib/test/fixtures";
+
+// trace-orchestrator imports createOrchestrator, which transitively instantiates
+// third-party SDK clients (octokit/linear/notion/…) at module load. Neutralize
+// them so the import chain resolves without real creds (mirrors conversation.test).
+vi.mock("@linear/sdk", () => ({ LinearClient: linearClientClass() }));
+vi.mock("octokit", () => ({ Octokit: octokitClass() }));
+vi.mock("@octokit/auth-app", () => ({ createAppAuth: vi.fn(() => ({})) }));
+vi.mock("@discordjs/rest", () => ({ REST: discordRESTClass() }));
+vi.mock("@notionhq/client", () => ({ Client: notionClientClass() }));
+vi.mock("resend", () => ({ Resend: resendClass() }));
+vi.mock("@vercel/edge-config", () => ({
+  createClient: vi.fn(() => ({ getAll: vi.fn().mockResolvedValue({}) })),
+}));
+
+const { SimEventBus } = await import("./event-bus.ts");
+const { createTracingOrchestratorFactory } = await import("./trace-orchestrator.ts");
+
+/** A base factory whose agent replays a fixed AI-SDK-shaped fullStream. */
+function fakeFactory(parts: unknown[]): OrchestratorFactory {
+  return (): OrchestratorAgent => ({
+    stream: async () => ({
+      fullStream: (async function* () {
+        for (const part of parts) yield part;
+      })(),
+      totalUsage: Promise.resolve({}),
+      steps: Promise.resolve([]),
+    }),
+  });
+}
+
+async function drain(stream: AsyncIterable<unknown>): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for await (const part of stream) out.push(part);
+  return out;
+}
+
+const CTX = null as unknown as AgentContext;
+const TRACKER = null as unknown as TurnUsageTracker;
+
+describe("createTracingOrchestratorFactory", () => {
+  it("re-emits tool lifecycle parts as trace.tool events, matched by toolCallId", async () => {
+    const bus = new SimEventBus("t1");
+    const factory = createTracingOrchestratorFactory(
+      bus,
+      fakeFactory([
+        { type: "tool-input-start", toolCallId: "c1", toolName: "web_search" },
+        { type: "tool-result", toolCallId: "c1", preliminary: true },
+        { type: "tool-result", toolCallId: "c1" },
+        { type: "text-delta", id: "t", text: "done" },
+      ]),
+    );
+    const agent = factory(CTX, TRACKER, undefined, "anthropic/claude-sonnet-4.6", null);
+    const result = await agent.stream({ messages: [] });
+    await drain(result.fullStream);
+
+    const trace = bus.history().filter((e) => e.type === "trace.tool");
+    expect(trace).toHaveLength(3);
+    expect(trace.every((e) => e.type === "trace.tool" && e.toolCallId === "c1")).toBe(true);
+    const start = trace[0];
+    expect(start.type === "trace.tool" && start.phase).toBe("start");
+    expect(start.type === "trace.tool" && start.toolName).toBe("web_search");
+    const prelim = trace[1];
+    expect(prelim.type === "trace.tool" && prelim.phase).toBe("result");
+    expect(prelim.type === "trace.tool" && prelim.preliminary).toBe(true);
+  });
+
+  it("splits delegate_<domain> tool calls into a delegateName for subagent rows", async () => {
+    const bus = new SimEventBus("td");
+    const factory = createTracingOrchestratorFactory(
+      bus,
+      fakeFactory([
+        { type: "tool-input-start", toolCallId: "d1", toolName: "delegate_github" },
+        { type: "tool-input-start", toolCallId: "w1", toolName: "web_search" },
+      ]),
+    );
+    await drain(
+      (await factory(CTX, TRACKER, undefined, "model", null).stream({ messages: [] })).fullStream,
+    );
+
+    const trace = bus.history().filter((e) => e.type === "trace.tool");
+    const delegate = trace.find((e) => e.type === "trace.tool" && e.toolCallId === "d1");
+    expect(delegate?.type === "trace.tool" && delegate.delegateName).toBe("github");
+    const plain = trace.find((e) => e.type === "trace.tool" && e.toolCallId === "w1");
+    expect(plain?.type === "trace.tool" && plain.delegateName).toBeUndefined();
+  });
+
+  it("emits an error-phase row for tool-error parts", async () => {
+    const bus = new SimEventBus("t2");
+    const factory = createTracingOrchestratorFactory(
+      bus,
+      fakeFactory([
+        { type: "tool-input-start", toolCallId: "c9", toolName: "schedule_task" },
+        { type: "tool-error", toolCallId: "c9" },
+      ]),
+    );
+    const agent = factory(CTX, TRACKER, undefined, "model", null);
+    await drain((await agent.stream({ messages: [] })).fullStream);
+
+    const phases = bus
+      .history()
+      .filter((e) => e.type === "trace.tool")
+      .map((e) => (e.type === "trace.tool" ? e.phase : ""));
+    expect(phases).toEqual(["start", "error"]);
+  });
+
+  it("passes every stream part through unchanged (renderer still drives the UX)", async () => {
+    const bus = new SimEventBus("t3");
+    const parts = [
+      { type: "tool-input-start", toolCallId: "c1", toolName: "web_search" },
+      { type: "tool-result", toolCallId: "c1" },
+      { type: "text-delta", id: "t", text: "hi" },
+    ];
+    const factory = createTracingOrchestratorFactory(bus, fakeFactory(parts));
+    const agent = factory(CTX, TRACKER, undefined, "model", null);
+    const seen = await drain((await agent.stream({ messages: [] })).fullStream);
+    expect(seen).toEqual(parts);
+  });
+});

--- a/src/lib/simulator/trace-orchestrator.ts
+++ b/src/lib/simulator/trace-orchestrator.ts
@@ -1,0 +1,86 @@
+import type { OrchestratorAgent, OrchestratorFactory } from "@/lib/ai/types";
+
+import { DELEGATE_PREFIX } from "@/lib/ai/constants";
+import { createOrchestrator } from "@/lib/ai/orchestrator";
+
+import type { SimEventBus } from "./event-bus.ts";
+
+/** The tool-lifecycle parts of the AI SDK fullStream we re-emit as trace rows. */
+interface ToolStreamPart {
+  type: string;
+  toolCallId?: string;
+  toolName?: string;
+  preliminary?: boolean;
+}
+
+/**
+ * A delegation surfaces in the orchestrator stream as a `delegate_<domain>`
+ * tool call. Split off the domain as the `delegateName` so the Trace tab can
+ * render it as a subagent row ("delegate › github") rather than a raw tool name.
+ */
+function traceLabel(toolName: string): { toolName: string; delegateName?: string } {
+  if (toolName.startsWith(DELEGATE_PREFIX)) {
+    return { toolName, delegateName: toolName.slice(DELEGATE_PREFIX.length) };
+  }
+  return { toolName };
+}
+
+/**
+ * Tee the real orchestrator's `fullStream`: re-emit each tool-lifecycle part as
+ * a `trace.tool` SimEvent (so the inspector's Trace tab populates), then yield
+ * the part unchanged so `renderStream` still drives the message UX. This
+ * re-homes the trace emission MOCK mode used to hardwire — the renderer and the
+ * production `streamTurn` stay untouched. Tool-result/-error parts may omit
+ * `toolName`; the reducer matches the closing row to its opening row by
+ * `toolCallId`, so the label always comes from the `start` row.
+ */
+async function* teeTrace(
+  fullStream: AsyncIterable<unknown>,
+  bus: SimEventBus,
+): AsyncGenerator<unknown> {
+  for await (const raw of fullStream) {
+    const part = raw as ToolStreamPart;
+    const toolCallId = part.toolCallId ?? "unknown";
+    const { toolName, delegateName } = traceLabel(part.toolName ?? "tool");
+    if (part.type === "tool-input-start") {
+      bus.emit({ type: "trace.tool", toolCallId, toolName, delegateName, phase: "start" });
+    } else if (part.type === "tool-result") {
+      bus.emit({
+        type: "trace.tool",
+        toolCallId,
+        toolName,
+        delegateName,
+        phase: "result",
+        preliminary: part.preliminary,
+      });
+    } else if (part.type === "tool-error") {
+      bus.emit({ type: "trace.tool", toolCallId, toolName, delegateName, phase: "error" });
+    }
+    yield raw;
+  }
+}
+
+/**
+ * An {@link OrchestratorFactory} that runs the REAL orchestrator and tees its
+ * stream into the {@link SimEventBus} for the inspector's Trace tab. The only
+ * `createAgent` the simulator injects now that MOCK mode is gone — a thin
+ * tracing passthrough around `createOrchestrator`, not a stand-in for the model.
+ *
+ * `baseFactory` defaults to the real `createOrchestrator`; tests inject a fake
+ * to drive a deterministic stream without a model (mirroring how `streamTurn`
+ * accepts an injected factory).
+ */
+export function createTracingOrchestratorFactory(
+  bus: SimEventBus,
+  baseFactory: OrchestratorFactory = createOrchestrator,
+): OrchestratorFactory {
+  return (ctx, tracker, extraMetadata, model, budget): OrchestratorAgent => {
+    const agent = baseFactory(ctx, tracker, extraMetadata, model, budget);
+    return {
+      stream: async (input) => {
+        const result = await agent.stream(input);
+        return { ...result, fullStream: teeTrace(result.fullStream, bus) };
+      },
+    };
+  };
+}

--- a/src/lib/simulator/types.ts
+++ b/src/lib/simulator/types.ts
@@ -1,0 +1,282 @@
+/**
+ * Wire + domain types for the Discord chat simulator. Everything the browser
+ * UI and the backend share lives here so the SSE contract has one source of
+ * truth. `SimEmbed`/`SimButton`/`SimActionRow` are deliberately loose mirrors
+ * of the `discord-api-types` shapes the bot already builds (the fake REST
+ * passes tool/approval payloads through verbatim).
+ */
+
+import type { UserRole } from "@/lib/ai/constants";
+import type { ChatMessage, SerializedAgentContext } from "@/lib/ai/types";
+
+export interface SimEmbedAuthor {
+  name: string;
+  icon_url?: string;
+}
+
+export interface SimEmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+export interface SimEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  author?: SimEmbedAuthor;
+  fields?: SimEmbedField[];
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+export interface SimButtonEmoji {
+  name?: string;
+  id?: string;
+  animated?: boolean;
+}
+
+/** A Discord button (ComponentType.Button === 2). */
+export interface SimButton {
+  type: 2;
+  style: number;
+  label?: string;
+  emoji?: SimButtonEmoji;
+  custom_id?: string;
+  url?: string;
+  disabled?: boolean;
+}
+
+/** A Discord action row (ComponentType.ActionRow === 1). */
+export interface SimActionRow {
+  type: 1;
+  components: SimButton[];
+}
+
+export interface SimReaction {
+  emoji: string;
+  count: number;
+  me: boolean;
+}
+
+/** One message in a virtual channel, as the UI renders it. */
+export interface SimMessage {
+  id: string;
+  channelId: string;
+  authorId: string;
+  authorKind: "bot" | "user";
+  content: string;
+  embeds: SimEmbed[];
+  components: SimActionRow[];
+  reactions: SimReaction[];
+  createdAt: string;
+  editedAt?: string;
+  /** Set for interaction follow-ups posted with the ephemeral flag (64). */
+  ephemeral?: boolean;
+  /** Set when this message is a tool-approval prompt, so the UI can wire its buttons. */
+  approvalId?: string;
+}
+
+export interface VirtualChannel {
+  id: string;
+  name: string;
+  kind: "channel" | "thread";
+  parentId?: string;
+}
+
+export interface VirtualMember {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl?: string;
+  bot?: boolean;
+  roles: string[];
+}
+
+export interface VirtualRole {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface VirtualEmoji {
+  id: string;
+  name: string;
+  animated: boolean;
+  url?: string;
+}
+
+/** Full virtual-server state, for mention resolution + reconnect hydration. */
+export interface VirtualGuildSnapshot {
+  guildId: string;
+  botUserId: string;
+  channels: VirtualChannel[];
+  members: VirtualMember[];
+  roles: VirtualRole[];
+  emojis: VirtualEmoji[];
+  messages: SimMessage[];
+}
+
+export interface SimUsageSummary {
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  toolCallCount: number;
+  stepCount: number;
+  toolNames: string[];
+}
+
+/** One context-budget category (system prompt, tools, history, …) for the inspector. */
+export interface SimContextCategory {
+  label: string;
+  chars: number;
+  estimatedTokens: number;
+  items?: { name: string; estimatedTokens: number }[];
+}
+
+/**
+ * A render-ready view of everything the model saw for the conversation — the
+ * inspector's "Context" tab. Built backend-side from the real
+ * `buildContextSnapshot` + `breakdownFromSnapshot` so it matches `/inspect-context`.
+ */
+export interface SimContextSnapshot {
+  model: string;
+  systemPrompt: string;
+  tools: { name: string; description: string }[];
+  context: SerializedAgentContext;
+  messages: ChatMessage[];
+  categories: SimContextCategory[];
+  estimatedInputTokens: number;
+  totalUsage: SimUsageSummary;
+  turnCount: number;
+  totalCostUsd?: { input: number; output: number; total: number };
+}
+
+interface SimEventBase {
+  /** Monotonic per run — gives the UI a total order for replay. */
+  seq: number;
+  ts: number;
+  runId: string;
+}
+
+/**
+ * The SSE wire contract. `message.*` carry exactly what the bot sent to
+ * Discord (captured at the two transports); `approval.*` are derived
+ * convenience events emitted alongside the raw `message.*` so the buttons get
+ * their `approvalId` without the UI re-parsing embeds.
+ */
+export type SimEvent =
+  | (SimEventBase & { type: "guild.sync"; guild: VirtualGuildSnapshot })
+  | (SimEventBase & {
+      type: "run.start";
+      turnIndex: number;
+      channelId: string;
+      threadId?: string;
+    })
+  | (SimEventBase & {
+      type: "run.finish";
+      turnIndex: number;
+      discordMessageId: string;
+      model: string;
+      text: string;
+      usage: SimUsageSummary;
+    })
+  | (SimEventBase & { type: "run.error"; message: string; traceId?: string })
+  | (SimEventBase & { type: "message.create"; message: SimMessage })
+  | (SimEventBase & {
+      type: "message.edit";
+      messageId: string;
+      channelId: string;
+      content?: string;
+      embeds?: SimEmbed[];
+      components?: SimActionRow[];
+      editedAt: string;
+    })
+  | (SimEventBase & { type: "message.delete"; messageId: string; channelId: string })
+  | (SimEventBase & {
+      type: "reaction.add";
+      messageId: string;
+      channelId: string;
+      emoji: string;
+      byBot: boolean;
+    })
+  | (SimEventBase & {
+      type: "reaction.remove";
+      messageId: string;
+      channelId: string;
+      emoji: string;
+      byBot: boolean;
+    })
+  | (SimEventBase & {
+      type: "channel.create";
+      channelId: string;
+      name: string;
+      kind: "channel" | "thread";
+      parentId?: string;
+      /** The parent-channel message a thread branched from (its starter). */
+      starterMessageId?: string;
+    })
+  | (SimEventBase & {
+      type: "approval.prompt";
+      approvalId: string;
+      messageId: string;
+      channelId: string;
+      toolName: string;
+      delegateName?: string;
+      reason: string;
+      embed: SimEmbed;
+      components: SimActionRow[];
+    })
+  | (SimEventBase & {
+      type: "approval.decision";
+      approvalId: string;
+      messageId: string;
+      channelId: string;
+      status: "approved" | "denied" | "timeout";
+      decidedByUserId: string | null;
+      embed: SimEmbed;
+    })
+  | (SimEventBase & { type: "context.snapshot"; snapshot: SimContextSnapshot })
+  | (SimEventBase & {
+      type: "trace.tool";
+      toolCallId: string;
+      toolName: string;
+      delegateName?: string;
+      phase: "start" | "result" | "error";
+      preliminary?: boolean;
+    });
+
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/** A `SimEvent` minus the fields {@link SimEventBus} stamps on `emit()`. */
+export type EmittableEvent = DistributiveOmit<SimEvent, "seq" | "ts" | "runId">;
+
+/** Body of `POST /api/simulator/chat`. */
+export interface SimChatRequest {
+  sessionId: string;
+  content: string;
+  role: UserRole;
+  username?: string;
+  nickname?: string;
+  channelName?: string;
+  /**
+   * When the message is sent from inside an existing thread, its id — the bot
+   * keeps replying there. Omitted for a base-channel message.
+   */
+  threadId?: string;
+  /**
+   * For a base-channel message: open a thread for the reply (the real bot's
+   * behavior on a channel mention). Defaults to true. Ignored when `threadId`
+   * is set.
+   */
+  openThread?: boolean;
+}
+
+/** Body of `POST /api/simulator/approve`. */
+export interface SimApproveRequest {
+  sessionId: string;
+  approvalId: string;
+  decision: "approve" | "deny";
+  clickerUserId?: string;
+  clickerRoles?: string[];
+}

--- a/src/lib/simulator/virtual-guild.ts
+++ b/src/lib/simulator/virtual-guild.ts
@@ -1,0 +1,205 @@
+import type {
+  SimActionRow,
+  SimEmbed,
+  SimMessage,
+  VirtualChannel,
+  VirtualEmoji,
+  VirtualGuildSnapshot,
+  VirtualMember,
+  VirtualRole,
+} from "./types.ts";
+
+interface CreateMessageInit {
+  authorId: string;
+  authorKind: "bot" | "user";
+  content?: string;
+  embeds?: SimEmbed[];
+  components?: SimActionRow[];
+  ephemeral?: boolean;
+  approvalId?: string;
+}
+
+interface MessagePatch {
+  content?: string;
+  embeds?: SimEmbed[];
+  components?: SimActionRow[];
+}
+
+interface VirtualGuildOptions {
+  guildId: string;
+  botUserId: string;
+  channels?: { id?: string; name: string }[];
+  members?: VirtualMember[];
+  roles?: VirtualRole[];
+  emojis?: VirtualEmoji[];
+}
+
+/**
+ * In-memory model of one Discord server: channels/threads, messages,
+ * reactions, members, roles, emoji. Pure state + id minting — it never emits
+ * events (the transport adapters do), so the bus stays the single funnel.
+ */
+export class VirtualGuild {
+  readonly guildId: string;
+  readonly botUserId: string;
+
+  private channels = new Map<string, VirtualChannel>();
+  private channelIdByName = new Map<string, string>();
+  private messages = new Map<string, SimMessage>();
+  private members = new Map<string, VirtualMember>();
+  private roles = new Map<string, VirtualRole>();
+  private emojis = new Map<string, VirtualEmoji>();
+
+  private idSeq = 1;
+  private readonly idBase = 930_000_000_000_000;
+
+  constructor(options: VirtualGuildOptions) {
+    this.guildId = options.guildId;
+    this.botUserId = options.botUserId;
+    for (const channel of options.channels ?? []) {
+      this.registerChannel(channel.id ?? this.nextId(), channel.name, "channel");
+    }
+    for (const member of options.members ?? []) this.members.set(member.id, member);
+    for (const role of options.roles ?? []) this.roles.set(role.id, role);
+    for (const emoji of options.emojis ?? []) this.emojis.set(emoji.id, emoji);
+  }
+
+  /** Mint a fresh digit-only snowflake-shaped id. */
+  nextId(): string {
+    return String(this.idBase + this.idSeq++);
+  }
+
+  private registerChannel(
+    id: string,
+    name: string,
+    kind: "channel" | "thread",
+    parentId?: string,
+  ): VirtualChannel {
+    const channel: VirtualChannel = { id, name, kind, parentId };
+    this.channels.set(id, channel);
+    if (!this.channelIdByName.has(name)) this.channelIdByName.set(name, id);
+    return channel;
+  }
+
+  getChannel(id: string): VirtualChannel | undefined {
+    return this.channels.get(id);
+  }
+
+  /** Find a channel by name, creating it (kind "channel") if absent. */
+  ensureChannel(name: string): VirtualChannel {
+    const existingId = this.channelIdByName.get(name);
+    if (existingId) return this.channels.get(existingId)!;
+    return this.registerChannel(this.nextId(), name, "channel");
+  }
+
+  createThread(parentId: string, name: string): VirtualChannel {
+    return this.registerChannel(this.nextId(), name, "thread", parentId);
+  }
+
+  getMember(id: string): VirtualMember | undefined {
+    return this.members.get(id);
+  }
+
+  addMember(member: VirtualMember): void {
+    this.members.set(member.id, member);
+  }
+
+  createMessage(channelId: string, init: CreateMessageInit): SimMessage {
+    const message: SimMessage = {
+      id: this.nextId(),
+      channelId,
+      authorId: init.authorId,
+      authorKind: init.authorKind,
+      content: init.content ?? "",
+      embeds: init.embeds ?? [],
+      components: init.components ?? [],
+      reactions: [],
+      createdAt: new Date().toISOString(),
+      ephemeral: init.ephemeral,
+      approvalId: init.approvalId,
+    };
+    this.messages.set(message.id, message);
+    return message;
+  }
+
+  editMessage(channelId: string, messageId: string, patch: MessagePatch): SimMessage {
+    const existing = this.messages.get(messageId) ?? this.adoptUnknown(channelId, messageId);
+    if (patch.content !== undefined) existing.content = patch.content;
+    if (patch.embeds !== undefined) existing.embeds = patch.embeds;
+    if (patch.components !== undefined) existing.components = patch.components;
+    existing.editedAt = new Date().toISOString();
+    return existing;
+  }
+
+  /**
+   * Materialize a record for a message id we never minted (e.g. a pre-created
+   * placeholder adopted by id) so an edit has something to mutate.
+   */
+  private adoptUnknown(channelId: string, messageId: string): SimMessage {
+    const message: SimMessage = {
+      id: messageId,
+      channelId,
+      authorId: this.botUserId,
+      authorKind: "bot",
+      content: "",
+      embeds: [],
+      components: [],
+      reactions: [],
+      createdAt: new Date().toISOString(),
+    };
+    this.messages.set(messageId, message);
+    return message;
+  }
+
+  getMessage(channelId: string, messageId: string): SimMessage | undefined {
+    return this.messages.get(messageId);
+  }
+
+  /** Most-recent-first, like Discord's `getMessages`. */
+  listMessages(channelId: string, limit = 50): SimMessage[] {
+    return [...this.messages.values()]
+      .filter((message) => message.channelId === channelId && !message.ephemeral)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit);
+  }
+
+  deleteMessage(channelId: string, messageId: string): void {
+    this.messages.delete(messageId);
+  }
+
+  addReaction(channelId: string, messageId: string, emoji: string, byBot: boolean): void {
+    const message = this.messages.get(messageId);
+    if (!message) return;
+    const existing = message.reactions.find((reaction) => reaction.emoji === emoji);
+    if (existing) {
+      existing.count += 1;
+      if (byBot) existing.me = true;
+    } else {
+      message.reactions.push({ emoji, count: 1, me: byBot });
+    }
+  }
+
+  removeReaction(channelId: string, messageId: string, emoji: string, byBot: boolean): void {
+    const message = this.messages.get(messageId);
+    if (!message) return;
+    const existing = message.reactions.find((reaction) => reaction.emoji === emoji);
+    if (!existing) return;
+    existing.count -= 1;
+    if (byBot) existing.me = false;
+    if (existing.count <= 0) {
+      message.reactions = message.reactions.filter((reaction) => reaction.emoji !== emoji);
+    }
+  }
+
+  snapshot(): VirtualGuildSnapshot {
+    return {
+      guildId: this.guildId,
+      botUserId: this.botUserId,
+      channels: [...this.channels.values()],
+      members: [...this.members.values()],
+      roles: [...this.roles.values()],
+      emojis: [...this.emojis.values()],
+      messages: [...this.messages.values()].filter((message) => !message.ephemeral),
+    };
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,9 +2,12 @@ import { evlog, type EvlogVariables } from "evlog/hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 
+import { isSimEnabled } from "@/lib/simulator/guard";
+
 import crons from "./routes/crons";
 import gateway from "./routes/gateway";
 import interactions from "./routes/interactions";
+import simulator from "./routes/simulator";
 
 const discord = new Hono();
 discord.route("/", gateway);
@@ -15,3 +18,9 @@ app.use(cors());
 app.use(evlog());
 app.route("/discord", discord);
 app.route("/", crons);
+
+// Dev-only chat simulator. Mounted only behind the gate so its process-global
+// transport swaps can never run in a real bot process.
+if (isSimEnabled()) {
+  app.route("/simulator", simulator);
+}

--- a/src/server/routes/simulator.ts
+++ b/src/server/routes/simulator.ts
@@ -1,0 +1,53 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+
+import type { SimApproveRequest, SimChatRequest } from "@/lib/simulator/types";
+
+import { getOrCreateSession, getSession } from "@/lib/simulator/run-registry";
+
+const simulator = new Hono();
+
+/**
+ * Run one turn and stream the captured Discord events (placeholder, throttled
+ * edits, splits, approval cards, reactions) as Server-Sent Events. One SSE
+ * connection per turn; the browser keeps conversation state across turns.
+ */
+simulator.post("/chat", async (c) => {
+  const req = await c.req.json<SimChatRequest>();
+  const session = getOrCreateSession(req.sessionId);
+  return streamSSE(c, async (stream) => {
+    const events = session.bus.subscribe({ signal: c.req.raw.signal, replayHistory: false });
+    const pump = (async () => {
+      for await (const event of events) {
+        await stream.writeSSE({
+          event: event.type,
+          id: String(event.seq),
+          data: JSON.stringify(event),
+        });
+        if (event.type === "run.finish" || event.type === "run.error") break;
+      }
+    })();
+    try {
+      await session.runTurn(req);
+    } finally {
+      await pump;
+    }
+  });
+});
+
+/** Drive the real approval-button handler → unblocks the waiting tool wrapper. */
+simulator.post("/approve", async (c) => {
+  const body = await c.req.json<SimApproveRequest>();
+  const session = getSession(body.sessionId);
+  if (!session) return c.json({ ok: false, reason: "no active session" }, 404);
+  return c.json(await session.decide(body));
+});
+
+/** Reconnect hydration: current virtual-server snapshot + the event history. */
+simulator.get("/state", (c) => {
+  const session = getSession(c.req.query("sessionId") ?? "");
+  if (!session) return c.json({ guild: null, history: [] });
+  return c.json({ guild: session.guild.snapshot(), history: session.bus.history() });
+});
+
+export default simulator;

--- a/src/workflows/chat.ts
+++ b/src/workflows/chat.ts
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/nextjs";
-import { generateText } from "ai";
 import { createHook, FatalError, getWorkflowMetadata, sleep } from "workflow";
 
 import type {
@@ -11,6 +10,13 @@ import type {
 
 import { ContextSnapshotStore } from "@/bot/context-snapshot";
 import { ConversationStore } from "@/bot/store";
+import { LEADIN_TURN_LIMIT } from "@/lib/ai/constants";
+import {
+  capHistory,
+  stampCurrentTime,
+  summarizeDroppedHistory,
+  truncateForHistory,
+} from "@/lib/ai/conversation-turn";
 import { streamTurn } from "@/lib/ai/streaming";
 import { addTurnUsage, emptyTurnUsage } from "@/lib/ai/turn-usage";
 import { createDiscordAPI } from "@/lib/discord/client";
@@ -23,18 +29,6 @@ import { releaseSession } from "@/lib/sandbox/session";
 import type { ChatHookEvent, ChatPayload } from "./types";
 
 export type { ChatHookEvent, ChatPayload } from "./types";
-
-/** Cap on accumulated user+assistant turns — 25 exchanges. */
-const MAX_HISTORY_MESSAGES = 50;
-
-/**
- * Stored assistant turns are clipped to this many chars. The full text was
- * already delivered to Discord; history only needs enough for continuity.
- */
-const MAX_STORED_ASSISTANT_CHARS = 4000;
-
-/** Cheap model that compacts dropped history into one summary message. */
-const HISTORY_SUMMARY_MODEL = "openai/gpt-5.4-mini";
 
 /**
  * How long the hook loop waits for a follow-up before ending the
@@ -58,52 +52,17 @@ const IDLE = "idle-timeout";
  */
 const DRAIN_GRACE = "10s";
 
-function truncateForHistory(text: string): string {
-  if (text.length <= MAX_STORED_ASSISTANT_CHARS) return text;
-  return `${text.slice(0, MAX_STORED_ASSISTANT_CHARS)}\n[truncated]`;
-}
-
+/**
+ * Durable wrapper around {@link summarizeDroppedHistory}: the `"use step"`
+ * directive makes the summary a retryable workflow step so a cap that lands
+ * mid-conversation isn't re-billed on replay. Passed into `capHistory` so the
+ * shared capping logic stays byte-identical to the simulator's.
+ */
 async function summarizeHistory(dropped: ChatMessage[]): Promise<string> {
   "use step";
-  const transcript = dropped.map((m) => `${m.role}: ${m.content}`).join("\n\n");
-  const { text } = await generateText({
-    model: HISTORY_SUMMARY_MODEL,
-    prompt:
-      "Summarize this conversation excerpt in under 200 words. Preserve concrete facts, decisions, names, links, and any commitments the assistant made. Write it as context the assistant will rely on to continue the conversation.\n\n" +
-      transcript,
-  });
-  return text;
+  return summarizeDroppedHistory(dropped);
 }
 summarizeHistory.maxRetries = 1;
-
-/**
- * Keep history under the cap by replacing the dropped prefix with one
- * cheap-model summary message. Falls back to plain dropping when the summary
- * step fails — losing old context beats failing the conversation.
- */
-async function capHistory(messages: ChatMessage[]): Promise<void> {
-  if (messages.length <= MAX_HISTORY_MESSAGES) return;
-  // +1 reserves room for the summary message itself; then advance to the next
-  // user message so the retained history starts with a user turn. (The
-  // summary is also user-role, so the model may see two consecutive user
-  // messages — the AI SDK provider conversion merges those into one.) Never
-  // drop the latest exchange, even on a degenerate non-alternating tail —
-  // otherwise a failed summary could wipe the entire history.
-  const maxDrop = messages.length - 2;
-  let dropCount = Math.min(messages.length - MAX_HISTORY_MESSAGES + 1, maxDrop);
-  while (dropCount < maxDrop && messages[dropCount].role !== "user") dropCount += 1;
-  const dropped = messages.slice(0, dropCount);
-  try {
-    const summary = await summarizeHistory(dropped);
-    messages.splice(0, dropCount, {
-      role: "user",
-      content: `[Summary of ${dropped.length} earlier messages, compacted to save space]\n${summary}`,
-    });
-  } catch {
-    countMetric("workflow.chat.history_summary_failed");
-    messages.splice(0, dropCount);
-  }
-}
 
 interface RunTurnArgs {
   channelId: string;
@@ -402,25 +361,6 @@ interface StableScope {
 }
 
 /**
- * Followup turns past this count drop the scraped lead-in blocks from the
- * system prompt — by then the model has real conversation history and the
- * lead-in is just pinned token weight. Dropping it changes the prompt once
- * (one cache miss at the boundary turn), after which it is stable again.
- */
-const LEADIN_TURN_LIMIT = 3;
-
-/**
- * Append the turn's wall-clock time to a followup user message. The system
- * prompt's `{{NOW_ISO}}`/`{{DATE}}` are pinned to the first turn so the
- * prompt stays byte-stable across turns; this stamp is how later turns learn
- * the real current time. It is persisted into conversation history so the
- * replayed prefix stays byte-stable too.
- */
-function stampCurrentTime(content: string, nowISO: string | undefined): string {
-  return nowISO ? `${content}\n\n[current time: ${nowISO}]` : content;
-}
-
-/**
  * Run one conversation turn: push the user message, execute the turn step,
  * and fold the assistant reply into history. On failure (sentinel or a step
  * error after retries) the pushed user message is popped so the failed turn
@@ -462,7 +402,7 @@ async function runConversationTurn(args: {
     return;
   }
   state.messages.push({ role: "assistant", content: truncateForHistory(turn.text) });
-  await capHistory(state.messages);
+  await capHistory(state.messages, summarizeHistory);
   state.turnCount += 1;
   state.totalUsage = addTurnUsage(state.totalUsage, turn.usage);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
         "src/lib/ai/tools/**",
         "src/lib/evlog.ts",
         "src/lib/db/**",
+        // Dev-only, gated chat simulator (never runs in production). Its load-
+        // bearing pure logic keeps its own unit tests; the orchestration glue
+        // is exercised in-browser, so unit coverage here isn't meaningful.
+        "src/lib/simulator/**",
         // Thin wrappers around @vercel/sandbox / factory wiring. Covered by
         // hooks.ts + integration tests — unit coverage here would be 90%
         // SDK-glue assertions against mocks.


### PR DESCRIPTION
## Why

There was no way to see what the bot *sends to Discord* — streamed edits, tool-activity lines, subagent previews, footers, message splitting, approval cards — without deploying and poking a real server: slow, noisy, not reproducible. This adds a gated, dev-only `/simulator` that runs the **real orchestrator** locally and renders that UX faithfully, so message construction and the model's context can be iterated in a tight loop. It's also a harness for running agents locally.

Before:

```
Iterate on message UX → deploy → @mention the bot in a real Discord server →
read it back by eye → repeat. No view into the context/trace the model saw.
```

After:

```
SIMULATOR_ENABLED=1 SKIP_ENV_VALIDATION=1 next dev → open /simulator →
@mention the bot → watch the real thread/stream/footer render, with a live
context snapshot + execution trace in the side inspector.
```

## What changed

- **`/simulator` page** (`src/app/simulator/**`): a two-pane React UI — a high-fidelity Discord chat column (chat → thread → follow-up) and a tabbed inspector (session **Controls**, live **Context** snapshot, execution **Trace**). Hand-rolled Discord-markdown renderer, embeds, and clickable approval cards.
- **Drives the bot's real plumbing** (`src/lib/simulator/**`): builds a `GATEWAY_MESSAGE_CREATE` packet + `HandlerContext`, runs the actual mention detection and `prepareFreshTurn` (thread creation, lead-in, placeholder, `AgentContext`), then `streamTurn`. Two virtual Discord transports (fake `@discordjs/core` API + smart `@discordjs/rest` proxy) capture exactly what the bot emits; events fan out over SSE.
- **Context tab** reuses the real `buildContextSnapshot` + `/inspect-context` breakdown; **Trace tab** is fed by teeing the orchestrator's tool-call stream (delegations render as `delegate › <domain>`).
- **Production seams** — all dev-gated, no-op in production:
  - `__setDiscordRestForSimulation` / `__setRedisForSimulation` overrides
  - extracted `prepareFreshTurn` + `replyEmptyMention` from the mention handler
  - extracted `conversation-turn.ts` (history capping) shared with `chat.ts`
  - gated `app.route("/simulator")` mount behind `isSimEnabled()`

## Test plan

- `bun run typecheck` — clean
- `bun lint` — 0 errors
- `bun format --check` — clean
- `bun test:coverage` — 1066/1066 pass; thresholds met (stmts 92.4%, branches 88.7%, funcs 92.3%, lines 92.9%)
- Manual (in-browser, Chrome): sent a mention → real thread created, real orchestrator engaged, reply/footer/error all rendered via real bot code; Context + Trace tabs populate. A full streamed reply needs gateway creds (`AI_GATEWAY_API_KEY` or a fresh `VERCEL_OIDC_TOKEN`) — env/ops only, not code.

> Dev-only: never set `SIMULATOR_ENABLED` on a deployment. The transport/Redis swaps no-op in production and the route only mounts behind the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)