### PR TITLE
Let a publisher whose revision counter fell behind catch up

### DIFF
--- a/packages/agents/agent/channels/discord.ts
+++ b/packages/agents/agent/channels/discord.ts
@@ -272,14 +272,30 @@ async function publishDesiredRender(
     ...(authorizations.length === 0 ? {} : { authorizations }),
   };
 
-  try {
-    const accepted = await renderPublisher.publish(intent);
-    if (accepted) {
-      state.renderRevision = revision;
+  /** `undefined` means the counter was behind and has been resynced; try again. */
+  const land = async (attempt: RenderIntent): Promise<boolean | undefined> => {
+    const publication = await renderPublisher.publish(attempt);
+    if (publication.accepted) {
+      state.renderRevision = attempt.revision;
       state.lastRenderPublishedAt = now;
       if (input.phase === "streaming") state.lastRenderPreview = preview;
+      return true;
     }
-    return accepted;
+    // Redis already holds this revision or a later one, so this counter is
+    // behind — it advances only on a publish that lands, and anything that
+    // knocked one out (a retried step, a restored checkpoint) leaves every
+    // later attempt re-offering a number Redis has already seen. Resync to what
+    // it holds and go once more; the intent was built from current state, so
+    // only the tag was wrong.
+    if (publication.behindRevision === undefined) return false;
+    state.renderRevision = publication.behindRevision;
+    return undefined;
+  };
+
+  try {
+    const landed = await land(intent);
+    if (landed !== undefined) return landed;
+    return (await land({ ...intent, revision: state.renderRevision + 1 })) ?? false;
   } catch (cause) {
     warnFailure("publish Discord render intent", cause);
     return false;

--- a/packages/agents/agent/lib/discord/render-intent.ts
+++ b/packages/agents/agent/lib/discord/render-intent.ts
@@ -4,6 +4,8 @@ import type { ConversationStore } from "@repo/shared/conversations";
 import { BOT_ROUTES } from "@repo/shared/wire";
 import type { ParkedPayload, RenderIntent } from "@repo/shared/wire";
 
+type RenderPublication = Awaited<ReturnType<ConversationStore["render"]["publish"]>>;
+
 import { traceHeaders } from "../telemetry.ts";
 
 export interface FooterInput {
@@ -32,10 +34,10 @@ export interface RenderPublisherDeps {
 
 export function createRenderPublisher(deps: RenderPublisherDeps) {
   return {
-    publish: async (intent: RenderIntent): Promise<boolean> => {
+    publish: async (intent: RenderIntent): Promise<RenderPublication> => {
       const publication = await deps.store.publish(intent);
-      if (!publication.accepted) return false;
-      if (!publication.shouldWake) return true;
+      if (!publication.accepted) return publication;
+      if (!publication.shouldWake) return publication;
 
       // Redis is the durable path. This small callback only avoids waiting for a
       // replacement bot's startup/periodic recovery sweep.
@@ -55,7 +57,7 @@ export function createRenderPublisher(deps: RenderPublisherDeps) {
       } catch (cause) {
         console.warn("bot render callback failed; Redis recovery remains pending", cause);
       }
-      return true;
+      return publication;
     },
 
     settleAndPark: (intent: RenderIntent, parked: ParkedPayload): Promise<number | undefined> =>

--- a/packages/bot/src/utils/conversation/subagent-follower.ts
+++ b/packages/bot/src/utils/conversation/subagent-follower.ts
@@ -27,6 +27,17 @@ import type { ConversationFlowDeps } from "./types.ts";
 const MAX_LINE = 200;
 
 /**
+ * How deep the tree is followed.
+ *
+ * A delegated subagent can itself delegate — `code` runs codex, so the work worth
+ * narrating is two levels below the turn — and stopping at the first child showed
+ * only that something had started. Bounded rather than unbounded because each
+ * level opens a stream per node, and a line about a great-grandchild's tool call
+ * is further from what the person asked than one line can usefully carry.
+ */
+const MAX_DEPTH = 3;
+
+/**
  * One delegation's open streams: the parent, plus every child it adopts.
  *
  * The set matters. A child is started mid-stream and never awaited, so clearing
@@ -132,12 +143,11 @@ interface Stream {
    * Ignore anything emitted before this instant.
    *
    * Only meaningful for the parent, whose stream holds every earlier turn of the
-   * conversation. A child session is created for this delegation, so its whole
-   * stream is relevant and it passes `0`.
+   * conversation.
    */
   readonly since: number;
-  /** Whether a `subagent.called` here should open another stream. */
-  readonly adoptChildren: boolean;
+  /** How many levels below the turn this stream is; children stop at MAX_DEPTH. */
+  readonly depth: number;
 }
 
 /**
@@ -159,15 +169,16 @@ async function readStream(follow: Follow, stream: Stream): Promise<void> {
     if (signal.aborted) return;
     if (Date.parse(event.meta.at) < stream.since) continue;
 
-    if (stream.adoptChildren && event.type === "subagent.called") {
-      // Not awaited: the parent's stream must keep draining, and both feed the
-      // same line. A child does not adopt its own children — following every
-      // level would open a stream per node of the tree.
+    // Not awaited: this stream must keep draining, and every level feeds the
+    // same line.
+    if (event.type === "subagent.called" && stream.depth < MAX_DEPTH) {
       launch(follow, {
         sessionId: event.data.childSessionId,
         subagent: event.data.name,
+        // A child session is created for this delegation, so its whole stream
+        // belongs to it.
         since: 0,
-        adoptChildren: false,
+        depth: stream.depth + 1,
       });
     }
 
@@ -238,7 +249,7 @@ export function followSubagent(
       sessionId: delegation.sessionId,
       subagent: delegation.name,
       since: Date.parse(delegation.startedAt),
-      adoptChildren: true,
+      depth: 0,
     },
   );
 

--- a/packages/shared/scripts/check-render-writer.ts
+++ b/packages/shared/scripts/check-render-writer.ts
@@ -128,11 +128,9 @@ check("republishing the same frame is accepted", again.accepted, true);
 // lost, and the frame is by definition still unpainted. Only a publish that finds
 // the dispatch already advertised suppresses it.
 check("and nudges again, because the last nudge may have been lost", again.shouldWake, true);
-check(
-  "a reused revision with new content is refused",
-  await throws(() => writer.publish(intentFor(dispatchId, 1, "streaming", "different"))),
-  true,
-);
+const reused = await writer.publish(intentFor(dispatchId, 1, "streaming", "different"));
+check("a reused revision with new content is refused", reused.accepted, false);
+check("and answers with the stored revision", reused.behindRevision, 1);
 const advanced = await writer.publish(intentFor(dispatchId, 2, "streaming", "second"));
 check("a newer frame replaces it", advanced.accepted, true);
 const readIntent = await reader.intent(dispatchId);
@@ -287,6 +285,28 @@ check(
 await writer.publish(intentFor(asked, 3, "streaming", "answered"));
 const afterAsking = (await deliveryRecord.read(KEY))?.turn.expiresAtMs ?? 0;
 check("and gives it back once nothing is being asked", afterAsking < whileAsking, true);
+
+// The wedge this replaced: the publisher's revision counter only advances on a
+// publish that lands, so anything that knocked it back — a retried step, a
+// restored checkpoint — left every later attempt re-offering a number Redis had
+// already seen, and the turn never showed anything again.
+await scrub();
+const wedged = await liveDispatch();
+await writer.publish(intentFor(wedged, 1, "streaming"));
+await writer.publish(intentFor(wedged, 2, "streaming", "second"));
+const behind = await writer.publish(intentFor(wedged, 2, "streaming", "counter fell behind"));
+check("a publisher behind the stored revision is refused", behind.accepted, false);
+check("and told what Redis holds, so it can resync", behind.behindRevision, 2);
+const resynced = await writer.publish(
+  intentFor(wedged, (behind.behindRevision ?? 0) + 1, "streaming", "resynced"),
+);
+check("so the very next attempt lands", resynced.accepted, true);
+const afterResync = await reader.intent(wedged);
+check(
+  "carrying what it was trying to say",
+  Result.isOk(afterResync) && afterResync.value?.text,
+  "resynced",
+);
 
 await scrub();
 report("the render writer moves a paint through every transition it owns");

--- a/packages/shared/src/conversations/writers/render.ts
+++ b/packages/shared/src/conversations/writers/render.ts
@@ -66,12 +66,17 @@ if record.phase ~= "live" then return 0 end
 local current = redis.call("GET", KEYS[1])
 if current then
   local decoded = cjson.decode(current)
+  -- The one thing phase decides: a streaming frame may never overwrite a settled
+  -- one, whatever the revisions say.
   if decoded.phase ~= "streaming" and ARGV[5] == "streaming" then return 0 end
-  if tonumber(decoded.revision) > tonumber(ARGV[1]) then return 0 end
-  if tonumber(decoded.revision) == tonumber(ARGV[1]) then
-    if current == ARGV[2] then return 2 end
-    return -2
-  end
+  local stored = tonumber(decoded.revision)
+  local wanted = tonumber(ARGV[1])
+  if stored == wanted and current == ARGV[2] then return 2 end
+  -- Otherwise the publisher's counter is behind what Redis holds. Answered with
+  -- the stored revision, negated, so it can resync — refusing instead wedges the
+  -- turn permanently, because the counter only advances on a publish that lands
+  -- and every retry then re-attempts the same rejected number.
+  if stored >= wanted then return -stored end
 end
 redis.call("SET", KEYS[1], ARGV[2], "EX", tonumber(ARGV[4]))
 -- Proof of life. The turn holds its conversation for as long as it keeps
@@ -234,10 +239,16 @@ export interface PaintCompletion {
  * `accepted` is whether the intent is now the desired state; `shouldWake` is
  * whether anyone needs telling. They differ when the dispatch was already
  * advertised, where waking again would only add a redundant pass.
+ *
+ * `behindRevision` is set when the publish was refused because Redis already
+ * holds that revision or a later one. It carries what Redis holds, so a caller
+ * whose own counter has fallen behind can resync and try again rather than
+ * retrying the same rejected number forever.
  */
 export interface RenderPublication {
   readonly accepted: boolean;
   readonly shouldWake: boolean;
+  readonly behindRevision?: number;
 }
 
 export class RenderWriter {
@@ -280,8 +291,8 @@ export class RenderWriter {
         ],
       ),
     );
-    if (outcome === -2) throw new Error("render revision was reused with different content");
-    return { accepted: outcome !== 0, shouldWake: outcome !== 0 && outcome !== 3 };
+    if (outcome < 0) return { accepted: false, shouldWake: false, behindRevision: -outcome };
+    return { accepted: outcome !== 0, shouldWake: outcome === 1 || outcome === 2 };
   }
 
   /**


### PR DESCRIPTION
A `code_task` turn went silent after one line. The follower was not at fault — it adopted the child and narrated its tool call, and `↳ code: code_task` was live on the anchor throughout.

## What actually stalled

The turn requested approval twice, with different ids:

| time | request | state |
|---|---|---|
| 19:47:18 | `aitxt-MMAZ…` | approved |
| 19:47:56 | `aitxt-2VuS…` | **never published** |

So the bot kept rendering revision 3 — an approval already answered, settled in place with its buttons removed. Nothing left to click, and no way forward.

`publishDesiredRender` advances `state.renderRevision` **only when a publish is accepted**, and swallows throws into a warning. Once that counter falls behind what Redis holds, every later attempt re-offers a stored number: `PUBLISH` answers `0` or `-2`, the counter never moves, and the turn is mute permanently.

`settleAndPark` already self-heals this exact hazard by landing above the stored revision. `publish` did not — that asymmetry was the bug.

## The fix

`PUBLISH` answers a behind publisher with the stored revision (negated) instead of refusing blind; `RenderPublication` carries it as `behindRevision`; `publishDesiredRender` resyncs and retries once. Safe because the intent is rebuilt from current state every call — the content was right, only the tag was wrong.

Reuse no longer throws: with resync it's an ordinary recoverable state, not a publisher bug.

## Also

The follower adopts **three levels** rather than one. `code` runs codex, so the work worth narrating is two levels below the turn; stopping at the first child could only report that something started.

`check:render` reproduces the wedge and asserts the resync lands with the right content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)