### PR TITLE
Fetch a stream credential per connection instead of storing a dead one

### DIFF
--- a/packages/agents/agent/channels/discord.ts
+++ b/packages/agents/agent/channels/discord.ts
@@ -38,6 +38,7 @@ import {
 } from "@repo/shared/wire";
 import type { DeliveryPayload, ParkedPayload, RenderIntent, WireResponse } from "@repo/shared/wire";
 import * as Sentry from "@sentry/node";
+import { getVercelOidcToken } from "@vercel/oidc";
 import type { UserContent } from "ai";
 import { defineChannel, POST, type Session } from "eve/channels";
 import { createUnauthorizedResponse } from "eve/channels/auth";
@@ -478,6 +479,32 @@ export default defineChannel<DiscordChannelState, DiscordChannelContext>({
       } finally {
         await conversations.delivery.releaseIngress(payload.continuationKey, payload.interactionId);
       }
+    }),
+
+    /**
+     * A fresh credential for reading a session's event stream.
+     *
+     * Minted per request, never stored. These are issued with a *fixed* expiry
+     * shared across every mint rather than a lifetime measured from issuance, so
+     * one handed out at 20:52 died at 21:38 — a stored copy is a credential that
+     * silently stops working partway through the delegation it was meant to
+     * cover. The bot asks again on every reconnect instead.
+     */
+    POST(WIRE_ROUTES.streamToken, async (request) => {
+      if (!botAuthenticated(request)) {
+        return createUnauthorizedResponse({ status: 401, message: "bad bearer" });
+      }
+      const token = await getVercelOidcToken().catch((cause: unknown) => {
+        warnFailure("mint a stream token", cause);
+        return undefined;
+      });
+      if (token === undefined) {
+        return failed(
+          new Transient({ operation: "mint a stream token", detail: "unavailable" }),
+          503,
+        );
+      }
+      return Response.json({ token });
     }),
 
     /** Explicit `/new`-style retirement. */

--- a/packages/agents/agent/hooks/subagent.ts
+++ b/packages/agents/agent/hooks/subagent.ts
@@ -4,9 +4,10 @@
  *
  * A delegated turn goes silent from outside: the parent suspends while the child
  * runs, publishes no renders, and is reclaimed by the sweep as though it had died.
- * Something has to watch, and the only side that can hold a stream is the bot —
- * which has no Vercel identity of its own, so the token is minted here, inside a
- * function, and left where the bot will look.
+ * Something has to watch, and the only side that can hold a stream is the bot. It
+ * has no Vercel identity of its own, so it asks this deployment for a credential
+ * per connection over `WIRE_ROUTES.streamToken` — this record carries only the
+ * address.
  *
  * **On `actions.requested`, not `subagent.called`.** The latter never reaches a
  * hook: eve dispatches it through `callAdapterEventHandler` to the channel adapter
@@ -20,9 +21,7 @@
  */
 
 import { createConversationStore } from "@repo/shared/conversations";
-import { messageOf } from "@repo/shared/errors";
 import { getRedis } from "@repo/shared/redis";
-import { getVercelOidcToken } from "@vercel/oidc";
 import type { SessionAuthContext } from "eve/context";
 import { defineHook } from "eve/hooks";
 import type { HookEventMap } from "eve/hooks";
