### PR TITLE
Report why Codex failed instead of eleven fixed words

### DIFF
--- a/packages/agents/agent/subagents/code/tools/code_task.ts
+++ b/packages/agents/agent/subagents/code/tools/code_task.ts
@@ -1,3 +1,4 @@
+import { messageOf } from "@repo/shared/errors";
 import { defineDynamic, defineTool } from "eve/tools";
 import { z } from "zod";
 
@@ -92,12 +93,21 @@ export default defineDynamic({
               });
               return { ok: true as const, repo, ...outcome };
             } catch (cause) {
-              return failed(
-                "harness_failed",
-                cause instanceof Error
-                  ? sanitizeText(cause.message, 2_000).text
-                  : "The Codex session did not complete.",
+              // Whatever it was. The `instanceof Error` check this replaces fell
+              // through to a fixed string for anything else thrown, and the
+              // harness does throw non-Errors — so every Codex failure reported
+              // the same eleven words and the one place that still held the
+              // reason discarded it.
+              const reason = messageOf(cause);
+              console.warn(
+                JSON.stringify({
+                  event: "code.harness_failed",
+                  repo,
+                  sessionKey: ctx.session.id,
+                  reason,
+                }),
               );
+              return failed("harness_failed", sanitizeText(reason, 2_000).text);
             }
           });
         },


### PR DESCRIPTION
`code_task` has never opened a pull request. The child session's stream shows why — and it isn't the backplane.

```
20:52:43  actions.requested [code_task]
20:52:43  input.requested                 ← approved
20:52:58  action.result  code_task → { ok: false,
                           error: { code: "harness_failed",
                                    message: "The Codex session did not complete." } }
20:53:01  actions.requested [code_task]   ← retried, same path
```

That message is the **fallback** branch: the catch reported `cause.message` only when the thrown value was an `Error`, and a fixed string otherwise. The harness throws non-Errors, so every Codex failure has reported the same eleven words while the one place still holding the reason discarded it.

`messageOf` covers every shape a catch can see, and the reason is logged with repo and session before being sanitized into the tool result.

## Two more things from the same trace — not fixed here

**The parent session dies an hour later** with an eve `FatalError`:

```
Refusing to persist a corrupt agent handle store: [{
  code: "too_small", minimum: 1,
  path: ["handles", 0, "operation", "parentTurnId"],
  message: "Too small: expected string to have >=1 characters"
}]
  at assertPersistableAgentHandleStore → writeHandles → prepareAgentStart → startLocalSubagent
```

eve builds a subagent handle with an **empty parent turn id** when dispatching after a resumed park, then refuses its own write. The same empty turn id shows up in our Redis as `agent:turn-tokens:<session>::events` keys. This is upstream — the trace and stack above are the report to file.

**The second `input.requested` still isn't published**, so an answered approval keeps its place with no buttons. The resync in #150 didn't resolve it. It matters less than it looked: the retry it hides leads straight back to the same harness failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)