@@ -76,19 +75,9 @@ export default defineHook({
       const dispatchId = dispatchOf(ctx.session.auth.current?.attributes);
       if (dispatchId === undefined) return;
 
-      // A mint that fails costs the watch, not the turn.
-      const streamToken = await getVercelOidcToken().catch((cause: unknown) => {
-        console.warn(
-          JSON.stringify({ event: "subagent.token_unavailable", reason: messageOf(cause) }),
-        );
-        return undefined;
-      });
-      if (streamToken === undefined) return;
-
       await conversations.delegation.begin(dispatchId, {
         ...delegation,
         sessionId: ctx.session.id,
-        streamToken,
         startedAt: new Date().toISOString(),
       });
     },

--- a/packages/bot/src/agent/client.ts
+++ b/packages/bot/src/agent/client.ts
@@ -20,7 +20,7 @@ import { httpStatusOf, messageOf, Transient, UpstreamError } from "@repo/shared/
 import { Result } from "@repo/shared/result";
 import { noRetry, quickRetry } from "@repo/shared/result/retry";
 import type { RetryPolicy } from "@repo/shared/result/retry";
-import { WIRE_ROUTES, wireResponseSchema } from "@repo/shared/wire";
+import { decodeStreamToken, WIRE_ROUTES, wireResponseSchema } from "@repo/shared/wire";
 import type {
   InteractionPayload,
   DeliveryPayload,
@@ -141,6 +141,35 @@ export function createAgentClient(deps: AgentClientDeps) {
 
     sendInteraction: async (payload: InteractionPayload): Promise<Result<AgentAck, AgentError>> =>
       post(WIRE_ROUTES.interaction, payload, "agent.interaction", quickRetry, decodeSessionAck),
+
+    /**
+     * A credential for reading a session's event stream.
+     *
+     * Asked for per connection rather than stored: these carry a fixed expiry
+     * shared across every mint, so a copy taken when a delegation started can be
+     * dead well before that delegation is.
+     */
+    streamToken: async (): Promise<Result<string, AgentError>> => {
+      const answered = await post(
+        WIRE_ROUTES.streamToken,
+        { continuationKey: "" },
+        "agent.stream-token",
+        quickRetry,
+        (body: unknown) => decodeStreamToken(body),
+      );
+      if (Result.isError(answered)) return answered;
+      const decoded = answered.value;
+      if (Result.isError(decoded)) {
+        return Result.err(
+          new UpstreamError({
+            service: "agent",
+            status: 502,
+            detail: "stream token response was malformed",
+          }),
+        );
+      }
+      return Result.ok(decoded.value.token);
+    },
 
     sendReset: async (payload: ResetRequestPayload): Promise<Result<undefined, AgentError>> =>
       post(WIRE_ROUTES.reset, payload, "agent.reset", quickRetry, decodeCommandAck),

--- a/packages/bot/src/utils/conversation/subagent-follower.ts
+++ b/packages/bot/src/utils/conversation/subagent-follower.ts
@@ -19,6 +19,7 @@
 
 import type { Delegation } from "@repo/shared/conversations";
 import { messageOf } from "@repo/shared/errors";
+import { Result } from "@repo/shared/result";
 import { Client } from "eve/client";
 import type { MessageStreamEvent } from "eve/client";
 
@@ -122,6 +123,19 @@ function summarize(subagent: string, event: MessageStreamEvent): string | undefi
       return undefined;
     }
   }
+}
+
+/**
+ * A credential for the next connection, or the empty string.
+ *
+ * Empty rather than a throw: the client treats it as "no auth", the route
+ * answers 401, and `launch` reports that once — a stream that cannot authenticate
+ * is the same outcome either way, and this keeps the failure on the reporting
+ * path rather than escaping an auth callback.
+ */
+async function freshToken(deps: ConversationFlowDeps): Promise<string> {
+  const minted = await deps.eve.streamToken();
+  return Result.isOk(minted) ? minted.value : "";
 }
 
 interface Follow {
@@ -234,14 +248,18 @@ export function followSubagent(
       signal: following.controller.signal,
       onLine,
       following,
-      // The stream token is a Vercel OIDC token, minted where the delegation was
-      // announced because the bot has no Vercel identity of its own. Declaring it
-      // as OIDC also sends the trusted-OIDC header that deployment protection
-      // reads. `redirect: "manual"` keeps that credential from following a
+      // Fetched per connection, not stored. The credential is a Vercel OIDC
+      // token, which the bot cannot mint itself and which carries a *fixed*
+      // expiry shared across every mint — so a copy taken when the delegation
+      // started can be dead long before the delegation is. This callback re-runs
+      // on every reconnect, which is exactly where a renewal belongs.
+      //
+      // Declaring it as OIDC also sends the trusted-OIDC header deployment
+      // protection reads; `redirect: "manual"` keeps it from following a
       // redirect to another origin.
       client: new Client({
         host: deps.eve.baseUrl,
-        auth: { vercelOidc: { token: () => Promise.resolve(delegation.streamToken) } },
+        auth: { vercelOidc: { token: () => freshToken(deps) } },
         redirect: "manual",
       }),
     },

--- a/packages/shared/src/conversations/records/delegation.ts
+++ b/packages/shared/src/conversations/records/delegation.ts
@@ -22,18 +22,19 @@ export const delegationSchema = z.strictObject({
   name: z.string().min(1).max(64),
   /** Which call this is, so a second delegation replaces rather than duplicates. */
   callId: z.string().min(1).max(128),
-  /**
-   * Vercel OIDC token for reading the child's stream, minted where the
-   * delegation is announced because the bot has no Vercel identity of its own.
-   */
-  streamToken: z.string().min(1).max(4_096),
   startedAt: z.iso.datetime(),
 });
 
 export type Delegation = z.output<typeof delegationSchema>;
 
 /**
- * Shorter than the twelve-hour token it carries, so a delegation can never
- * outlive the credential that makes it useful. Cleared on completion regardless.
+ * Long enough for any delegation, because the record no longer carries a
+ * credential that could expire under it.
+ *
+ * It used to hold a Vercel OIDC token and was bounded by that token's supposed
+ * twelve-hour life. Both halves of that were wrong: the token is issued with a
+ * *fixed* expiry shared across every mint, so one taken at 20:52 died at 21:38 —
+ * forty-six minutes, not twelve hours — and a reader handed a stored copy has no
+ * way to renew it. The credential is fetched per connection now.
  */
-export const DELEGATION_TTL_SECONDS = 6 * 60 * 60;
+export const DELEGATION_TTL_SECONDS = 24 * 60 * 60;

--- a/packages/shared/src/wire.ts
+++ b/packages/shared/src/wire.ts
@@ -422,6 +422,15 @@ export const wireResponseSchema = z
 
 export type WireResponse = z.output<typeof wireResponseSchema>;
 
+/** What `WIRE_ROUTES.streamToken` answers with. */
+export const streamTokenSchema = z.object({ token: z.string().min(1).max(4_096) }).readonly();
+
+export function decodeStreamToken(
+  input: unknown,
+): Result<z.output<typeof streamTokenSchema>, InvalidInput> {
+  return decode(streamTokenSchema, "stream token", input);
+}
+
 /**
  * Every route on the agent's custom Discord channel.
  *
@@ -435,6 +444,14 @@ export const WIRE_ROUTES = {
   interaction: "/discord/interaction",
   reset: "/discord/reset",
   steer: "/discord/steer",
+  /**
+   * A freshly minted credential for reading a session's event stream.
+   *
+   * The bot has no Vercel identity of its own, so it cannot mint one; the agent
+   * runs inside a function and can. Asked for on demand rather than stored,
+   * because these live under an hour — see `streamTokenSchema`.
+   */
+  streamToken: "/discord/stream-token",
 } as const;
 
 /** The bot's own internal route, called only by the agent. */


### PR DESCRIPTION
The delegation record carried a Vercel OIDC token with a comment claiming "twelve hours covers any delegation, so one mint serves the whole thing and there is no refresh path to get wrong". Both halves were wrong.

Measured against three live delegations — every token expires at the **same instant** regardless of when it was minted:

| minted | expires | lifetime |
|---|---|---|
| 20:34:30 | 21:38:47 | 64 min |
| 20:47:24 | 21:38:47 | 51 min |
| 20:52:30 | 21:38:47 | **46 min** |

`getVercelOidcToken()` returns a shared credential with a fixed expiry, not a fresh 12-hour one per call. A delegation outliving it loses its stream to a 401 mid-flight, the follower reports once and dies, and the turn narrates nothing again. Confirmed directly: both parent and child stream routes 401 a stored token minted 46 minutes earlier.

## Fix

The bot can't mint one — no Vercel identity, which is why it was handed a copy. So the agent serves them: `WIRE_ROUTES.streamToken` mints on demand behind the bearer the bot already uses, and the follower's auth callback fetches per connection. That callback re-runs on every reconnect, which is where renewal belongs.

The record stops carrying a credential (also taking a live token out of Redis), and its TTL is no longer pinned to a lifetime that was never real: 6h → 24h.

## Still open

The second `input.requested` of a turn isn't published, leaving an answered approval on screen with no buttons and the turn unable to proceed. The resync in #150 didn't resolve it, and `code_task` has **never** opened a PR. Next step is the agent's logs — the swallowed `warnFailure("publish Discord render intent")` — or a working child stream, which this change is a precondition for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)